### PR TITLE
Fixes to run XCG unpackaged

### DIFF
--- a/XamlControlsGallery/Common/FileLoader.cs
+++ b/XamlControlsGallery/Common/FileLoader.cs
@@ -13,8 +13,13 @@ namespace AppUIBasics.Common
     {
         public static async Task<string> LoadText(string relativeFilePath)
         {
+#if UNPACKAGED
+            var sourcePath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), relativeFilePath));
+            var file = await StorageFile.GetFileFromPathAsync(sourcePath);
+#else
             Uri sourceUri = new Uri("ms-appx:///" + relativeFilePath);
             var file = await StorageFile.GetFileFromApplicationUriAsync(sourceUri);
+#endif
 
             return await FileIO.ReadTextAsync(file);
         }

--- a/XamlControlsGallery/Common/SuspensionManager.cs
+++ b/XamlControlsGallery/Common/SuspensionManager.cs
@@ -75,7 +75,12 @@ namespace AppUIBasics.Common
                 serializer.WriteObject(sessionData, _sessionState);
 
                 // Get an output stream for the SessionState file and write the state asynchronously
-                StorageFile file = await ApplicationData.Current.LocalFolder.CreateFileAsync(sessionStateFilename, CreationCollisionOption.ReplaceExisting);
+#if !UNPACKAGED
+                StorageFolder localFolder = ApplicationData.Current.LocalFolder;
+#else
+                StorageFolder localFolder = await StorageFolder.GetFolderFromPathAsync(System.AppContext.BaseDirectory);
+#endif
+                StorageFile file = await localFolder.CreateFileAsync(sessionStateFilename, CreationCollisionOption.ReplaceExisting);
                 using (Stream fileStream = await file.OpenStreamForWriteAsync())
                 {
                     sessionData.Seek(0, SeekOrigin.Begin);
@@ -104,7 +109,12 @@ namespace AppUIBasics.Common
             try
             {
                 // Get the input stream for the SessionState file
-                StorageFile file = await ApplicationData.Current.LocalFolder.GetFileAsync(sessionStateFilename);
+#if !UNPACKAGED
+                StorageFolder localFolder = ApplicationData.Current.LocalFolder;
+#else
+                StorageFolder localFolder = await StorageFolder.GetFolderFromPathAsync(System.AppContext.BaseDirectory);
+#endif
+                StorageFile file = await localFolder.GetFileAsync(sessionStateFilename);
                 using (IInputStream inStream = await file.OpenSequentialReadAsync())
                 {
                     // Deserialize the Session State

--- a/XamlControlsGallery/Controls/ControlExample.xaml.cs
+++ b/XamlControlsGallery/Controls/ControlExample.xaml.cs
@@ -276,8 +276,13 @@ namespace AppUIBasics
                 var manager = AppRecordingManager.GetDefault();
                 if (manager.GetStatus().CanRecord)
                 {
+#if !UNPACKAGED
+                    StorageFolder localFolder = ApplicationData.Current.LocalFolder;
+#else
+                    StorageFolder localFolder = await StorageFolder.GetFolderFromPathAsync(System.AppContext.BaseDirectory);
+#endif
                     var result = await manager.SaveScreenshotToFilesAsync(
-                        ApplicationData.Current.LocalFolder,
+                        localFolder,
                         "appScreenshot",
                         AppRecordingSaveScreenshotOption.HdrContentVisible,
                         manager.SupportedScreenshotMediaEncodingSubtypes);
@@ -285,7 +290,7 @@ namespace AppUIBasics
                     if (result.Succeeded)
                     {
                         // Open the screenshot back up
-                        var screenshotFile = await ApplicationData.Current.LocalFolder.GetFileAsync("appScreenshot.png");
+                        var screenshotFile = await localFolder.GetFileAsync("appScreenshot.png");
                         using (var stream = await screenshotFile.OpenAsync(FileAccessMode.Read))
                         {
                             var decoder = await BitmapDecoder.CreateAsync(stream);
@@ -315,7 +320,7 @@ namespace AppUIBasics
                                 ColorManagementMode.DoNotColorManage);
 
                             // Save the cropped picture
-                            var file = await ApplicationData.Current.LocalFolder.CreateFileAsync(GetBestScreenshotName(), CreationCollisionOption.ReplaceExisting);
+                            var file = await localFolder.CreateFileAsync(GetBestScreenshotName(), CreationCollisionOption.ReplaceExisting);
                             using (var outStream = await file.OpenAsync(FileAccessMode.ReadWrite))
                             {
                                 BitmapEncoder encoder = await BitmapEncoder.CreateAsync(BitmapEncoder.PngEncoderId, outStream);
@@ -341,7 +346,7 @@ namespace AppUIBasics
             if (XamlSource != null)
             {
                 // Most of them don't have this, but the xaml source name is a really good file name
-                string xamlSource = XamlSource.LocalPath;
+                string xamlSource = new Uri("ms-appx:///" + Path.Combine("ControlPagesSampleCode", XamlSource)).LocalPath;
                 string fileName = Path.GetFileNameWithoutExtension(xamlSource);
                 if (!String.IsNullOrWhiteSpace(fileName))
                 {

--- a/XamlControlsGallery/Directory.Build.targets
+++ b/XamlControlsGallery/Directory.Build.targets
@@ -1,16 +1,13 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" Condition="Exists($([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../')))"/>
-  <PropertyGroup Condition="'$(WindowsPackageType)' != ''">
+  <PropertyGroup Condition="'$(WindowsPackageType)' == 'MSIX'">
     <!-- These are set in Directory.Build.targets because we need to import the publish profile first -->
-    <DefineConstants>$(DefineConstants);$(WindowsPackageType.ToUpper())</DefineConstants>
-    <PackageNameSuffix Condition="'$(WindowsPackageType)' != 'MSIX'">$(WindowsPackageType)</PackageNameSuffix>
-    <PackageNameSuffix Condition="'$(WindowsPackageType)' == 'MSIX'">Desktop</PackageNameSuffix>
-    <AppxPackageName>XamlControlsGallery.$(PackageNameSuffix)</AppxPackageName>
+    <AppxPackageName>XamlControlsGallery.Desktop</AppxPackageName>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(WindowsPackageType)' != ''">
+  <ItemGroup Condition="'$(WindowsPackageType)' == 'MSIX'">
     <AppxManifest Include="Package.$(WindowsPackageType).appxmanifest">
       <SubType>Designer</SubType>
     </AppxManifest>
   </ItemGroup>
+  <Import Project="net6.override.targets" Condition="'$(MSBuildRuntimeType)' == 'Core'" />
 </Project>

--- a/XamlControlsGallery/Helper/NavigationOrientationHelper.cs
+++ b/XamlControlsGallery/Helper/NavigationOrientationHelper.cs
@@ -20,8 +20,11 @@ namespace AppUIBasics.Helper
 
         private const string IsLeftModeKey = "NavigationIsOnLeftMode";
 
+        private static bool _isLeftMode = true;
+
         public static bool IsLeftMode()
         {
+#if !UNPACKAGED
             var valueFromSettings = ApplicationData.Current.LocalSettings.Values[IsLeftModeKey];
             if(valueFromSettings == null)
             {
@@ -29,12 +32,19 @@ namespace AppUIBasics.Helper
                 valueFromSettings = true;
             }
             return (bool)valueFromSettings;
+#else
+            return _isLeftMode;
+#endif
         }
 
         public static void IsLeftModeForElement(bool isLeftMode, UIElement element)
         {
             UpdateTitleBarForElement(isLeftMode, element);
+#if !UNPACKAGED
             ApplicationData.Current.LocalSettings.Values[IsLeftModeKey] = isLeftMode;
+#else
+            _isLeftMode = isLeftMode;
+#endif
         }
 
         public static void UpdateTitleBarForElement(bool isLeftMode, UIElement element)

--- a/XamlControlsGallery/Helper/ProtocolActivationClipboardHelper.cs
+++ b/XamlControlsGallery/Helper/ProtocolActivationClipboardHelper.cs
@@ -13,10 +13,13 @@ namespace AppUIBasics.Helper
     {
         private const string ShowCopyLinkTeachingTipKey = "ShowCopyLinkTeachingTip";
 
+        private static bool _showCopyLinkTeachingTip = true;
+
         public static bool ShowCopyLinkTeachingTip
         {
             get
             {
+#if !UNPACKAGED
                 object valueFromSettings = ApplicationData.Current.LocalSettings.Values[ShowCopyLinkTeachingTipKey];
                 if (valueFromSettings == null)
                 {
@@ -24,9 +27,16 @@ namespace AppUIBasics.Helper
                     valueFromSettings = true;
                 }
                 return (bool)valueFromSettings;
+#else
+                return _showCopyLinkTeachingTip;
+#endif
             }
 
+#if !UNPACKAGED
             set => ApplicationData.Current.LocalSettings.Values[ShowCopyLinkTeachingTipKey] = value;
+#else
+            set => _showCopyLinkTeachingTip = value;
+#endif
         }
 
         public static void Copy(ControlInfoDataItem item)

--- a/XamlControlsGallery/Helper/ThemeHelper.cs
+++ b/XamlControlsGallery/Helper/ThemeHelper.cs
@@ -72,7 +72,9 @@ namespace AppUIBasics.Helper
                     }
                 }
 
+#if !UNPACKAGED
                 ApplicationData.Current.LocalSettings.Values[SelectedAppThemeKey] = value.ToString();
+#endif
                 UpdateSystemCaptionButtonColors();
             }
         }

--- a/XamlControlsGallery/Helper/UIHelper.cs
+++ b/XamlControlsGallery/Helper/UIHelper.cs
@@ -9,7 +9,11 @@ namespace AppUIBasics.Helper
     public static class UIHelper
     {
         public static bool IsScreenshotMode { get; set; }
+#if !UNPACKAGED
         public static StorageFolder ScreenshotStorageFolder { get; set; } = ApplicationData.Current.LocalFolder;
+#else
+        public static StorageFolder ScreenshotStorageFolder { get; set; } = Task.Run(async () => await StorageFolder.GetFolderFromPathAsync(System.AppContext.BaseDirectory)).Result;
+#endif
 
         public static IEnumerable<T> GetDescendantsOfType<T>(this DependencyObject start) where T : DependencyObject
         {

--- a/XamlControlsGallery/Package.MSIX.appxmanifest
+++ b/XamlControlsGallery/Package.MSIX.appxmanifest
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" IgnorableNamespaces="uap mp uap3">
+  <Identity Name="Microsoft.WinUI3ControlsGallery.Desktop" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="1.3.6.0" />
+  <mp:PhoneIdentity PhoneProductId="863667e0-667a-4bb4-ac52-c59656c7333a" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
+  <Properties>
+    <DisplayName>WinUI 3 Controls Gallery</DisplayName>
+    <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
+    <Logo>Assets\Tiles\StoreLogo-sdk.png</Logo>
+    <uap:SupportedUsers>multiple</uap:SupportedUsers>
+  </Properties>
+  <Resources>
+    <Resource Language="x-generate" />
+  </Resources>
+  <Applications>
+    <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="$targetentrypoint$">
+      <uap:VisualElements DisplayName="WinUI 3 Controls Gallery" Square150x150Logo="Assets\Tiles\squaretile-sdk.png" Square44x44Logo="Assets\Tiles\SmallTile-sdk.png" Description="WinUI 3 Controls Gallery" BackgroundColor="transparent">
+        <uap:DefaultTile Square310x310Logo="Assets\Tiles\LargeTile.png" Wide310x150Logo="Assets\Tiles\WideTile.png" Square71x71Logo="Assets\Tiles\SmallTile.png">
+          <uap:ShowNameOnTiles>
+            <uap:ShowOn Tile="square150x150Logo" />
+            <uap:ShowOn Tile="wide310x150Logo" />
+            <uap:ShowOn Tile="square310x310Logo" />
+          </uap:ShowNameOnTiles>
+        </uap:DefaultTile>
+        <uap:SplashScreen Image="Assets\Tiles\splash-sdk.png" BackgroundColor="#00b2f0" />
+      </uap:VisualElements>
+      <Extensions>
+        <uap3:Extension Category="windows.appUriHandler">
+          <uap3:AppUriHandler>
+            <uap3:Host Name="xamlcontrolsgallery.com" />
+          </uap3:AppUriHandler>
+        </uap3:Extension>
+        <uap:Extension Category="windows.protocol">
+          <uap:Protocol Name="xamlcontrolsgallery">
+            <uap:DisplayName>WinUI 3 Controls Gallery</uap:DisplayName>
+          </uap:Protocol>
+        </uap:Extension>
+      </Extensions>
+    </Application>
+  </Applications>
+  <Capabilities>
+    <Capability Name="internetClient" />
+  </Capabilities>
+</Package>

--- a/XamlControlsGallery/Package.Universal.appxmanifest
+++ b/XamlControlsGallery/Package.Universal.appxmanifest
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" IgnorableNamespaces="uap mp uap3">
+  <Identity Name="Microsoft.WinUI3ControlsGallery.UWP" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="1.3.6.0" />
+  <mp:PhoneIdentity PhoneProductId="c8049b5d-eada-4613-9fb7-b4cbb780f468" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
+  <Properties>
+    <DisplayName>WinUI 3 Controls Gallery</DisplayName>
+    <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
+    <Logo>Assets\Tiles\StoreLogo-sdk.png</Logo>
+  </Properties>
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17134.0" MaxVersionTested="10.0.18362.0" />
+  </Dependencies>
+  <Resources>
+    <Resource Language="x-generate" />
+  </Resources>
+  <Applications>
+    <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="$targetentrypoint$">
+      <uap:VisualElements DisplayName="WinUI 3 Controls Gallery" Square150x150Logo="Assets\Tiles\squaretile-sdk.png" Square44x44Logo="Assets\Tiles\SmallTile-sdk.png" Description="WinUI 3 Controls Gallery" BackgroundColor="transparent">
+        <uap:DefaultTile Square310x310Logo="Assets\Tiles\LargeTile.png" Wide310x150Logo="Assets\Tiles\WideTile.png" Square71x71Logo="Assets\Tiles\SmallTile.png">
+          <uap:ShowNameOnTiles>
+            <uap:ShowOn Tile="square150x150Logo" />
+            <uap:ShowOn Tile="wide310x150Logo" />
+            <uap:ShowOn Tile="square310x310Logo" />
+          </uap:ShowNameOnTiles>
+        </uap:DefaultTile>
+        <uap:SplashScreen Image="Assets\Tiles\splash-sdk.png"/>
+      </uap:VisualElements>
+      <Extensions>
+        <uap3:Extension Category="windows.appUriHandler">
+          <uap3:AppUriHandler>
+            <uap3:Host Name="xamlcontrolsgallery.com" />
+          </uap3:AppUriHandler>
+        </uap3:Extension>
+        <uap:Extension Category="windows.protocol">
+          <uap:Protocol Name="xamlcontrolsgallery">
+            <uap:DisplayName>WinUI 3 Controls Gallery</uap:DisplayName>
+          </uap:Protocol>
+        </uap:Extension>
+      </Extensions>
+    </Application>
+  </Applications>
+  <Capabilities>
+    <Capability Name="internetClient" />
+  </Capabilities>
+</Package>

--- a/XamlControlsGallery/Properties/PublishProfiles/win10-arm64-unpackaged.pubxml
+++ b/XamlControlsGallery/Properties/PublishProfiles/win10-arm64-unpackaged.pubxml
@@ -5,12 +5,12 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <Platform>arm64</Platform>
+    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>False</PublishReadyToRun>
-    <PublishAppxPackage>True</PublishAppxPackage>
+    <PublishReadyToRun>True</PublishReadyToRun>
+    <PublishAppxPackage>False</PublishAppxPackage>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/XamlControlsGallery/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/XamlControlsGallery/Properties/PublishProfiles/win10-arm64.pubxml
@@ -7,7 +7,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>arm64</Platform>
     <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
-    <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun>True</PublishReadyToRun>

--- a/XamlControlsGallery/Properties/PublishProfiles/win10-x64-unpackaged.pubxml
+++ b/XamlControlsGallery/Properties/PublishProfiles/win10-x64-unpackaged.pubxml
@@ -5,12 +5,12 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <Platform>x64</Platform>
+    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>False</PublishReadyToRun>
-    <PublishAppxPackage>True</PublishAppxPackage>
+    <PublishReadyToRun>True</PublishReadyToRun>
+    <PublishAppxPackage>False</PublishAppxPackage>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/XamlControlsGallery/Properties/PublishProfiles/win10-x64.pubxml
+++ b/XamlControlsGallery/Properties/PublishProfiles/win10-x64.pubxml
@@ -7,7 +7,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
     <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
-    <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun>True</PublishReadyToRun>

--- a/XamlControlsGallery/Properties/PublishProfiles/win10-x86-unpackaged.pubxml
+++ b/XamlControlsGallery/Properties/PublishProfiles/win10-x86-unpackaged.pubxml
@@ -9,8 +9,8 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>False</PublishReadyToRun>
-    <PublishAppxPackage>True</PublishAppxPackage>
+    <PublishReadyToRun>True</PublishReadyToRun>
+    <PublishAppxPackage>False</PublishAppxPackage>
    <!-- 
     See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>

--- a/XamlControlsGallery/XamlControlsGallery.DesktopWap.Package.wapproj
+++ b/XamlControlsGallery/XamlControlsGallery.DesktopWap.Package.wapproj
@@ -55,7 +55,7 @@
     <GenerateTestArtifacts>True</GenerateTestArtifacts>
     <AppxBundlePlatforms Condition="'$(BuildAllAppFlavors)' == 'true'">x86|x64|arm64</AppxBundlePlatforms>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
-    <AssetTargetFallback>net5.0-windows$(TargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>
+    <AssetTargetFallback>net5.0-windows$(TargetPlatformVersion);net6.0-windows$(TargetPlatformVersion);$(AssetTargetFallback)</AssetTargetFallback>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
     <AppxBundle>Always</AppxBundle>

--- a/XamlControlsGallery/XamlControlsGallery.DesktopWap.csproj
+++ b/XamlControlsGallery/XamlControlsGallery.DesktopWap.csproj
@@ -10,7 +10,7 @@
     <NoWarn>8305</NoWarn>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
-    <EnablePreviewMsixTooling>false</EnablePreviewMsixTooling>
+    <EnableMsixTooling>false</EnableMsixTooling>
     <NoWarn>
       0108; <!-- 'x' hides inherited member 'y'. Use the new keyword if hiding was intended. -->
       8305  <!-- 'x' is for evaluation purposes only and is subject to change or removal in future updates. -->
@@ -18,6 +18,7 @@
     <MSBuildWarningsAsMessages>
       WMC1501 <!-- x is for evaluation purposes only and is subject to change or removal in future updates. -->
     </MSBuildWarningsAsMessages>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
 
   <Import Project="Common.props" />

--- a/XamlControlsGallery/net6.override.targets
+++ b/XamlControlsGallery/net6.override.targets
@@ -1,0 +1,17 @@
+<Project>
+<!-- Hack to get around issues with missing tasks in .net core -->
+  <Target Name="GetInstalledSDKLocations"
+      Condition="'@(SDKReference)' != ''"
+      DependsOnTargets="$(GetInstalledSDKLocationsDependsOn)"
+      Returns="@(InstalledSDKLocations)">
+    <ItemGroup>
+    </ItemGroup>
+  </Target>
+  <Target
+      Name="ResolveSDKReferences"
+      Returns="@(ResolvedSDKReference)"
+      DependsOnTargets="$(ResolveSDKReferencesDependsOn)">
+    <ItemGroup>
+    </ItemGroup>
+  </Target>
+</Project>

--- a/XamlControlsGallery/standalone.props
+++ b/XamlControlsGallery/standalone.props
@@ -6,6 +6,7 @@
     <MicrosoftNETCoreUniversalWindowsPlatformVersion>6.2.11</MicrosoftNETCoreUniversalWindowsPlatformVersion>
     <Win2DWinUIVersion>0.1.0.3</Win2DWinUIVersion>
     <ColorCodeVersion>2.0.13</ColorCodeVersion>
+    <MicrosoftWindowsSDKBuildToolsNugetPackageVersion>10.0.22563-preview</MicrosoftWindowsSDKBuildToolsNugetPackageVersion>
     <MicrosoftCsWinRTPackageVersion>1.5.0</MicrosoftCsWinRTPackageVersion>
     <!-- Where to place the files generated from CSWinRT from XamlControlsGallery.Desktop.-->
     <GeneratedFilesDir>obj\generated</GeneratedFilesDir>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The ApplicationData.Current API is unavailable to apps without a package identity and this was causing unpackaged XamlControlsGallery to crash on launch due to usage of the aforementioned API in XCG 2.6. This change addresses that by replacing all usage sites of ApplicationData.Current with approximations when XCG is running without a package identity:

- [AppContext.BaseDirectory](https://www.hanselman.com/blog/how-do-i-find-which-directory-my-net-core-console-application-was-started-in-or-is-running-from)  as a replacement for ApplicationData.Current.LocalFolder
- Private static fields instead of persisting values to ApplicationData.Current.LocalSettings).

XCG does use other APIs that do not work without a package identity (e.g. Windows.ApplicationModel.Package) but they do not result in process termination so I left them alone.

## Motivation and Context
Allow XCG to run unpackaged

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
