### PR TITLE
Set an explicit background on the ExampleContainer grid

### DIFF
--- a/XamlControlsGallery/ControlExample.xaml
+++ b/XamlControlsGallery/ControlExample.xaml
@@ -82,7 +82,8 @@
                 x:Name="ExampleContainer"
                 x:FieldModifier="Public"
                 BorderBrush="{ThemeResource SystemControlBackgroundListLowBrush}"
-                BorderThickness="1">
+                BorderThickness="1"
+                Background="{ThemeResource SystemControlBackgroundAltHighBrush}">
                 <Grid.RowDefinitions>
                     <RowDefinition />
                     <RowDefinition Height="Auto" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Set an explicit background on the ExampleContainer grid of the ControlExample control. 

## Description
<!--- Describe your changes in detail -->
This resolves an issue where the "Toggle Theme" button wouldn't affect the example (since there was no brush to toggle). We'll set it to SystemControlBackgroundAltHighBrush. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change fixes an issue where the Toggle Theme button would not appear to toggle the theme of the background (but would toggle the theme of the controls inside), leading to illegibility of the controls. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual testing.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/25991996/49039137-c432d980-f173-11e8-9b81-6768a7ab763e.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
