### PR TITLE
Fixed titlebar buttons when changing theme

### DIFF
--- a/WinUIGallery/ControlPages/TitlebarPage.xaml.cs
+++ b/WinUIGallery/ControlPages/TitlebarPage.xaml.cs
@@ -25,6 +25,7 @@ using Windows.Foundation;
 using Windows.Foundation.Collections;
 using WinRT;
 using System.Runtime.InteropServices;
+using WinUIGallery.DesktopWap.Helper;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -48,12 +49,6 @@ namespace AppUIBasics.ControlPages
             UpdateButtonText();
         }
 
-
-        [ComImport, Guid("EECDBF0E-BAE9-4CB6-A68E-9598E1CB57BB"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        private interface IWindowNative
-        {
-            IntPtr WindowHandle { get; }
-        };
 
         private void SetTitlebar(UIElement titlebar)
         {
@@ -126,20 +121,7 @@ namespace AppUIBasics.ControlPages
             res["WindowCaptionForeground"] = currentFgColor;
             //res["WindowCaptionForegroundDisabled"] = currentFgColor;
 
-            // to trigger repaint tracking task id 38044406
-            var native = App.StartupWindow.As<IWindowNative>();
-            var hwnd = native.WindowHandle;
-            var activeWindow = Win32.GetActiveWindow();
-            if (hwnd == activeWindow)
-            {
-                Win32.SendMessage(hwnd, Win32.WM_ACTIVATE, Win32.WA_INACTIVE, IntPtr.Zero);
-                Win32.SendMessage(hwnd, Win32.WM_ACTIVATE, Win32.WA_ACTIVE, IntPtr.Zero);
-            }
-            else
-            {
-                Win32.SendMessage(hwnd, Win32.WM_ACTIVATE, Win32.WA_ACTIVE, IntPtr.Zero);
-                Win32.SendMessage(hwnd, Win32.WM_ACTIVATE, Win32.WA_INACTIVE, IntPtr.Zero);
-            }
+            TitlebarHelper.triggerTitleBarRepaint();
         }
 
         private void customTitlebar_Click(object sender, RoutedEventArgs e)

--- a/WinUIGallery/Helper/TitlebarHelper.cs
+++ b/WinUIGallery/Helper/TitlebarHelper.cs
@@ -21,17 +21,10 @@ namespace WinUIGallery.DesktopWap.Helper
     internal class TitlebarHelper
     {
 
-        [ComImport, Guid("EECDBF0E-BAE9-4CB6-A68E-9598E1CB57BB"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        private interface IWindowNative
-        {
-            IntPtr WindowHandle { get; }
-        };
-
         public static void triggerTitleBarRepaint()
         {
             // to trigger repaint tracking task id 38044406
-            var native = AppUIBasics.App.StartupWindow.As<IWindowNative>();
-            var hwnd = native.WindowHandle;
+            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(AppUIBasics.App.StartupWindow);
             var activeWindow = AppUIBasics.Win32.GetActiveWindow();
             if (hwnd == activeWindow)
             {

--- a/WinUIGallery/Helper/TitlebarHelper.cs
+++ b/WinUIGallery/Helper/TitlebarHelper.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using AppUIBasics.Helper;
+using Windows.Storage;
+using Windows.Storage.Pickers;
+using Windows.System;
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Navigation;
+using WinRT;
+using System.Runtime.InteropServices;
+
+namespace WinUIGallery.DesktopWap.Helper
+{
+    internal class TitlebarHelper
+    {
+
+        [ComImport, Guid("EECDBF0E-BAE9-4CB6-A68E-9598E1CB57BB"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        private interface IWindowNative
+        {
+            IntPtr WindowHandle { get; }
+        };
+
+        public static void triggerTitleBarRepaint()
+        {
+            // to trigger repaint tracking task id 38044406
+            var native = AppUIBasics.App.StartupWindow.As<IWindowNative>();
+            var hwnd = native.WindowHandle;
+            var activeWindow = AppUIBasics.Win32.GetActiveWindow();
+            if (hwnd == activeWindow)
+            {
+                AppUIBasics.Win32.SendMessage(hwnd, AppUIBasics.Win32.WM_ACTIVATE, AppUIBasics.Win32.WA_INACTIVE, IntPtr.Zero);
+                AppUIBasics.Win32.SendMessage(hwnd, AppUIBasics.Win32.WM_ACTIVATE, AppUIBasics.Win32.WA_ACTIVE, IntPtr.Zero);
+            }
+            else
+            {
+                AppUIBasics.Win32.SendMessage(hwnd, AppUIBasics.Win32.WM_ACTIVATE, AppUIBasics.Win32.WA_ACTIVE, IntPtr.Zero);
+                AppUIBasics.Win32.SendMessage(hwnd, AppUIBasics.Win32.WM_ACTIVATE, AppUIBasics.Win32.WA_INACTIVE, IntPtr.Zero);
+            }
+
+        }
+
+    }
+}

--- a/WinUIGallery/SettingsPage.xaml.cs
+++ b/WinUIGallery/SettingsPage.xaml.cs
@@ -20,6 +20,7 @@ using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Navigation;
 using WinRT;
 using System.Runtime.InteropServices;
+using WinUIGallery.DesktopWap.Helper;
 
 #if UNIVERSAL
 using Windows.UI.ViewManagement;
@@ -90,12 +91,6 @@ namespace AppUIBasics
             }
         }
 
-        [ComImport, Guid("EECDBF0E-BAE9-4CB6-A68E-9598E1CB57BB"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        private interface IWindowNative
-        {
-            IntPtr WindowHandle { get; }
-        };
-
         private void OnThemeRadioButtonChecked(object sender, RoutedEventArgs e)
         {
             var selectedTheme = ((RadioButton)sender)?.Tag?.ToString();
@@ -130,20 +125,7 @@ namespace AppUIBasics
                 }
             }
 
-            // to trigger repaint tracking task id 38044406
-            var native = App.StartupWindow.As<IWindowNative>();
-            var hwnd = native.WindowHandle;
-            var activeWindow = Win32.GetActiveWindow();
-            if (hwnd == activeWindow)
-            {
-                Win32.SendMessage(hwnd, Win32.WM_ACTIVATE, Win32.WA_INACTIVE, IntPtr.Zero);
-                Win32.SendMessage(hwnd, Win32.WM_ACTIVATE, Win32.WA_ACTIVE, IntPtr.Zero);
-            }
-            else
-            {
-                Win32.SendMessage(hwnd, Win32.WM_ACTIVATE, Win32.WA_ACTIVE, IntPtr.Zero);
-                Win32.SendMessage(hwnd, Win32.WM_ACTIVATE, Win32.WA_INACTIVE, IntPtr.Zero);
-            }
+            TitlebarHelper.triggerTitleBarRepaint();
 
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Title bar buttons are set to Black when in Light mode and vice versa for dark mode

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
