### PR TITLE
CP Update Mica backdrop when theme changes

### DIFF
--- a/XamlControlsGallery/ControlPagesSampleCode/SystemBackdrops/SystemBackdropsSample1.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/SystemBackdrops/SystemBackdropsSample1.txt
@@ -16,15 +16,11 @@ bool TrySetMicaBackdrop()
         m_configurationSource = new Microsoft.UI.Composition.SystemBackdrops.SystemBackdropConfiguration();
         this.Activated += Window_Activated;
         this.Closed += Window_Closed;
+        ((FrameworkElement)this.Content).ActualThemeChanged += Window_ThemeChanged;
 
         // Initial configuration state.
         m_configurationSource.IsInputActive = true;
-        switch (((FrameworkElement)this.Content).ActualTheme)
-        {
-        case ElementTheme.Dark:    m_configurationSource.Theme = Microsoft.UI.Composition.SystemBackdrops.SystemBackdropTheme.Dark; break;
-        case ElementTheme.Light:   m_configurationSource.Theme = Microsoft.UI.Composition.SystemBackdrops.SystemBackdropTheme.Light; break;
-        case ElementTheme.Default: m_configurationSource.Theme = Microsoft.UI.Composition.SystemBackdrops.SystemBackdropTheme.Default; break;
-        }
+        SetConfigurationSourceTheme();
 
         m_micaController = new Microsoft.UI.Composition.SystemBackdrops.MicaController();
 
@@ -56,3 +52,20 @@ private void Window_Closed(object sender, WindowEventArgs args)
     m_configurationSource = null;
 }
 
+private void Window_ThemeChanged(FrameworkElement sender, object args)
+{
+    if (m_configurationSource != null)
+    {
+        SetConfigurationSourceTheme();
+    }
+}
+
+private void SetConfigurationSourceTheme();
+{
+    switch (((FrameworkElement)this.Content).ActualTheme)
+    {
+        case ElementTheme.Dark:    m_configurationSource.Theme = Microsoft.UI.Composition.SystemBackdrops.SystemBackdropTheme.Dark; break;
+        case ElementTheme.Light:   m_configurationSource.Theme = Microsoft.UI.Composition.SystemBackdrops.SystemBackdropTheme.Light; break;
+        case ElementTheme.Default: m_configurationSource.Theme = Microsoft.UI.Composition.SystemBackdrops.SystemBackdropTheme.Default; break;
+    }
+}

--- a/XamlControlsGallery/ControlPagesSampleCode/SystemBackdrops/SystemBackdropsSample2.txt
+++ b/XamlControlsGallery/ControlPagesSampleCode/SystemBackdrops/SystemBackdropsSample2.txt
@@ -17,15 +17,11 @@ bool TrySetAcrylicBackdrop()
         m_configurationSource = new Microsoft.UI.Composition.SystemBackdrops.SystemBackdropConfiguration();
         this.Activated += Window_Activated;
         this.Closed += Window_Closed;
+        ((FrameworkElement)this.Content).ActualThemeChanged += Window_ThemeChanged;
 
         // Initial configuration state.
         m_configurationSource.IsInputActive = true;
-        switch (((FrameworkElement)this.Content).ActualTheme)
-        {
-        case ElementTheme.Dark:    m_configurationSource.Theme = Microsoft.UI.Composition.SystemBackdrops.SystemBackdropTheme.Dark; break;
-        case ElementTheme.Light:   m_configurationSource.Theme = Microsoft.UI.Composition.SystemBackdrops.SystemBackdropTheme.Light; break;
-        case ElementTheme.Default: m_configurationSource.Theme = Microsoft.UI.Composition.SystemBackdrops.SystemBackdropTheme.Default; break;
-        }
+        SetConfigurationSourceTheme();
 
         m_acrylicController = new Microsoft.UI.Composition.SystemBackdrops.DesktopAcrylicController();
 
@@ -57,3 +53,20 @@ private void Window_Closed(object sender, WindowEventArgs args)
     m_configurationSource = null;
 }
 
+private void Window_ThemeChanged(FrameworkElement sender, object args)
+{
+    if (m_configurationSource != null)
+    {
+        SetConfigurationSourceTheme();
+    }
+}
+
+private void SetConfigurationSourceTheme()
+{
+    switch (((FrameworkElement)this.Content).ActualTheme)
+    {
+        case ElementTheme.Dark:    m_configurationSource.Theme = Microsoft.UI.Composition.SystemBackdrops.SystemBackdropTheme.Dark; break;
+        case ElementTheme.Light:   m_configurationSource.Theme = Microsoft.UI.Composition.SystemBackdrops.SystemBackdropTheme.Light; break;
+        case ElementTheme.Default: m_configurationSource.Theme = Microsoft.UI.Composition.SystemBackdrops.SystemBackdropTheme.Default; break;
+    }
+}

