### PR TITLE
Remove the transient vs not behavior based on pointer over in CommandBarFlyout page. Can introduce confusion to narrator users

### DIFF
--- a/XamlControlsGallery/ControlPages/CommandBarFlyoutPage.xaml.cs
+++ b/XamlControlsGallery/ControlPages/CommandBarFlyoutPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Windows.Foundation.Metadata;
+using Windows.Foundation.Metadata;
 using Microsoft.UI;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
@@ -45,7 +45,8 @@ namespace AppUIBasics.ControlPages
 
         private void MyImageButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
-            ShowMenu((sender as Button).IsPointerOver);
+            // show in Transient mode.
+            ShowMenu(true);
         }
     }
 }


### PR DESCRIPTION
Always be transient or not for a type of interaction. Switching it based on pointer over can be confusing for keyboard/narrator users.

Internal bug: [Bug 38293416](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/38293416): [XCG WinUI3] WinUI Accessibility->CommandBarFlyout card: See more menu list is expanding automatically when image is invoked.