### PR TITLE
Fixes for TabView Windowing sample

### DIFF
--- a/XamlControlsGallery/App.xaml
+++ b/XamlControlsGallery/App.xaml
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
     //*********************************************************
     //
     // Copyright (c) Microsoft. All rights reserved.
@@ -121,6 +121,9 @@
             </Style>
 
             <x:Double x:Key="TeachingTipMinWidth">50</x:Double>
+
+            <SolidColorBrush x:Key="WindowCaptionBackground">Transparent</SolidColorBrush>
+            <SolidColorBrush x:Key="WindowCaptionBackgroundDisabled">Transparent</SolidColorBrush>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/XamlControlsGallery/TabViewPages/MyTabContentControl.xaml
+++ b/XamlControlsGallery/TabViewPages/MyTabContentControl.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+<UserControl
     x:Class="AppUIBasics.TabViewPages.MyTabContentControl"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -11,7 +11,6 @@
 
     <StackPanel Padding="12">
         <TextBlock Text="{Binding}" Style="{ThemeResource TitleTextBlockStyle}" />
-        <TextBlock x:Name="DesktopTextBlock" Visibility="Collapsed" Text="Dragging a Tab to create a new Window is not yet supported." Style="{ThemeResource SubtitleTextBlockStyle}" />
         <TextBlock x:Name="UwpTextBlock1" Text="Drag the Tab outside of the window to spawn a new window." Style="{ThemeResource SubtitleTextBlockStyle}" />
         <TextBlock x:Name="UwpTextBlock2" Text="Notice that the state of the Tab is maintained in the new window. For example, if you toggle the ToggleSwitch ON, it will remain ON in the new window." Style="{ThemeResource BodyTextBlockStyle}" />
         <ToggleSwitch x:Name="ControlToggle" Header="Turn on ProgressRing" Margin="0,8" />

--- a/XamlControlsGallery/TabViewPages/MyTabContentControl.xaml
+++ b/XamlControlsGallery/TabViewPages/MyTabContentControl.xaml
@@ -11,8 +11,8 @@
 
     <StackPanel Padding="12">
         <TextBlock Text="{Binding}" Style="{ThemeResource TitleTextBlockStyle}" />
-        <TextBlock x:Name="UwpTextBlock1" Text="Drag the Tab outside of the window to spawn a new window." Style="{ThemeResource SubtitleTextBlockStyle}" />
-        <TextBlock x:Name="UwpTextBlock2" Text="Notice that the state of the Tab is maintained in the new window. For example, if you toggle the ToggleSwitch ON, it will remain ON in the new window." Style="{ThemeResource BodyTextBlockStyle}" />
+        <TextBlock Text="Drag the Tab outside of the window to spawn a new window." Style="{ThemeResource SubtitleTextBlockStyle}" />
+        <TextBlock Text="Notice that the state of the Tab is maintained in the new window. For example, if you toggle the ToggleSwitch ON, it will remain ON in the new window." Style="{ThemeResource BodyTextBlockStyle}" />
         <ToggleSwitch x:Name="ControlToggle" Header="Turn on ProgressRing" Margin="0,8" />
         <ProgressRing IsActive="{x:Bind ControlToggle.IsOn, Mode=OneWay}" HorizontalAlignment="Left" />
     </StackPanel>

--- a/XamlControlsGallery/TabViewPages/MyTabContentControl.xaml.cs
+++ b/XamlControlsGallery/TabViewPages/MyTabContentControl.xaml.cs
@@ -10,11 +10,6 @@ namespace AppUIBasics.TabViewPages
         public MyTabContentControl()
         {
             this.InitializeComponent();
-
-#if !UNIVERSAL
-            UwpTextBlock1.Visibility = Visibility.Collapsed;
-            UwpTextBlock2.Visibility = Visibility.Collapsed;
-#endif
         }
     }
 }

--- a/XamlControlsGallery/TabViewPages/MyTabContentControl.xaml.cs
+++ b/XamlControlsGallery/TabViewPages/MyTabContentControl.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
@@ -12,7 +12,6 @@ namespace AppUIBasics.TabViewPages
             this.InitializeComponent();
 
 #if !UNIVERSAL
-            DesktopTextBlock.Visibility = Visibility.Visible;
             UwpTextBlock1.Visibility = Visibility.Collapsed;
             UwpTextBlock2.Visibility = Visibility.Collapsed;
 #endif

--- a/XamlControlsGallery/TabViewPages/TabViewWindowingSamplePage.xaml
+++ b/XamlControlsGallery/TabViewPages/TabViewWindowingSamplePage.xaml
@@ -7,6 +7,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    
 
     <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
         <TabView x:Name="Tabs" 

--- a/XamlControlsGallery/TabViewPages/TabViewWindowingSamplePage.xaml
+++ b/XamlControlsGallery/TabViewPages/TabViewWindowingSamplePage.xaml
@@ -1,4 +1,4 @@
-﻿<Page
+<Page
     x:Class="AppUIBasics.TabViewPages.TabViewWindowingSamplePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -16,6 +16,7 @@
                              AllowDropTabs="True"
                              CanDragTabs="True"
                              CanReorderTabs="True"
