### PR TITLE
Fix search crash and crashes when the element root is null

### DIFF
--- a/XamlControlsGallery/App.xaml.cs
+++ b/XamlControlsGallery/App.xaml.cs
@@ -97,15 +97,9 @@ namespace AppUIBasics
         {
 #if UNIVERSAL
             NavigationRootPage navigationRootPage = (NavigationRootPage)Window.Current.Content;
-            switch (navigationRootPage.RootFrame?.Content)
+            if (navigationRootPage != null)
             {
-                case ItemPage itemPage:
-                    itemPage.SetInitialVisuals();
-                    break;
-                case NewControlsPage newControlsPage:
-                case AllControlsPage allControlsPage:
-                    navigationRootPage.NavigationView.AlwaysShowHeader = false;
-                    break;
+                navigationRootPage.App_Resuming();
             }
 #endif
         }

--- a/XamlControlsGallery/ItemPage.xaml.cs
+++ b/XamlControlsGallery/ItemPage.xaml.cs
@@ -214,19 +214,23 @@ namespace AppUIBasics
 
         protected override void OnNavigatedFrom(NavigationEventArgs e)
         {
-            NavigationRootPage.GetForElement(this).NavigationViewLoaded = null;
-            NavigationRootPage.GetForElement(this).PageHeader.TopCommandBar.Visibility = Visibility.Collapsed;
-            NavigationRootPage.GetForElement(this).PageHeader.ToggleThemeAction = null;
-            NavigationRootPage.GetForElement(this).PageHeader.CopyLinkAction = null;
-
-            // Reverse Connected Animation
-            if (e.SourcePageType != typeof(ItemPage))
+            var navigationRootPage = NavigationRootPage.GetForElement(this);
+            if (navigationRootPage != null)
             {
-                PageHeader pageHeader = NavigationRootPage.GetForElement(this).PageHeader;
+                navigationRootPage.NavigationViewLoaded = null;
+                navigationRootPage.PageHeader.TopCommandBar.Visibility = Visibility.Collapsed;
+                navigationRootPage.PageHeader.ToggleThemeAction = null;
+                navigationRootPage.PageHeader.CopyLinkAction = null;
 
-                if (pageHeader.Visibility == Visibility.Visible)
+                // Reverse Connected Animation
+                if (e.SourcePageType != typeof(ItemPage))
                 {
-                    ConnectedAnimationService.GetForCurrentView().PrepareToAnimate("controlAnimation", pageHeader.TitlePanel);
+                    PageHeader pageHeader = navigationRootPage.PageHeader;
+
+                    if (pageHeader.Visibility == Visibility.Visible)
+                    {
+                        ConnectedAnimationService.GetForCurrentView().PrepareToAnimate("controlAnimation", pageHeader.TitlePanel);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Description
Selecting a search result directly from the dropdown off the AutoSuggestBox crashes the app because NavigationRootPage has a couple places which call Navigate() with the wrong parameter type. This is now fixed. I also saw some crashes in ItemPage.OnNavigatedFrom() due to the NavigationRootPage.GetForElement(this) returning null sometimes when the element isn't in a tree, so I've added a null check around those uses.

This also removes direct access to RootFrame for better encapsulation.

## Motivation and Context
Crashes are bad

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
