### PR TITLE
Add debug manifest file for development

### DIFF
--- a/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
@@ -85,8 +85,12 @@ namespace AppUIBasics
         {
             get
             {
-#if !UNIVERSAL
+#if !UNIVERSAL && DEBUG
+                return "WinUI 3 Gallery Dev";
+#elif !UNIVERSAL
                 return "WinUI 3 Gallery";
+#elif DEBUG
+                return "WinUI 3 Gallery Dev (UWP)";
 #else
                 return "WinUI 3 Gallery (UWP)";
 #endif

--- a/WinUIGallery/Package.WAP.Debug.appxmanifest
+++ b/WinUIGallery/Package.WAP.Debug.appxmanifest
@@ -1,0 +1,55 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Package
+    xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+    xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
+    xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+    xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
+    xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+    IgnorableNamespaces="uap mp uap3">
+  <Identity Name="Microsoft.WinUI3ControlsGallery.Debug" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="1.3.13.0" />
+  <mp:PhoneIdentity PhoneProductId="863667e0-667a-4bb4-ac52-c59656c7333a" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
+  <Properties>
+    <DisplayName>WinUI 3 Gallery</DisplayName>
+    <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
+    <Logo>Assets\Tiles\StoreLogo-sdk.png</Logo>
+    <uap:SupportedUsers>multiple</uap:SupportedUsers>
+  </Properties>
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17134.0" MaxVersionTested="10.0.18362.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17134.0" MaxVersionTested="10.0.18362.0" />
+  </Dependencies>
+  <Resources>
+    <Resource Language="x-generate" />
+  </Resources>
+  <Applications>
+    <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="$targetentrypoint$">
+      <uap:VisualElements DisplayName="WinUI 3 Gallery (Debug)" Square150x150Logo="Assets\Tiles\squaretile-sdk.png" Square44x44Logo="Assets\Tiles\SmallTile-sdk.png" Description="WinUI 3 Gallery" BackgroundColor="transparent">
+        <uap:DefaultTile Square310x310Logo="Assets\Tiles\LargeTile.png" Wide310x150Logo="Assets\Tiles\WideTile.png" Square71x71Logo="Assets\Tiles\SmallTile.png">
+          <uap:ShowNameOnTiles>
+            <uap:ShowOn Tile="square150x150Logo" />
+            <uap:ShowOn Tile="wide310x150Logo" />
+            <uap:ShowOn Tile="square310x310Logo" />
+          </uap:ShowNameOnTiles>
+        </uap:DefaultTile>
+        <uap:SplashScreen Image="Assets\Tiles\splash-sdk.png" BackgroundColor="#00b2f0" />
+      </uap:VisualElements>
+      <Extensions>
+        <uap3:Extension Category="windows.appUriHandler">
+          <uap3:AppUriHandler>
+            <uap3:Host Name="winuigallery.com" />
+            <uap3:Host Name="xamlcontrolsgallery.com" />
+          </uap3:AppUriHandler>
+        </uap3:Extension>
+        <uap:Extension Category="windows.protocol">
+          <uap:Protocol Name="winui3gallerydebug">
+            <uap:DisplayName>WinUI 3 Gallery</uap:DisplayName>
+          </uap:Protocol>
+        </uap:Extension>
+      </Extensions>
+    </Application>
+  </Applications>
+  <Capabilities>
+    <Capability Name="internetClient" />
+    <rescap:Capability Name="runFullTrust" />
+  </Capabilities>
+</Package>

--- a/WinUIGallery/Package.WAP.Debug.appxmanifest
+++ b/WinUIGallery/Package.WAP.Debug.appxmanifest
@@ -9,7 +9,7 @@
   <Identity Name="Microsoft.WinUI3ControlsGallery.Debug" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="1.3.13.0" />
   <mp:PhoneIdentity PhoneProductId="863667e0-667a-4bb4-ac52-c59656c7333a" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
-    <DisplayName>WinUI 3 Gallery</DisplayName>
+    <DisplayName>WinUI 3 Gallery Debug</DisplayName>
     <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
     <Logo>Assets\Tiles\StoreLogo-sdk.png</Logo>
     <uap:SupportedUsers>multiple</uap:SupportedUsers>
@@ -23,7 +23,7 @@
   </Resources>
   <Applications>
     <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="$targetentrypoint$">
-      <uap:VisualElements DisplayName="WinUI 3 Gallery (Debug)" Square150x150Logo="Assets\Tiles\squaretile-sdk.png" Square44x44Logo="Assets\Tiles\SmallTile-sdk.png" Description="WinUI 3 Gallery" BackgroundColor="transparent">
+      <uap:VisualElements DisplayName="WinUI 3 Gallery (Debug)" Square150x150Logo="Assets\Tiles\squaretile-sdk.png" Square44x44Logo="Assets\Tiles\SmallTile-sdk.png" Description="WinUI 3 Gallery Debug" BackgroundColor="transparent">
         <uap:DefaultTile Square310x310Logo="Assets\Tiles\LargeTile.png" Wide310x150Logo="Assets\Tiles\WideTile.png" Square71x71Logo="Assets\Tiles\SmallTile.png">
           <uap:ShowNameOnTiles>
             <uap:ShowOn Tile="square150x150Logo" />
@@ -42,7 +42,7 @@
         </uap3:Extension>
         <uap:Extension Category="windows.protocol">
           <uap:Protocol Name="winui3gallerydebug">
-            <uap:DisplayName>WinUI 3 Gallery</uap:DisplayName>
+            <uap:DisplayName>WinUI 3 Gallery Debug</uap:DisplayName>
           </uap:Protocol>
         </uap:Extension>
       </Extensions>

--- a/WinUIGallery/Package.WAP.Dev.appxmanifest
+++ b/WinUIGallery/Package.WAP.Dev.appxmanifest
@@ -7,9 +7,9 @@
     xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
     IgnorableNamespaces="uap mp uap3">
   <Identity Name="Microsoft.WinUI3ControlsGallery.Debug" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="1.3.13.0" />
-  <mp:PhoneIdentity PhoneProductId="863667e0-667a-4bb4-ac52-c59656c7333a" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
+  <mp:PhoneIdentity PhoneProductId="0ba9d13a-a477-463f-955f-91d935fa4cd5" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
-    <DisplayName>WinUI 3 Gallery Debug</DisplayName>
+    <DisplayName>WinUI 3 Gallery Dev</DisplayName>
     <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
     <Logo>Assets\Tiles\StoreLogo-sdk.png</Logo>
     <uap:SupportedUsers>multiple</uap:SupportedUsers>
@@ -23,7 +23,7 @@
   </Resources>
   <Applications>
     <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="$targetentrypoint$">
-      <uap:VisualElements DisplayName="WinUI 3 Gallery (Debug)" Square150x150Logo="Assets\Tiles\squaretile-sdk.png" Square44x44Logo="Assets\Tiles\SmallTile-sdk.png" Description="WinUI 3 Gallery Debug" BackgroundColor="transparent">
+      <uap:VisualElements DisplayName="WinUI 3 Gallery Dev" Square150x150Logo="Assets\Tiles\squaretile-sdk.png" Square44x44Logo="Assets\Tiles\SmallTile-sdk.png" Description="WinUI 3 Gallery Debug" BackgroundColor="transparent">
         <uap:DefaultTile Square310x310Logo="Assets\Tiles\LargeTile.png" Wide310x150Logo="Assets\Tiles\WideTile.png" Square71x71Logo="Assets\Tiles\SmallTile.png">
           <uap:ShowNameOnTiles>
             <uap:ShowOn Tile="square150x150Logo" />
@@ -41,8 +41,8 @@
           </uap3:AppUriHandler>
         </uap3:Extension>
         <uap:Extension Category="windows.protocol">
-          <uap:Protocol Name="winui3gallerydebug">
-            <uap:DisplayName>WinUI 3 Gallery Debug</uap:DisplayName>
+          <uap:Protocol Name="winui3gallerydev">
+            <uap:DisplayName>WinUI 3 Gallery Dev</uap:DisplayName>
           </uap:Protocol>
         </uap:Extension>
       </Extensions>

--- a/WinUIGallery/Package.WAP.Dev.appxmanifest
+++ b/WinUIGallery/Package.WAP.Dev.appxmanifest
@@ -15,7 +15,6 @@
     <uap:SupportedUsers>multiple</uap:SupportedUsers>
   </Properties>
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17134.0" MaxVersionTested="10.0.18362.0" />
     <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17134.0" MaxVersionTested="10.0.18362.0" />
   </Dependencies>
   <Resources>
@@ -49,7 +48,6 @@
     </Application>
   </Applications>
   <Capabilities>
-    <Capability Name="internetClient" />
     <rescap:Capability Name="runFullTrust" />
   </Capabilities>
 </Package>

--- a/WinUIGallery/WinUIGallery.DesktopWap.Package.wapproj
+++ b/WinUIGallery/WinUIGallery.DesktopWap.Package.wapproj
@@ -77,7 +77,10 @@
     <AppxBundle>Always</AppxBundle>
   </PropertyGroup>
   <ItemGroup>
-    <AppxManifest Include="Package.WAP.appxmanifest">
+    <AppxManifest Include="Package.WAP.appxmanifest" Condition="!('$(Configuration)' == 'Debug')">
+      <SubType>Designer</SubType>
+    </AppxManifest>
+    <AppxManifest Include="Package.WAP.Debug.appxmanifest" Condition="'$(Configuration)' == 'Debug'">
       <SubType>Designer</SubType>
     </AppxManifest>
   </ItemGroup>

--- a/WinUIGallery/WinUIGallery.DesktopWap.Package.wapproj
+++ b/WinUIGallery/WinUIGallery.DesktopWap.Package.wapproj
@@ -80,7 +80,7 @@
     <AppxManifest Include="Package.WAP.appxmanifest" Condition="!('$(Configuration)' == 'Debug')">
       <SubType>Designer</SubType>
     </AppxManifest>
-    <AppxManifest Include="Package.WAP.Debug.appxmanifest" Condition="'$(Configuration)' == 'Debug'">
+    <AppxManifest Include="Package.WAP.Dev.appxmanifest" Condition="'$(Configuration)' == 'Debug'">
       <SubType>Designer</SubType>
     </AppxManifest>
   </ItemGroup>


### PR DESCRIPTION
Similar to the WinUI 2 gallery, this PR adds a debug manifest that allows you to have the Store version and the development versions installed at the same time instead of the two versions overriding each other all the time.

Question: Right now the app would still display WinUI 3 Gallery when being started, is that good?