### PR TITLE
Remove LocalizedControlType from Elements Automation Name

### DIFF
--- a/WinUIGallery/ControlPages/ButtonPage.xaml
+++ b/WinUIGallery/ControlPages/ButtonPage.xaml
@@ -19,7 +19,8 @@
         <local:ControlExample x:Name="Example1" HeaderText="A simple Button with text content.">
             <local:ControlExample.Example>
                 <Button x:Name="Button1" Content="Standard XAML button" Click="Button_Click"
-                    IsEnabled="{x:Bind DisableButton1.IsChecked.Value.Equals(x:False), Mode=OneWay}" />
+                        AutomationProperties.Name="Standard XAML"
+                        IsEnabled="{x:Bind DisableButton1.IsChecked.Value.Equals(x:False), Mode=OneWay}" />
             </local:ControlExample.Example>
             <local:ControlExample.Output>
                 <TextBlock x:Name="Control1Output" FontFamily="Global User Interface"/>
@@ -110,7 +111,7 @@
 
         <local:ControlExample HeaderText="Accent style applied to Button.">
             <local:ControlExample.Example>
-                <Button Style="{StaticResource AccentButtonStyle}" Content="Accent style button"/>
+                <Button Style="{StaticResource AccentButtonStyle}" Content="Accent style button" AutomationProperties.Name="Accent style"/>
             </local:ControlExample.Example>
             <local:ControlExample.Xaml>
                 <x:String >

--- a/WinUIGallery/ControlPages/CheckBoxPage.xaml
+++ b/WinUIGallery/ControlPages/CheckBoxPage.xaml
@@ -18,7 +18,7 @@
             <local:ControlExample.Example>
                 <StackPanel Orientation="Horizontal">
                     <!-- A two-state CheckBox. -->
-                    <CheckBox Content="Two-state CheckBox" Checked="Control1_Checked" Unchecked="Control1_Unchecked" />
+                    <CheckBox Content="Two-state CheckBox" Checked="Control1_Checked" Unchecked="Control1_Unchecked" AutomationProperties.Name="Two-state" />
                 </StackPanel>
             </local:ControlExample.Example>
             <local:ControlExample.Output>
@@ -36,7 +36,8 @@
             <local:ControlExample.Example>
                 <StackPanel Orientation="Horizontal">
                     <CheckBox Content="Three-state CheckBox" IsThreeState="True" Indeterminate="Control2_Indeterminate"
-                            Checked="Control2_Checked" Unchecked="Control2_Unchecked" />
+                              Checked="Control2_Checked" Unchecked="Control2_Unchecked"
+                              AutomationProperties.Name="Three-state"/>
                 </StackPanel>
             </local:ControlExample.Example>
             <local:ControlExample.Output>

--- a/WinUIGallery/ControlPages/CheckBoxPage.xaml
+++ b/WinUIGallery/ControlPages/CheckBoxPage.xaml
@@ -18,38 +18,38 @@
             <local:ControlExample.Example>
                 <StackPanel Orientation="Horizontal">
                     <!-- A two-state CheckBox. -->
-                    <CheckBox Content="Two-state CheckBox" Checked="Control1_Checked" Unchecked="Control1_Unchecked" AutomationProperties.Name="Two-state" />
+                    <CheckBox Content="Two-state CheckBox" Checked="TwoState_Checked" Unchecked="TwoState_Unchecked" AutomationProperties.Name="Two-state" />
                 </StackPanel>
             </local:ControlExample.Example>
             <local:ControlExample.Output>
-                <TextBlock x:Name="Control1Output"/>
+                <TextBlock x:Name="TwoStateOutput"/>
             </local:ControlExample.Output>
             <local:ControlExample.Xaml>
                 <x:String xml:space="preserve">
 &lt;CheckBox Content="Two-state CheckBox"
-          Checked="Control1_Checked"
-          Unchecked="Control1_Unchecked" /&gt;
+          Checked="TwoState_Checked"
+          Unchecked="TwoState_Unchecked" /&gt;
                 </x:String>
             </local:ControlExample.Xaml>
         </local:ControlExample>
         <local:ControlExample x:Name="Example2" HeaderText="A 3-state CheckBox." RelativePanel.Below="Example1">
             <local:ControlExample.Example>
                 <StackPanel Orientation="Horizontal">
-                    <CheckBox Content="Three-state CheckBox" IsThreeState="True" Indeterminate="Control2_Indeterminate"
-                              Checked="Control2_Checked" Unchecked="Control2_Unchecked"
+                    <CheckBox Content="Three-state CheckBox" IsThreeState="True" Indeterminate="ThreeState_Indeterminate"
+                              Checked="ThreeState_Checked" Unchecked="ThreeState_Unchecked"
                               AutomationProperties.Name="Three-state"/>
                 </StackPanel>
             </local:ControlExample.Example>
             <local:ControlExample.Output>
-                <TextBlock x:Name="Control2Output" />
+                <TextBlock x:Name="ThreeStateOutput" />
             </local:ControlExample.Output>
             <local:ControlExample.Xaml>
                 <x:String xml:space="preserve">
 &lt;CheckBox Content="Three-state CheckBox"
           IsThreeState="True"
