### PR TITLE
Update ListViewSample2_xaml.txt

### DIFF
--- a/WinUIGallery/ControlPagesSampleCode/ListView/ListViewSample2_xaml.txt
+++ b/WinUIGallery/ControlPagesSampleCode/ListView/ListViewSample2_xaml.txt
@@ -12,6 +12,17 @@ code-behind. See the C# code below for more details on how to create/bind to a g
             <ItemsStackPanel AreStickyGroupHeadersEnabled="$(AreStickyGroupHeadersEnabled)"/>
         </ItemsPanelTemplate>
     </ListView.ItemsPanel>
+    <ListView.GroupStyle>
+        <GroupStyle >
+            <GroupStyle.HeaderTemplate>
+                <DataTemplate x:DataType="local1:GroupInfoList">
+                    <Border AutomationProperties.Name="{x:Bind Key}">
+                        <TextBlock Text="{x:Bind Key}" Style="{ThemeResource TitleTextBlockStyle}"/>
+                    </Border>
+                </DataTemplate>
+            </GroupStyle.HeaderTemplate>
+        </GroupStyle>
+    </ListView.GroupStyle>
 </ListView>
                     
 <!-- Data template used is same as above examples. -->


### PR DESCRIPTION
Update ListViewSample2 to include the Header template required to create groups in a ListView. 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added the lines of xaml from the *.cs file that are required to display groups to the sample text file. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I spent a view hours trying to figure out groups, and it wasn't until I looked at the source code for the examples that I saw the "GroupStyle" bit that was required. You have to have it, and unless you know is there from the source, the example doesn't give enough to replicate it. 

## How Has This Been Tested?
It's text. 

## Screenshots (if appropriate):

## Types of changes
- [X] Update Example. 
