### PR TITLE
Re-enable AnimatedVisualPlayer sample

### DIFF
--- a/XamlControlsGallery/ControlPages/AnimatedVisualPlayerPage.xaml
+++ b/XamlControlsGallery/ControlPages/AnimatedVisualPlayerPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page
+<Page
     x:Class="AppUIBasics.ControlPages.AnimatedVisualPlayerPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -36,8 +36,11 @@
                         <AnimatedVisualPlayer x:Name="Player"
                                                           AutoPlay="False">
 
-                            <!--  Codegen-ed Lottie animation source: /AnimatedVisuals/LottieLogo1.cs -->
-                            <!--<animatedvisuals:LottieLogo1/>-->
+                            <AnimatedVisualPlayer.Source>
+                                <!--  Codegen-ed Lottie animation source: /AnimatedVisuals/LottieLogo1.cs -->
+                                <animatedvisuals:LottieLogo1/>
+                            </AnimatedVisualPlayer.Source>
+
 
                             <!-- Fallback since Lottie-Windows is only supported on OS version 17763 and above -->
                             <AnimatedVisualPlayer.FallbackContent>
@@ -58,17 +61,15 @@
                             <ColumnDefinition />
                         </Grid.ColumnDefinitions>
 
-                        <!-- Play/Pause -->
-                        <Button x:Name="PlayPauseButton"
-                                Grid.Column="0"
-                                Margin="10"
-                                HorizontalAlignment="Stretch"
-                                Click="PlayPauseButton_Click"
-                                AutomationProperties.Name="Play">
-                            <StackPanel>
-                                <SymbolIcon x:Name="PlayIcon" Symbol="Play"/>
-                                <SymbolIcon x:Name="PauseIcon" Symbol="Pause" Visibility="Collapsed"/>
-                            </StackPanel>
+                        <!--  Play  -->
+                        <Button x:Name="PlayButton"
+                            Grid.Column="0"
+                            Margin="10"
+                            HorizontalAlignment="Stretch"
+                            Click="PlayButton_Click"
+                            ToolTipService.ToolTip="Play"
+                            AutomationProperties.Name="Play">
+                            <SymbolIcon Symbol="Play" />
                         </Button>
                         <!--  Pause  -->
                         <ToggleButton x:Name="PauseButton"

--- a/XamlControlsGallery/DataModel/ControlInfoData.json
+++ b/XamlControlsGallery/DataModel/ControlInfoData.json
@@ -1763,6 +1763,37 @@
       "Description": "",
       "Items": [
         {
+          "UniqueId": "AnimatedVisualPlayer",
+          "Title": "AnimatedVisualPlayer",
+          "Subtitle": "An element to render and control playback of motion graphics.",
+          "ImagePath": "ms-appx:///Assets/Animations.png",
+          "Description": "An element to render and control playback of motion graphics.",
+          "Content": "<p>Look at the <i>AnimatedVisualPlayerPage.xaml</i> and <i>AnimatedVisualPlayerPage.xaml.cs</i> files in Visual Studio to see the full code for this page.</p>",
+          "IsNew": false,
+          "Docs": [
+            {
+              "Title": "AnimatedVisualPlayer - API",
+              "Uri": "https://www.docs.microsoft.com/uwp/api/microsoft.ui.xaml.controls.animatedvisualplayer"
+            },
+            {
+              "Title": "Full Samples",
+              "Uri": "ms-windows-store://pdp/?productid=9N3J5TG8FF7F"
+            },
+            {
+              "Title": "Tutorials",
+              "Uri": "https://docs.microsoft.com/windows/communitytoolkit/animations/lottie#tutorials"
+            },
+            {
+              "Title": "Lottie Overview",
+              "Uri": "https://docs.microsoft.com/windows/communitytoolkit/animations/lottie"
+            },
+            {
+              "Title": "Lottie Windows - GitHub",
+              "Uri": "https://www.docs.microsoft.com/uwp/api/microsoft.ui.xaml.controls.animatedvisualplayer"
+            }
+          ]
+        },
+        {
           "UniqueId": "Image",
           "Title": "Image",
           "Subtitle": "A control to display image content.",

--- a/XamlControlsGallery/XamlControlsGallery.DesktopWap.csproj
+++ b/XamlControlsGallery/XamlControlsGallery.DesktopWap.csproj
@@ -28,8 +28,7 @@
        in the WinUI repo, or the next ItemGroup below when standalone. -->
   <ItemGroup>
     <PackageReference Include="ColorCode.WinUI" />
-    <!-- Win2D.WinUI is not public yet -->
-    <!-- <PackageReference Include="Win2d.winui" /> -->
+    <PackageReference Include="Microsoft.Graphics.Win2D" />
     <PackageReference Include="Microsoft.WinUI" />
     <PackageReference Include="Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage" />
     <Manifest Include="$(ApplicationManifest)" />
@@ -49,8 +48,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(IsInWinUIRepo)' != 'true'">
     <PackageReference Update="ColorCode.WinUI" Version="$(ColorCodeVersion)" />
-    <!-- Win2D.WinUI is not public yet -->
-    <!-- <PackageReference Update="Win2d.winui" Version="$(Win2DWinUIVersion)" /> -->
+    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.0.1" />
     <PackageReference Update="Microsoft.VCRTForwarders.140" Version="1.0.6" />
     <PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="3.8.0-4.20472.6" />
     <PackageReference Update="Microsoft.WinUI" Version="$(WinUIPackageVersion)" Condition="'$(WinUIPackageVersion)' != ''" />
@@ -73,23 +71,17 @@
     <PRIResource Include="Strings\en-US\Resources.resw" />
 
     <Compile Remove="CollectionsInterop.cs" />
-    <Compile Remove="AnimatedVisuals\LottieLogo1.cs" />
     <Compile Remove="Behaviors\ImageScrollBehavior.cs" />
     <Compile Remove="ControlPages\MediaPlayerElementPage.xaml.cs" />
     <Compile Remove="ControlPages\RevealPage.xaml.cs" />
     <Compile Remove="ControlPages\ScrollViewer2Page.xaml.cs" />
     <Compile Remove="ControlPages\InputValidationPage.xaml.cs" />
-    <!-- Win2D.WinUI is not public yet, and LottieLogo1.cs and  depends on it -->
-    <Compile Remove="AnimatedVisuals\LottieLogo1.cs" />
-    <Compile Remove="ControlPages\AnimatedVisualPlayerPage.xaml.cs" />
 
     <Page Remove="ControlPages\MediaPlayerElementPage.xaml" />
     <Page Remove="ControlPages\RevealPage.xaml" />
     <Page Remove="ControlPages\ScrollViewer2Page.xaml" />
     <Page Remove="ControlPages\InputValidationPage.xaml" />
-
-    <!-- Win2D.WinUI is not public yet, and AnimatedVisualPlayerPage.xaml depends on it -->
-    <Page Remove="ControlPages\AnimatedVisualPlayerPage.xaml" />
+    
   </ItemGroup>
   <ItemGroup>
     <None Remove="ControlPages\MediaPlayerElementPage.xaml" />


### PR DESCRIPTION
The AnimatedVisualPlayer sample was disabled because the required Win2D component was not available at the time for WinUI3. The [Microsoft.Graphics.Win2D](https://www.nuget.org/packages/Microsoft.Graphics.Win2D) nuget package is available and supports what we need.