-          Checked="Control2_Checked"
-          Unchecked="Control2_Unchecked"
-          Indeterminate="Control2_Indeterminate" /&gt;
+          Checked="ThreeState_Checked"
+          Unchecked="ThreeState_Unchecked"
+          Indeterminate="ThreeState_Indeterminate" /&gt;
                 </x:String>
             </local:ControlExample.Xaml>
         </local:ControlExample>

--- a/WinUIGallery/ControlPages/CheckBoxPage.xaml.cs
+++ b/WinUIGallery/ControlPages/CheckBoxPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿//*********************************************************
+//*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
 // THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
@@ -26,29 +26,29 @@ namespace AppUIBasics.ControlPages
             SetCheckedState();
         }
 
-        private void Control1_Checked(object sender, RoutedEventArgs e)
+        private void TwoState_Checked(object sender, RoutedEventArgs e)
         {
-            Control1Output.Text = "You checked the box.";
+            TwoStateOutput.Text = "You checked the box.";
         }
 
-        private void Control1_Unchecked(object sender, RoutedEventArgs e)
+        private void TwoState_Unchecked(object sender, RoutedEventArgs e)
         {
-            Control1Output.Text = "You unchecked the box.";
+            TwoStateOutput.Text = "You unchecked the box.";
         }
 
-        private void Control2_Checked(object sender, RoutedEventArgs e)
+        private void ThreeState_Checked(object sender, RoutedEventArgs e)
         {
-            Control2Output.Text = "CheckBox is checked.";
+            ThreeStateOutput.Text = "CheckBox is checked.";
         }
 
-        private void Control2_Unchecked(object sender, RoutedEventArgs e)
+        private void ThreeState_Unchecked(object sender, RoutedEventArgs e)
         {
-            Control2Output.Text = "CheckBox is unchecked.";
+            ThreeStateOutput.Text = "CheckBox is unchecked.";
         }
 
-        private void Control2_Indeterminate(object sender, RoutedEventArgs e)
+        private void ThreeState_Indeterminate(object sender, RoutedEventArgs e)
         {
-            Control2Output.Text = "CheckBox state is indeterminate.";
+            ThreeStateOutput.Text = "CheckBox state is indeterminate.";
         }
 
         #region SelectAllMethods

--- a/WinUIGallery/ControlPages/RevealFocusPage.xaml
+++ b/WinUIGallery/ControlPages/RevealFocusPage.xaml
@@ -75,9 +75,9 @@
         <local:ControlExample x:Name="Example1" HeaderText="Change the appearance of the focus rectangle.">
 
             <StackPanel Orientation="Horizontal">
-                <Button Style="{StaticResource ButtonRevealCustomStyle}" AutomationProperties.Name="Square button 1"/>
-                <Button Style="{StaticResource ButtonRevealCustomStyle}" AutomationProperties.Name="Square button 2"/>
-                <Button Style="{StaticResource ButtonRevealCustomStyle}" AutomationProperties.Name="Square button 3"/>
+                <Button Style="{StaticResource ButtonRevealCustomStyle}" AutomationProperties.Name="Square 1"/>
+                <Button Style="{StaticResource ButtonRevealCustomStyle}" AutomationProperties.Name="Square 2"/>
+                <Button Style="{StaticResource ButtonRevealCustomStyle}" AutomationProperties.Name="Square 3"/>
             </StackPanel>
 
             <local:ControlExample.Options>
@@ -106,7 +106,7 @@
             <StackPanel>
                 <StackPanel Orientation="Horizontal">
                     <Button x:Name="exampleButton" 
-                        AutomationProperties.Name="Square button 4"
+                        AutomationProperties.Name="Square 4"
                         Style="{StaticResource ButtonRevealCustomStyle}"
                         FocusVisualMargin="{x:Bind local2:MyConverters.IntToThickness(marginSlider.Value), Mode=OneWay}"
                         FocusVisualPrimaryThickness="{x:Bind local2:MyConverters.IntToThickness(primarySlider.Value), Mode=OneWay}"
@@ -115,7 +115,7 @@
                         FocusVisualSecondaryBrush="{x:Bind local2:MyConverters.ColorToBrush(mySecondaryColorPicker.Color), Mode=OneWay}" />
                     <Button
                         Style="{StaticResource ButtonRevealCustomStyle}"
-                        AutomationProperties.Name="Square button 5"
+                        AutomationProperties.Name="Square 5"
                         FocusVisualMargin="{x:Bind local2:MyConverters.IntToThickness(marginSlider.Value), Mode=OneWay}"
                         FocusVisualPrimaryThickness="{x:Bind local2:MyConverters.IntToThickness(primarySlider.Value), Mode=OneWay}"
                         FocusVisualSecondaryThickness="{x:Bind local2:MyConverters.IntToThickness(secondarySlider.Value), Mode=OneWay}"
@@ -123,7 +123,7 @@
                         FocusVisualSecondaryBrush="{x:Bind local2:MyConverters.ColorToBrush(mySecondaryColorPicker.Color), Mode=OneWay}" />
                     <Button
                         Style="{StaticResource ButtonRevealCustomStyle}"
