### PR TITLE
Adds Automation Name to HeaderTile

### DIFF
--- a/WinUIGallery/Controls/HeaderTile.xaml
+++ b/WinUIGallery/Controls/HeaderTile.xaml
@@ -32,7 +32,7 @@
                 </ResourceDictionary.ThemeDictionaries>
             </ResourceDictionary>
         </Grid.Resources>
-        <HyperlinkButton Height="150" Padding="-1" NavigateUri="{x:Bind Link, Mode=OneWay}">
+        <HyperlinkButton Height="150" Padding="-1" NavigateUri="{x:Bind Link, Mode=OneWay}" AutomationProperties.LabeledBy="{Binding ElementName=TitleText}">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="102" />
@@ -44,7 +44,7 @@
                     HorizontalAlignment="Center"/>
 
                 <Grid Height="48" Opacity="1" Grid.Row="1" HorizontalAlignment="Stretch" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}">
-                    <TextBlock Text="{x:Bind Title, Mode=OneWay}"
+                    <TextBlock x:Name="TitleText" Text="{x:Bind Title, Mode=OneWay}"
                                Margin="16,0"
                                Style="{StaticResource BodyStrongTextBlockStyle}"
                                Foreground="{ThemeResource TextFillColorPrimaryBrush}"


### PR DESCRIPTION
Fixes missing Automation Property Name in Header Tiles.

Before:
<img width="924" alt="image" src="https://user-images.githubusercontent.com/7658216/177651790-84b43c01-2e23-47b9-959e-591982b19296.png">

After:
<img width="1023" alt="image" src="https://user-images.githubusercontent.com/7658216/177651694-1cf48d1a-6f1a-4bc6-acb7-401d727861d1.png">


Internal bug: 40233956
