### PR TITLE
Fix issue with color selection on TitleBar page not being keyboard accessible

### DIFF
--- a/WinUIGallery/ControlPages/TitleBarPage.xaml
+++ b/WinUIGallery/ControlPages/TitleBarPage.xaml
@@ -57,15 +57,14 @@
                                             </Style>
                                         </GridView.Resources>
                                         <GridView.Items>
-                                            <Rectangle Fill="Transparent"/>
-                                            <Rectangle Fill="Red"/>
-                                            <Rectangle Fill="Orange"/>
-                                            <Rectangle Fill="Yellow"/>
-                                            <Rectangle Fill="Green"/>
-                                            <Rectangle Fill="Blue"/>
-                                            <Rectangle Fill="White"/>
-                                            <Rectangle Fill="Black"/>
-                                        </GridView.Items>
+                                            <Rectangle Fill="Transparent" AutomationProperties.Name="Transparent"/>
+                                            <Rectangle Fill="Red" AutomationProperties.Name="Red"/>
+                                            <Rectangle Fill="Orange" AutomationProperties.Name="Orange"/>
+                                            <Rectangle Fill="Yellow" AutomationProperties.Name="Yellow"/>
+                                            <Rectangle Fill="Green" AutomationProperties.Name="Green"/>
+                                            <Rectangle Fill="Blue" AutomationProperties.Name="Blue"/>
+                                            <Rectangle Fill="White" AutomationProperties.Name="White"/>
+                                            <Rectangle Fill="Black" AutomationProperties.Name="Black"/>                                        </GridView.Items>
                                     </GridView>
 
                                 </Flyout>
@@ -92,14 +91,14 @@
                                             </Style>
                                         </GridView.Resources>
                                         <GridView.Items>
-                                            <Rectangle Fill="Transparent"/>
-                                            <Rectangle Fill="Red"/>
-                                            <Rectangle Fill="Orange"/>
-                                            <Rectangle Fill="Yellow"/>
-                                            <Rectangle Fill="Green"/>
-                                            <Rectangle Fill="Blue"/>
-                                            <Rectangle Fill="White"/>
-                                            <Rectangle Fill="Black"/>
+                                            <Rectangle Fill="Transparent" AutomationProperties.Name="Transparent"/>
+                                            <Rectangle Fill="Red" AutomationProperties.Name="Red"/>
+                                            <Rectangle Fill="Orange" AutomationProperties.Name="Orange"/>
+                                            <Rectangle Fill="Yellow" AutomationProperties.Name="Yellow"/>
+                                            <Rectangle Fill="Green" AutomationProperties.Name="Green"/>
+                                            <Rectangle Fill="Blue" AutomationProperties.Name="Blue"/>
+                                            <Rectangle Fill="White" AutomationProperties.Name="White"/>
+                                            <Rectangle Fill="Black" AutomationProperties.Name="Black"/>
                                         </GridView.Items>
                                     </GridView>
 

--- a/WinUIGallery/ControlPages/TitleBarPage.xaml
+++ b/WinUIGallery/ControlPages/TitleBarPage.xaml
@@ -24,7 +24,7 @@
     <Page.Resources>
         <x:Double x:Key="SwatchSize">32</x:Double>
     </Page.Resources>
-    
+
     <StackPanel>
         <local:ControlExample HeaderText="User defined UIElement as custom titlebar for the window"
                               CSharpSource="Window\TitleBar\TitleBarSample1.txt">
@@ -36,13 +36,13 @@
                     </TextBlock>
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" VerticalAlignment="Top" Spacing="10">
                         <Button x:Name="customTitleBar" Click="customTitleBar_Click"></Button>
-                        <TextBlock> Background Color </TextBlock>
+                        <TextBlock> Background Color</TextBlock>
                         <SplitButton x:Name="myBgColorButton" AutomationProperties.Name="Background color" Padding="0" MinHeight="0" MinWidth="0" VerticalAlignment="Top">
                             <Border x:Name="BackgroundColorElement" Width="{StaticResource SwatchSize}"
                                     Height="{StaticResource SwatchSize}" Background="Transparent" Margin="0" CornerRadius="4,0,0,4"/>
                             <SplitButton.Flyout>
                                 <Flyout Placement="Auto">
-                                    <GridView>
+                                    <GridView ItemClick="BgGridView_ItemClick" IsItemClickEnabled="True">
                                         <GridView.ItemsPanel>
                                             <ItemsPanelTemplate>
                                                 <ItemsWrapGrid MaximumRowsOrColumns="3" Orientation="Horizontal"/>
@@ -55,68 +55,29 @@
                                                 <Setter Property="RadiusX" Value="4"/>
                                                 <Setter Property="RadiusY" Value="4"/>
                                             </Style>
-                                            <Style TargetType="Button">
-                                                <Setter Property="Padding" Value="0"/>
-                                                <Setter Property="MinWidth" Value="0"/>
-                                                <Setter Property="MinHeight" Value="0"/>
-                                                <Setter Property="Margin" Value="6"/>
-                                                <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}"/>
-                                            </Style>
                                         </GridView.Resources>
                                         <GridView.Items>