+                             TabDroppedOutside="Tabs_TabDroppedOutside"
                              TabStripDragOver="Tabs_TabStripDragOver"
                              TabStripDrop="Tabs_TabStripDrop"
                              TabDragStarting="Tabs_TabDragStarting" >

--- a/XamlControlsGallery/TabViewPages/TabViewWindowingSamplePage.xaml.cs
+++ b/XamlControlsGallery/TabViewPages/TabViewWindowingSamplePage.xaml.cs
@@ -20,6 +20,14 @@ namespace AppUIBasics.TabViewPages
             this.InitializeComponent();
 
             Tabs.TabItemsChanged += Tabs_TabItemsChanged;
+
+            Loaded += TabViewWindowingSamplePage_Loaded;
+        }
+
+        private void TabViewWindowingSamplePage_Loaded(object sender, RoutedEventArgs e)
+        {
+            var currentWindow = WindowHelper.GetWindowForElement(this);
+            currentWindow.ExtendsContentIntoTitleBar = true;
         }
 
         private void Tabs_TabItemsChanged(TabView sender, Windows.Foundation.Collections.IVectorChangedEventArgs args)
@@ -49,6 +57,7 @@ namespace AppUIBasics.TabViewPages
 
             Tabs.SelectedIndex = 0;
 
+
 #if UNIVERSAL
             // Extend into the titlebar
             var coreTitleBar = CoreApplication.GetCurrentView().TitleBar;
@@ -59,7 +68,7 @@ namespace AppUIBasics.TabViewPages
             var titleBar = ApplicationView.GetForCurrentView().TitleBar;
             titleBar.ButtonBackgroundColor = Microsoft.UI.Colors.Transparent;
             titleBar.ButtonInactiveBackgroundColor = Microsoft.UI.Colors.Transparent;
-#endif
+#endif            
         }
 
         private void CoreTitleBar_LayoutMetricsChanged(CoreApplicationViewTitleBar sender, object args)
@@ -101,6 +110,7 @@ namespace AppUIBasics.TabViewPages
             newPage.AddTabToTabs(args.Tab);
 
             var newWindow = WindowHelper.CreateWindow();
+            newWindow.ExtendsContentIntoTitleBar = true;
             newWindow.Content = newPage;
 
             newWindow.Activate();

--- a/XamlControlsGallery/TabViewPages/TabViewWindowingSamplePage.xaml.cs
+++ b/XamlControlsGallery/TabViewPages/TabViewWindowingSamplePage.xaml.cs
@@ -93,28 +93,17 @@ namespace AppUIBasics.TabViewPages
         }
 
         // Create a new Window once the Tab is dragged outside.
-        private async void Tabs_TabDroppedOutside(TabView sender, TabViewTabDroppedOutsideEventArgs args)
+        private void Tabs_TabDroppedOutside(TabView sender, TabViewTabDroppedOutsideEventArgs args)
         {
-            // AppWindow was introduced in Windows 10 version 18362 (ApiContract version 8). 
-            // If the app is running on a version earlier than 18362, simply no-op.
-            // If your app needs to support multiple windows on earlier versions of Win10, you can use CoreWindow/ApplicationView.
-            // More information about showing multiple views can be found here: https://docs.microsoft.com/windows/uwp/design/layout/show-multiple-views
-            if (!ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
-            {
-                return;
-            }
+            var newPage = new TabViewWindowingSamplePage();
 
-            //AppWindow newWindow = await AppWindow.TryCreateAsync();
+            Tabs.TabItems.Remove(args.Tab);
+            newPage.AddTabToTabs(args.Tab);
 
-            //var newPage = new TabViewWindowingSamplePage();
-            //newPage.SetupWindow(newWindow);
+            var newWindow = WindowHelper.CreateWindow();
+            newWindow.Content = newPage;
 
-            //ElementCompositionPreview.SetAppWindowContent(newWindow, newPage);
-
-            //Tabs.TabItems.Remove(args.Tab);
-            //newPage.AddTabToTabs(args.Tab);
-
-            //await newWindow.TryShowAsync();
+            newWindow.Activate();
         }
 
         private void Tabs_TabDragStarting(TabView sender, TabViewTabDragStartingEventArgs args)

--- a/XamlControlsGallery/TabViewPages/TabViewWindowingSamplePage.xaml.cs
+++ b/XamlControlsGallery/TabViewPages/TabViewWindowingSamplePage.xaml.cs
@@ -28,6 +28,8 @@ namespace AppUIBasics.TabViewPages
         {
             var currentWindow = WindowHelper.GetWindowForElement(this);
             currentWindow.ExtendsContentIntoTitleBar = true;
+            currentWindow.SetTitleBar(CustomDragRegion);
+            CustomDragRegion.MinWidth = 188;
         }
 
         private void Tabs_TabItemsChanged(TabView sender, Windows.Foundation.Collections.IVectorChangedEventArgs args)


### PR DESCRIPTION
The TabView sample that showed using TabView as a titlebar and allowing tabs to be torn out into a new window was not working for WinUI3 since it only worked for UWP. This updates the sample for WinUI3.