### PR TITLE
Fix build warnings and UNIVERSAL build break

### DIFF
--- a/XamlControlsGallery/ContentIncludes.props
+++ b/XamlControlsGallery/ContentIncludes.props
@@ -26,7 +26,6 @@
     <Content Include="Assets\ProgressRing.png" />
     <Content Include="Assets\PullToRefresh.png" />
     <Content Include="Assets\RatingControl.png" />
-    <Content Include="Assets\RadioButtons.png" />
     <Content Include="Assets\Reveal.png" />
     <Content Include="Assets\RevealFocus.png" />
     <Content Include="Assets\Sound.png" />

--- a/XamlControlsGallery/Helper/NavigationOrientationHelper.cs
+++ b/XamlControlsGallery/Helper/NavigationOrientationHelper.cs
@@ -20,7 +20,9 @@ namespace AppUIBasics.Helper
 
         private const string IsLeftModeKey = "NavigationIsOnLeftMode";
 
+#if UNPACKAGED
         private static bool _isLeftMode = true;
+#endif
 
         public static bool IsLeftMode()
         {

--- a/XamlControlsGallery/Helper/ProtocolActivationClipboardHelper.cs
+++ b/XamlControlsGallery/Helper/ProtocolActivationClipboardHelper.cs
@@ -13,7 +13,9 @@ namespace AppUIBasics.Helper
     {
         private const string ShowCopyLinkTeachingTipKey = "ShowCopyLinkTeachingTip";
 
+#if UNPACKAGED
         private static bool _showCopyLinkTeachingTip = true;
+#endif
 
         public static bool ShowCopyLinkTeachingTip
         {

--- a/XamlControlsGallery/Helper/ThemeHelper.cs
+++ b/XamlControlsGallery/Helper/ThemeHelper.cs
@@ -105,7 +105,7 @@ namespace AppUIBasics.Helper
             if (CurrentApplicationWindow != null)
             {
                 // Dispatch on UI thread so that we have a current appbar to access and change
-                CurrentApplicationWindow.Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.High, () =>
+                _ = CurrentApplicationWindow.Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.High, () =>
                         {
                             UpdateSystemCaptionButtonColors();
                         });

--- a/XamlControlsGallery/TabViewPages/TabViewWindowingSamplePage.xaml
+++ b/XamlControlsGallery/TabViewPages/TabViewWindowingSamplePage.xaml
@@ -7,7 +7,6 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-    
 
     <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
         <TabView x:Name="Tabs" 

--- a/XamlControlsGallery/TabViewPages/TabViewWindowingSamplePage.xaml.cs
+++ b/XamlControlsGallery/TabViewPages/TabViewWindowingSamplePage.xaml.cs
@@ -67,10 +67,10 @@ namespace AppUIBasics.TabViewPages
 
             coreTitleBar.LayoutMetricsChanged += CoreTitleBar_LayoutMetricsChanged;
 
-            var titleBar = ApplicationView.GetForCurrentView().TitleBar;
+            var titleBar = Windows.UI.ViewManagement.ApplicationView.GetForCurrentView().TitleBar;
             titleBar.ButtonBackgroundColor = Microsoft.UI.Colors.Transparent;
             titleBar.ButtonInactiveBackgroundColor = Microsoft.UI.Colors.Transparent;
-#endif            
+#endif
         }
 
         private void CoreTitleBar_LayoutMetricsChanged(CoreApplicationViewTitleBar sender, object args)

--- a/XamlControlsGallery/XamlControlsGallery.DesktopWap.csproj
+++ b/XamlControlsGallery/XamlControlsGallery.DesktopWap.csproj
@@ -81,7 +81,7 @@
     <Page Remove="ControlPages\RevealPage.xaml" />
     <Page Remove="ControlPages\ScrollViewer2Page.xaml" />
     <Page Remove="ControlPages\InputValidationPage.xaml" />
-    
+
   </ItemGroup>
   <ItemGroup>
     <None Remove="ControlPages\MediaPlayerElementPage.xaml" />


### PR DESCRIPTION
## Description
In TabViewWindowingSamplePage.xaml.cs, ApplicationView is not found, so the full name is used (Windows.UI.ViewManagement)

NavigationOrientationHelper.cs(23,29): warning CS0414: The field 'NavigationOrientationHelper._isLeftMode' is assigned but its value is never used:
- The variable is only used inside an ifdef - move the declaration inside an ifdef

ProtocolActivationClipboardHelper.cs(16,29): warning CS0414: The field 'ProtocolActivationClipboardHelper._showCopyLinkTeachingTip' is assigned but its value is never used
- The variable is only used inside an ifdef - move the declaration inside an ifdef

ThemeHelper.cs(108,17): warning CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
- Make the method async and mark the call with await

PipsPagerPage.xaml(17,40): XamlCompiler warning WMC1506: OneWay bindings require at least one of their steps to support raising notifications when their value changes
- Change the binding from OneWay to OneTime

## Motivation and Context
With those changes, we can see the beautiful text:
Build succeeded.
0 Warning(s)
0 Error(s)

## How Has This Been Tested?
Local builds