-                                            <Button Click="BgColorButton_Click" AutomationProperties.Name="Transparent">
-                                                <Button.Content>
-                                                    <Rectangle Fill="Transparent"/>
-                                                </Button.Content>
-                                            </Button>
-                                            <Button Click="BgColorButton_Click" AutomationProperties.Name="Red">
-                                                <Button.Content>
-                                                    <Rectangle Fill="Red"/>
-                                                </Button.Content>
-                                            </Button>
-                                            <Button Click="BgColorButton_Click" AutomationProperties.Name="Orange">
-                                                <Button.Content>
-                                                    <Rectangle Fill="Orange"/>
-                                                </Button.Content>
-                                            </Button>
-                                            <Button Click="BgColorButton_Click" AutomationProperties.Name="Yellow">
-                                                <Button.Content>
-                                                    <Rectangle Fill="Yellow"/>
-                                                </Button.Content>
-                                            </Button>
-                                            <Button Click="BgColorButton_Click" AutomationProperties.Name="Green">
-                                                <Button.Content>
-                                                    <Rectangle Fill="Green"/>
-                                                </Button.Content>
-                                            </Button>
-                                            <Button Click="BgColorButton_Click" AutomationProperties.Name="Blue">
-                                                <Button.Content>
-                                                    <Rectangle Fill="Blue"/>
-                                                </Button.Content>
-                                            </Button>
-                                            <Button Click="BgColorButton_Click" AutomationProperties.Name="Indigo">
-                                                <Button.Content>
-                                                    <Rectangle Fill="White"/>
-                                                </Button.Content>
-                                            </Button>
-                                            <Button Click="BgColorButton_Click" AutomationProperties.Name="Violet">
-                                                <Button.Content>
-                                                    <Rectangle Fill="Black"/>
-                                                </Button.Content>
-                                            </Button>
+                                            <Rectangle Fill="Transparent"/>
+                                            <Rectangle Fill="Red"/>
+                                            <Rectangle Fill="Orange"/>
+                                            <Rectangle Fill="Yellow"/>
+                                            <Rectangle Fill="Green"/>
+                                            <Rectangle Fill="Blue"/>
+                                            <Rectangle Fill="White"/>
+                                            <Rectangle Fill="Black"/>
                                         </GridView.Items>
                                     </GridView>
 
                                 </Flyout>
                             </SplitButton.Flyout>
                         </SplitButton>
-                         
+
                         <TextBlock> Foreground Color</TextBlock>
                         <SplitButton x:Name="myFgColorButton" AutomationProperties.Name="Foreground color" Padding="0" MinHeight="0" MinWidth="0" VerticalAlignment="Top">
                             <Border x:Name="ForegroundColorElement" Width="{StaticResource SwatchSize}" Height="{StaticResource SwatchSize}" Background="Black" Margin="0" CornerRadius="4,0,0,4"/>
                             <SplitButton.Flyout>
                                 <Flyout Placement="Auto">
-                                    <GridView>
+                                    <GridView ItemClick="FgGridView_ItemClick" IsItemClickEnabled="True">
                                         <GridView.ItemsPanel>
                                             <ItemsPanelTemplate>
                                                 <ItemsWrapGrid MaximumRowsOrColumns="3" Orientation="Horizontal"/>
@@ -129,55 +90,16 @@
                                                 <Setter Property="RadiusX" Value="4"/>
                                                 <Setter Property="RadiusY" Value="4"/>
                                             </Style>
-                                            <Style TargetType="Button">
-                                                <Setter Property="Padding" Value="0"/>
-                                                <Setter Property="MinWidth" Value="0"/>
-                                                <Setter Property="MinHeight" Value="0"/>
-                                                <Setter Property="Margin" Value="6"/>
-                                                <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}"/>
-                                            </Style>
                                         </GridView.Resources>
                                         <GridView.Items>
