### PR TITLE
fix universal breaks and whitespace

### DIFF
--- a/XamlControlsGallery/Controls/ControlExample.xaml
+++ b/XamlControlsGallery/Controls/ControlExample.xaml
@@ -158,11 +158,11 @@
             <muxc:Expander Grid.Row="1" Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
                 contract7Present:CornerRadius="0,0,8,8"
                 HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
-                
+
                 <muxc:Expander.Header>
                     <TextBlock Text="Source code"/>
                 </muxc:Expander.Header>
-                
+
                 <StackPanel x:DefaultBindMode="OneWay">
                     <controls:SampleCodePresenter
                         x:Name="XamlPresenter"

--- a/XamlControlsGallery/Controls/ControlExample.xaml.cs
+++ b/XamlControlsGallery/Controls/ControlExample.xaml.cs
@@ -159,7 +159,14 @@ namespace AppUIBasics
             set { SetValue(SubstitutionsProperty, value); }
         }
 
-        public static readonly DependencyProperty ExampleHeightProperty = DependencyProperty.Register("ExampleHeight", typeof(GridLength), typeof(ControlExample), new PropertyMetadata(new GridLength(1, GridUnitType.Star)));
+        private static readonly GridLength defaultExampleHeight =
+#if !UNIVERSAL
+            new GridLength(1, GridUnitType.Star);
+#else
+            new GridLength { Value = 1, GridUnitType = GridUnitType.Star };
+#endif
+
+        public static readonly DependencyProperty ExampleHeightProperty = DependencyProperty.Register("ExampleHeight", typeof(GridLength), typeof(ControlExample), new PropertyMetadata(defaultExampleHeight));
         public GridLength ExampleHeight
         {
             get { return (GridLength)GetValue(ExampleHeightProperty); }
@@ -420,15 +427,15 @@ namespace AppUIBasics
             switch (nums.Length)
             {
                 case 1:
-                    ControlPresenter.Padding = new Thickness(nums[0]);
+                    ControlPresenter.Padding = new Thickness() { Left = nums[0], Top = nums[0], Right = nums[0], Bottom = nums[0] };
                     break;
 
                 case 2:
-                    ControlPresenter.Padding = new Thickness(nums[0], nums[1], nums[0], nums[1]);
+                    ControlPresenter.Padding = new Thickness() { Left = nums[0], Top = nums[1], Right = nums[0], Bottom = nums[1] };
                     break;
 
                 case 4:
-                    ControlPresenter.Padding = new Thickness(nums[0], nums[1], nums[2], nums[3]);
+                    ControlPresenter.Padding = new Thickness() { Left = nums[0], Top = nums[1], Right = nums[2], Bottom = nums[3] };
                     break;
             }
         }

--- a/XamlControlsGallery/Controls/SampleCodePresenter.xaml
+++ b/XamlControlsGallery/Controls/SampleCodePresenter.xaml
@@ -27,7 +27,7 @@
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>
-            
+
             <VisualStateGroup x:Name="ConfirmDialogGroups">
                 <VisualState x:Name="ConfirmationDialogHidden"/>
                 <VisualState x:Name="ConfirmationDialogVisible">

--- a/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/XamlControlsGallery/Navigation/NavigationRootPage.xaml.cs
@@ -135,9 +135,13 @@ namespace AppUIBasics
             };
 
             NavigationViewControl.RegisterPropertyChangedCallback(NavigationView.PaneDisplayModeProperty, new DependencyPropertyChangedCallback(OnPaneDisplayModeChanged));
+#if UNIVERSAL
+            App.appTitlebar = AppTitleBar;
+#else
             var window = App.StartupWindow;
             window.ExtendsContentIntoTitleBar = true;
             window.SetTitleBar(AppTitleBar);
+#endif
         }
 
         private void OnPaneDisplayModeChanged(DependencyObject sender, DependencyProperty dp)


### PR DESCRIPTION
## Description
The ExtendsContentIntoTitleBar API is not supported in UWP.
Fix the GridLength and Thickness constructors for UWP.
Whitespace

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
