### PR TITLE
Fixes for AnimatedVisualPlayer

### DIFF
--- a/XamlControlsGallery/ContentIncludes.props
+++ b/XamlControlsGallery/ContentIncludes.props
@@ -72,6 +72,7 @@
     <Content Include="Assets\LightGray.png" />
     <Content Include="Assets\ControlIcons\ListBoxIcon.png" />
     <Content Include="Assets\ControlIcons\ListViewIcon.png" />
+    <Content Include="Assets\LottieLogo1.png" />
     <Content Include="Assets\MediumGray.png" />
     <Content Include="Assets\ControlIcons\MenuFlyoutIcon.png" />
     <Content Include="Assets\ControlIcons\PasswordBoxIcon.png" />

--- a/XamlControlsGallery/ControlPages/AnimatedVisualPlayerPage.xaml
+++ b/XamlControlsGallery/ControlPages/AnimatedVisualPlayerPage.xaml
@@ -6,7 +6,8 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:animatedvisuals="using:AnimatedVisuals"
     xmlns:local="using:AppUIBasics"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Grid>
         <local:ControlExample x:Name="AnimatedVisualPlayerExample" 

--- a/XamlControlsGallery/ControlPages/ImplicitTransitionPage.xaml
+++ b/XamlControlsGallery/ControlPages/ImplicitTransitionPage.xaml
@@ -12,8 +12,8 @@
             <Setter Property="TabNavigation" Value="Cycle"/>
         </Style>
     </Page.Resources>
-    <StackPanel>
-        <local:ControlExample HeaderText="Automatically animate changes to Opacity" MinimumUniversalAPIContract="7">
+    <StackPanel Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <local:ControlExample HeaderText="Automatically animate changes to Opacity" >
             <Rectangle x:Name="OpacityRectangle" Width="50" Height="50" Fill="{ThemeResource SystemAccentColor}" VerticalAlignment="Center" Margin="45,5,5,5" Opacity="0.5" />
 
             <local:ControlExample.Options>

--- a/XamlControlsGallery/XamlControlsGallery.DesktopWap.csproj
+++ b/XamlControlsGallery/XamlControlsGallery.DesktopWap.csproj
@@ -48,7 +48,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(IsInWinUIRepo)' != 'true'">
     <PackageReference Update="ColorCode.WinUI" Version="$(ColorCodeVersion)" />
-    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.0.1" />
+    <PackageReference Include="Microsoft.Graphics.Win2D" Version="$(GraphicsWin2DVersion)" />
     <PackageReference Update="Microsoft.VCRTForwarders.140" Version="1.0.6" />
     <PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="3.8.0-4.20472.6" />
     <PackageReference Update="Microsoft.WinUI" Version="$(WinUIPackageVersion)" Condition="'$(WinUIPackageVersion)' != ''" />

--- a/XamlControlsGallery/standalone.props
+++ b/XamlControlsGallery/standalone.props
@@ -4,7 +4,7 @@
     <ProjectReunionPackageVersion>1.1-preview3</ProjectReunionPackageVersion>
     <ProjectReunionWinUIPackageVersion>1.1-preview3</ProjectReunionWinUIPackageVersion>
     <MicrosoftNETCoreUniversalWindowsPlatformVersion>6.2.11</MicrosoftNETCoreUniversalWindowsPlatformVersion>
-    <Win2DWinUIVersion>0.1.0.3</Win2DWinUIVersion>
+    <GraphicsWin2DVersion>1.0.3.1</GraphicsWin2DVersion>
     <ColorCodeVersion>2.0.13</ColorCodeVersion>
     <MicrosoftWindowsSDKBuildToolsNugetPackageVersion>10.0.22563-preview</MicrosoftWindowsSDKBuildToolsNugetPackageVersion>
     <MicrosoftCsWinRTPackageVersion>1.6.1</MicrosoftCsWinRTPackageVersion>


### PR DESCRIPTION
## Description
- Add LottieLogo1.png
- Fix the background to AnimatedVisualPage
- Update Win2D to version 1.0.3.1 (which now supports Hybrid CRT)
- Set the WinAppSDK minimum version to 1.0.3 (for Hybrid CRT & CsWinRT)
- Remove a hard-coded version in the project file
bonus fix:
- Also fix the background in ImplicitTransitionPage

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