-                        AutomationProperties.Name="Square button 6"
+                        AutomationProperties.Name="Square 6"
                         FocusVisualMargin="{x:Bind local2:MyConverters.IntToThickness(marginSlider.Value), Mode=OneWay}"
                         FocusVisualPrimaryThickness="{x:Bind local2:MyConverters.IntToThickness(primarySlider.Value), Mode=OneWay}"
                         FocusVisualSecondaryThickness="{x:Bind local2:MyConverters.IntToThickness(secondarySlider.Value), Mode=OneWay}"
@@ -140,7 +140,7 @@
                          />
 
                 <ComboBox MinWidth="300" Margin="0,16,0,0" 
-                          AutomationProperties.Name="Sample ComboBox"
+                          AutomationProperties.Name="Sample"
                           SelectedIndex="0"
                           FocusVisualMargin="{x:Bind local2:MyConverters.IntToThickness(marginSlider.Value), Mode=OneWay}"
                           FocusVisualPrimaryThickness="{x:Bind local2:MyConverters.IntToThickness(primarySlider.Value), Mode=OneWay}"
@@ -162,7 +162,7 @@
                     FocusVisualSecondaryBrush="{x:Bind local2:MyConverters.ColorToBrush(mySecondaryColorPicker.Color), Mode=OneWay}"/>
 
                 <Slider MinWidth="300" Margin="5,16,0,0" IsFocusEngagementEnabled="True" 
-                    AutomationProperties.Name="Sample slider"
+                    AutomationProperties.Name="Sample"
                     FocusVisualMargin="{x:Bind local2:MyConverters.IntToThickness(marginSlider.Value), Mode=OneWay}"
                     FocusVisualPrimaryThickness="{x:Bind local2:MyConverters.IntToThickness(primarySlider.Value), Mode=OneWay}"
                     FocusVisualSecondaryThickness="{x:Bind local2:MyConverters.IntToThickness(secondarySlider.Value), Mode=OneWay}"

--- a/WinUIGallery/ControlPages/SliderPage.xaml
+++ b/WinUIGallery/ControlPages/SliderPage.xaml
@@ -16,7 +16,7 @@
     <StackPanel>
         <local:ControlExample x:Name="Example1" HeaderText="A simple Slider.">
             <StackPanel Orientation="Horizontal">
-                <Slider x:Name="Slider1" AutomationProperties.Name="simple slider" Width="200" />
+                <Slider x:Name="Slider1" AutomationProperties.Name="simple" Width="200" />
             </StackPanel>
             <local:ControlExample.Output>
                 <TextBlock Text="{x:Bind Slider1.Value.ToString(), Mode=OneWay}" />
@@ -44,7 +44,7 @@
         </local:ControlExample>
         <local:ControlExample x:Name="Example3" HeaderText="A Slider with tick marks.">
             <StackPanel Orientation="Horizontal">
-                <Slider x:Name="Slider3" Width="290" TickFrequency="10" TickPlacement="Outside" AutomationProperties.Name="Slider with ticks"/>
+                <Slider x:Name="Slider3" Width="290" TickFrequency="10" TickPlacement="Outside" AutomationProperties.Name="Tick marks"/>
             </StackPanel>
             <local:ControlExample.Output>
                 <TextBlock Text="{x:Bind Slider3.Value.ToString(), Mode=OneWay}" />
@@ -58,7 +58,7 @@
         <local:ControlExample x:Name="Example4" HeaderText="A vertical slider with range and tick marks specified.">
             <StackPanel Orientation="Horizontal">
                 <Slider x:Name="Slider4" Width="100" Height="100" Orientation="Vertical" TickFrequency="10" TickPlacement="Outside"
-                        Maximum="50" Minimum="-50" AutomationProperties.Name="vertical slider"/>
+                        Maximum="50" Minimum="-50" AutomationProperties.Name="vertical"/>
             </StackPanel>
             <local:ControlExample.Output>
                 <TextBlock Text="{x:Bind Slider4.Value.ToString(), Mode=OneWay}" />

--- a/WinUIGallery/ControlPages/SplitButtonPage.xaml
+++ b/WinUIGallery/ControlPages/SplitButtonPage.xaml
@@ -59,7 +59,7 @@
 
         <local:ControlExample HeaderText="A SplitButton with text" XamlSource="Buttons\SplitButton\SplitButtonSample2.txt">
             <local:ControlExample.Example>
-                <SplitButton AutomationProperties.Name="Font color" x:Name="myColorButtonReveal" Padding="5" MinHeight="0" MinWidth="0" VerticalAlignment="Top">
+                <SplitButton AutomationProperties.Name="Font color with text" x:Name="myColorButtonReveal" Padding="5" MinHeight="0" MinWidth="0" VerticalAlignment="Top">
                     Choose color
                     <SplitButton.Flyout>
                         <Flyout Placement="Bottom">


### PR DESCRIPTION
Removes the control type from the automation name, so narrator doesn't read repetitive and confusing information.
Fixes issue where two Elements of same control type had same automation name.

Fixes internal bug 40234538 and 40234974