### PR TITLE
Fix Xaml source URIs to point to winui3 branch

### DIFF
--- a/XamlControlsGallery/ItemPage.xaml.cs
+++ b/XamlControlsGallery/ItemPage.xaml.cs
@@ -178,7 +178,7 @@ namespace AppUIBasics
                 {
                     // Pagetype is not null!
                     // So lets generate the github links and set them!
-                    var gitHubBaseURI = "https://github.com/microsoft/Xaml-Controls-Gallery/tree/master/XamlControlsGallery/ControlPages/";
+                    var gitHubBaseURI = "https://github.com/microsoft/WinUI-Gallery/tree/winui3/XamlControlsGallery/ControlPages/";
                     var pageName = pageType.Name + ".xaml";
                     PageCodeGitHubLink.NavigateUri = new Uri(gitHubBaseURI + pageName + ".cs");
                     PageMarkupGitHubLink.NavigateUri = new Uri(gitHubBaseURI + pageName);


### PR DESCRIPTION
## Description
The generated URIs pointed to the WinUI 2 branch (master), not the WinUI3 branch.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
