### PR TITLE
AnimatedIcon: add missing automation name to button

### DIFF
--- a/WinUIGallery/ControlPages/AnimatedIconPage.xaml
+++ b/WinUIGallery/ControlPages/AnimatedIconPage.xaml
@@ -20,7 +20,7 @@
                         </Hyperlink>.
                         For guidance on how to properly structure your animation file see the AnimatedIcon Guidance page.<LineBreak></LineBreak>
                     </TextBlock>
-                    <Button PointerEntered="Button_PointerEntered" PointerExited="Button_PointerExited" Width="75">
+                    <Button PointerEntered="Button_PointerEntered" PointerExited="Button_PointerExited" Width="75" AutomationProperties.Name="AnimatedIcon Example">
                         <AnimatedIcon x:Name="SearchAnimatedIcon">
                             <AnimatedIcon.Source>
                                 <animatedvisuals:AnimatedFindVisualSource/>


### PR DESCRIPTION
Adds Automation Property Name to button with AnimatedIcon example.

Before:
<img width="892" alt="image" src="https://user-images.githubusercontent.com/7658216/177653197-a478fdfb-90e0-4aa8-8d0c-7097a3d2817f.png">


After:
<img width="1002" alt="image" src="https://user-images.githubusercontent.com/7658216/177653160-bcd7c69f-cf80-4033-b465-1a1df789736f.png">

Internal bug: 40234408