### PR TITLE
ListView.CanReorder=True requires a mutable collection

### DIFF
--- a/XamlControlsGallery/ControlPages/ListViewPage.xaml
+++ b/XamlControlsGallery/ControlPages/ListViewPage.xaml
@@ -100,7 +100,6 @@
             <Grid MinWidth="550" Height="400">
                 <ListView
                     x:Name="Control2"
-                    ItemsSource="{x:Bind ContactsCVS.View, Mode=OneWay}"
                     CanDragItems="True"
                     CanReorderItems="True"
                     AllowDrop="True"
@@ -110,7 +109,8 @@
 
             <local:ControlExample.Xaml>
                 <RichTextBlock Style="{StaticResource XamlCodeRichTextBlockStyle}">
-                    <Paragraph>&lt;ListView ItemsSource="{x:Bind Contacts}" SelectionMode="
+                    <Paragraph>&lt;ListView CanDragItems="True" CanReorderItems="True" AllowDrop="True"</Paragraph>
+                    <Paragraph TextIndent="12">SelectionMode="
                         <Run Text="{x:Bind Control2.SelectionMode, Converter={StaticResource valueToStringConverter}, Mode=OneWay}"/> "/&gt;
                     </Paragraph>
                 </RichTextBlock>

--- a/XamlControlsGallery/ControlPages/ListViewPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/ListViewPage.xaml.cs
@@ -29,6 +29,7 @@ namespace AppUIBasics.ControlPages
         protected override async void OnNavigatedTo(NavigationEventArgs e)
         {
             Items = ControlInfoDataSource.Instance.Groups.Take(3).SelectMany(g => g.Items).ToList();
+            Control2.ItemsSource = await Contact.GetContactsAsync();
             Control4.ItemsSource = AppUIBasics.ControlPages.CustomDataObject.GetDataObjects();
             ContactsCVS.Source = await Contact.GetContactsGroupedAsync();
         }
@@ -37,8 +38,8 @@ namespace AppUIBasics.ControlPages
         {
             if (Control2 != null)
             {
-                string colorName = e.AddedItems[0].ToString();
-                switch (colorName)
+                string selectionMode = e.AddedItems[0].ToString();
+                switch (selectionMode)
                 {
                     case "None":
                         Control2.SelectionMode = ListViewSelectionMode.None;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update the ListView to have a mutable collection to enable ListView reordering.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
First found: https://github.com/Microsoft/Windows-universal-samples/issues/1014 

Without providing a mutable collection, attempting to drag/drop reorder caused a crash. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
