### PR TITLE
Find alternative for UWP ExtendViewIntoTitleBar API to fix issue with non clickable elements in top orientation

### DIFF
--- a/WinUIGallery/Helper/NavigationOrientationHelper.cs
+++ b/WinUIGallery/Helper/NavigationOrientationHelper.cs
@@ -55,6 +55,9 @@ namespace AppUIBasics.Helper
             CoreApplication.GetCurrentView().TitleBar.ExtendViewIntoTitleBar = isLeftMode;
 
             ApplicationViewTitleBar titleBar = ApplicationView.GetForCurrentView().TitleBar;
+#else
+            var window = App.StartupWindow;
+            window.ExtendsContentIntoTitleBar = isLeftMode;
 #endif
             if (isLeftMode)
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixes the issue by not extending the content into the titlebar just like the WinUI 2 Gallery does.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1065 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually.
## Screenshots (if appropriate):
![Screenshot of WinUI 3 Gallery with navigation being on top](https://user-images.githubusercontent.com/16122379/193393022-9a1be2fb-85ae-4071-b052-92999129b38c.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
