### PR TITLE
Change InkCanvas background for visible inking in High Contrast

### DIFF
--- a/XamlControlsGallery/ControlPages/InkToolbarPage.xaml
+++ b/XamlControlsGallery/ControlPages/InkToolbarPage.xaml
@@ -12,7 +12,7 @@
         <local:ControlExample x:Name="Example1" HeaderText="Basic InkCanvas with InkToolbar.">
             <StackPanel BorderBrush="Gray" BorderThickness="1">
                 <InkToolbar x:Name="inkToolbar" TargetInkCanvas="{x:Bind inkCanvas}"/>
-                <Grid Width="300" Height="300" Background="{ThemeResource SystemChromeWhiteColor}">
+                <Grid Width="300" Height="300" Background="{ThemeResource SystemControlBackgroundChromeWhiteBrush}">
                     <InkCanvas x:Name="inkCanvas"/>
                 </Grid>
             </StackPanel>


### PR DESCRIPTION

SystemChromeWhiteColor is always white as the background of InkCanvas. As a result, the inking is invisible in High Contrast mode.
SystemControlBackgroundChromeWhiteBrush is the good one that works for all modes, including High Contrast.