-                                            <Button Click="FgColorButton_Click" AutomationProperties.Name="Transparent">
-                                                <Button.Content>
-                                                    <Rectangle Fill="Transparent"/>
-                                                </Button.Content>
-                                            </Button>
-                                            <Button Click="FgColorButton_Click" AutomationProperties.Name="Red">
-                                                <Button.Content>
-                                                    <Rectangle Fill="Red"/>
-                                                </Button.Content>
-                                            </Button>
-                                            <Button Click="FgColorButton_Click" AutomationProperties.Name="Orange">
-                                                <Button.Content>
-                                                    <Rectangle Fill="Orange"/>
-                                                </Button.Content>
-                                            </Button>
-                                            <Button Click="FgColorButton_Click" AutomationProperties.Name="Yellow">
-                                                <Button.Content>
-                                                    <Rectangle Fill="Yellow"/>
-                                                </Button.Content>
-                                            </Button>
-                                            <Button Click="FgColorButton_Click" AutomationProperties.Name="Green">
-                                                <Button.Content>
-                                                    <Rectangle Fill="Green"/>
-                                                </Button.Content>
-                                            </Button>
-                                            <Button Click="FgColorButton_Click" AutomationProperties.Name="Blue">
-                                                <Button.Content>
-                                                    <Rectangle Fill="Blue"/>
-                                                </Button.Content>
-                                            </Button>
-                                            <Button Click="FgColorButton_Click" AutomationProperties.Name="Indigo">
-                                                <Button.Content>
-                                                    <Rectangle Fill="White"/>
-                                                </Button.Content>
-                                            </Button>
-                                            <Button Click="FgColorButton_Click" AutomationProperties.Name="Violet">
-                                                <Button.Content>
-                                                    <Rectangle Fill="Black"/>
-                                                </Button.Content>
-                                            </Button>
+                                            <Rectangle Fill="Transparent"/>
+                                            <Rectangle Fill="Red"/>
+                                            <Rectangle Fill="Orange"/>
+                                            <Rectangle Fill="Yellow"/>
+                                            <Rectangle Fill="Green"/>
+                                            <Rectangle Fill="Blue"/>
+                                            <Rectangle Fill="White"/>
+                                            <Rectangle Fill="Black"/>
                                         </GridView.Items>
                                     </GridView>
 
@@ -187,7 +109,7 @@
 
                     </StackPanel>
                 </StackPanel>
-                </local:ControlExample.Example>
+            </local:ControlExample.Example>
 
         </local:ControlExample>
         <local:ControlExample HeaderText="Fallback titlebar when no user defined titlebar is set"

--- a/WinUIGallery/ControlPages/TitleBarPage.xaml.cs
+++ b/WinUIGallery/ControlPages/TitleBarPage.xaml.cs
@@ -26,6 +26,8 @@ using Windows.Foundation.Collections;
 using WinRT;
 using System.Runtime.InteropServices;
 using WinUIGallery.DesktopWap.Helper;
+using Microsoft.UI.Xaml.Shapes;
+using System.Threading.Tasks;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -84,42 +86,38 @@ namespace AppUIBasics.ControlPages
 
         }
 
-        private void BgColorButton_Click(object sender, RoutedEventArgs e)
+        private void BgGridView_ItemClick(object sender, ItemClickEventArgs e)
         {
-            // Extract the color of the button that was clicked.
-            Button clickedColor = (Button)sender;
-            var rectangle = (Microsoft.UI.Xaml.Shapes.Rectangle)clickedColor.Content;
-            var color = ((Microsoft.UI.Xaml.Media.SolidColorBrush)rectangle.Fill).Color;
-
+            var rect = (Rectangle)e.ClickedItem;
+            var color = ((SolidColorBrush)rect.Fill).Color;
             BackgroundColorElement.Background = new SolidColorBrush(color);
 
             currentBgColor = color;
             UpdateTitleBarColor();
 
+            // Delay required to circumvent GridView bug: https://github.com/microsoft/microsoft-ui-xaml/issues/6350
+            Task.Delay(10).ContinueWith(_ => myBgColorButton.Flyout.Hide(), TaskScheduler.FromCurrentSynchronizationContext());
         }
 
-        private void FgColorButton_Click(object sender, RoutedEventArgs e)
+        private void FgGridView_ItemClick(object sender, ItemClickEventArgs e)
         {
-            // Extract the color of the button that was clicked.
-            Button clickedColor = (Button)sender;
-            var rectangle = (Microsoft.UI.Xaml.Shapes.Rectangle)clickedColor.Content;
-            var color = ((Microsoft.UI.Xaml.Media.SolidColorBrush)rectangle.Fill).Color;
+            var rect = (Rectangle)e.ClickedItem;
+            var color = ((SolidColorBrush)rect.Fill).Color;
 
             ForegroundColorElement.Background = new SolidColorBrush(color);
 
             currentFgColor = color;
             UpdateTitleBarColor();
 
+            // Delay required to circumvent GridView bug: https://github.com/microsoft/microsoft-ui-xaml/issues/6350
+            Task.Delay(10).ContinueWith(_ => myFgColorButton.Flyout.Hide(), TaskScheduler.FromCurrentSynchronizationContext());
         }
-
 
         private void UpdateTitleBarColor()
         {
             var res = Microsoft.UI.Xaml.Application.Current.Resources;
             res["WindowCaptionBackground"] = currentBgColor;
-            //res["WindowCaptionBackgroundDisabled"] = currentBgColor;
             res["WindowCaptionForeground"] = currentFgColor;
-            //res["WindowCaptionForegroundDisabled"] = currentFgColor;
 
             TitleBarHelper.triggerTitleBarRepaint();
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The issue was that Buttons inside a GridView are not entirely accessible, we are now using the same way as on the SplitButton page to solve this problem. This PR also cleans up some dead code/empty spaces.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1071 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