--- a/XamlControlsGallery/SamplePages/SampleSystemBackdropsWindow.xaml
+++ b/XamlControlsGallery/SamplePages/SampleSystemBackdropsWindow.xaml
@@ -12,7 +12,7 @@
                 <TextBlock Text="Current backdrop: " />
                 <TextBlock x:Name="tbCurrentBackdrop" />
             </StackPanel>
-            <Button x:Name="btnChangeBackdrop" AutomationProperties.Name="ChangeBackdropButton" Content="Change Backdrop" Click="ChangeBackdropButton_Click"/>
+            <Button x:Name="btnChangeBackdrop" AutomationProperties.Name="ChangeBackdropButton" Content="Change Backdrop" Click="ChangeBackdropButton_Click" />
             <TextBlock x:Name="tbChangeStatus" />
         </StackPanel>
     </StackPanel>

--- a/XamlControlsGallery/SamplePages/SampleSystemBackdropsWindow.xaml.cs
+++ b/XamlControlsGallery/SamplePages/SampleSystemBackdropsWindow.xaml.cs
@@ -94,6 +94,7 @@ namespace AppUIBasics.SamplePages
             }
             this.Activated -= Window_Activated;
             this.Closed -= Window_Closed;
+            ((FrameworkElement)this.Content).ActualThemeChanged -= Window_ThemeChanged;
             m_configurationSource = null;
 
             if (type == BackdropType.Mica)
@@ -133,15 +134,11 @@ namespace AppUIBasics.SamplePages
                 m_configurationSource = new Microsoft.UI.Composition.SystemBackdrops.SystemBackdropConfiguration();
                 this.Activated += Window_Activated;
                 this.Closed += Window_Closed;
+                ((FrameworkElement)this.Content).ActualThemeChanged += Window_ThemeChanged;
 
                 // Initial configuration state.
                 m_configurationSource.IsInputActive = true;
-                switch (((FrameworkElement)this.Content).ActualTheme)
-                {
-                case ElementTheme.Dark:    m_configurationSource.Theme = Microsoft.UI.Composition.SystemBackdrops.SystemBackdropTheme.Dark; break;
-                case ElementTheme.Light:   m_configurationSource.Theme = Microsoft.UI.Composition.SystemBackdrops.SystemBackdropTheme.Light; break;
-                case ElementTheme.Default: m_configurationSource.Theme = Microsoft.UI.Composition.SystemBackdrops.SystemBackdropTheme.Default; break;
-                }
+                SetConfigurationSourceTheme();
 
                 m_micaController = new Microsoft.UI.Composition.SystemBackdrops.MicaController();
 
@@ -163,15 +160,11 @@ namespace AppUIBasics.SamplePages
                 m_configurationSource = new Microsoft.UI.Composition.SystemBackdrops.SystemBackdropConfiguration();
                 this.Activated += Window_Activated;
                 this.Closed += Window_Closed;
+                ((FrameworkElement)this.Content).ActualThemeChanged += Window_ThemeChanged;
 
                 // Initial configuration state.
                 m_configurationSource.IsInputActive = true;
-                switch (((FrameworkElement)this.Content).ActualTheme)
-                {
-                case ElementTheme.Dark:    m_configurationSource.Theme = Microsoft.UI.Composition.SystemBackdrops.SystemBackdropTheme.Dark; break;
-                case ElementTheme.Light:   m_configurationSource.Theme = Microsoft.UI.Composition.SystemBackdrops.SystemBackdropTheme.Light; break;
-                case ElementTheme.Default: m_configurationSource.Theme = Microsoft.UI.Composition.SystemBackdrops.SystemBackdropTheme.Default; break;
-                }
+                SetConfigurationSourceTheme();
 
                 m_acrylicController = new Microsoft.UI.Composition.SystemBackdrops.DesktopAcrylicController();
 
@@ -206,6 +199,24 @@ namespace AppUIBasics.SamplePages
             }
             this.Activated -= Window_Activated;
             m_configurationSource = null;
+        }
+
+        private void Window_ThemeChanged(FrameworkElement sender, object args)
+        {
+            if (m_configurationSource != null)
+            {
+                SetConfigurationSourceTheme();
+            }
+        }
+
+        private void SetConfigurationSourceTheme()
+        {
+            switch (((FrameworkElement)this.Content).ActualTheme)
+            {
+                case ElementTheme.Dark:    m_configurationSource.Theme = Microsoft.UI.Composition.SystemBackdrops.SystemBackdropTheme.Dark; break;
+                case ElementTheme.Light:   m_configurationSource.Theme = Microsoft.UI.Composition.SystemBackdrops.SystemBackdropTheme.Light; break;
+                case ElementTheme.Default: m_configurationSource.Theme = Microsoft.UI.Composition.SystemBackdrops.SystemBackdropTheme.Default; break;
+            }
         }
 
         void ChangeBackdropButton_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Description
This change adds an ActualThemeChanged listener to the Mica/SystemBackdrops page in WinUI Controls Gallery. This allows the backdrop to update according to the theme without the user having to change the background.

(Cherry-pick from internal repo)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
