### PR TITLE
move window helper into helper directory

### DIFF
--- a/WinUIGallery/ControlPages/SplitViewPage.xaml.cs
+++ b/WinUIGallery/ControlPages/SplitViewPage.xaml.cs
@@ -1,3 +1,4 @@
+using AppUIBasics.Helper;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/WinUIGallery/Helper/WindowHelper.cs
+++ b/WinUIGallery/Helper/WindowHelper.cs
@@ -11,7 +11,7 @@
 using Microsoft.UI.Xaml;
 using System.Collections.Generic;
 
-namespace AppUIBasics
+namespace AppUIBasics.Helper
 {
     // Helper class to allow the app to find the Window that contains an
     // arbitrary UIElement (GetWindowForElement).  To do this, we keep track

--- a/WinUIGallery/IdleSynchronizer.cs
+++ b/WinUIGallery/IdleSynchronizer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using AppUIBasics.Helper;
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;


### PR DESCRIPTION
## Description
Move the WindowHelper into the helper directory, where it logically belongs.

## Motivation and Context
Matching an internal code-cleanup change.

