### PR TITLE
Fix TabView Sample Tear Behaviour Bug

### DIFF
--- a/XamlControlsGallery/TabViewPages/TabViewWindowingSamplePage.xaml.cs
+++ b/XamlControlsGallery/TabViewPages/TabViewWindowingSamplePage.xaml.cs
@@ -39,6 +39,17 @@ namespace AppUIBasics.TabViewPages
                     Window.Current.Close();
                 }
             }
+            // If there is only one tab left, disable dragging and reordering of Tabs.
+            else if (sender.TabItems.Count == 1)
+            {
+                sender.CanReorderTabs = false;
+                sender.CanDragTabs = false;
+            }
+            else
+            {
+                sender.CanReorderTabs = true;
+                sender.CanDragTabs = true;
+            }
         }
 
         protected override void OnNavigatedTo(NavigationEventArgs e)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When there is only one tab left in the TabView Windowing sample, tearing it outside of window crashes app. This is because it still closes and opens a new window when on the last tab, but an error is thrown during .Close() as you can't close the only tab in the window. 

Simply disabling `CanReorderTabs` and `CanDragTabs` when `TabItems.Count == 1` suffices.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes internal bug: 38125264

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
