### PR TITLE
Use the proper Window in multi-window scenarios

### DIFF
--- a/WinUIGallery/App.xaml.cs
+++ b/WinUIGallery/App.xaml.cs
@@ -50,9 +50,6 @@ namespace AppUIBasics
 #endif
             }
         }
-
-        public static UIElement appTitleBar = null;
-
         /// <summary>
         /// Initializes the singleton Application object.  This is the first line of authored code
         /// executed, and as such is the logical equivalent of main() or WinMain().

--- a/WinUIGallery/ControlPages/TitleBarPage.xaml.cs
+++ b/WinUIGallery/ControlPages/TitleBarPage.xaml.cs
@@ -7,6 +7,7 @@
 // PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
 //
 //*********************************************************
+using AppUIBasics.Helper;
 using System;
 using Microsoft;
 using System.Collections.Generic;
@@ -45,14 +46,17 @@ namespace AppUIBasics.ControlPages
         public TitleBarPage()
         {
             this.InitializeComponent();
-            UpdateTitleBarColor();
-            UpdateButtonText();
+            Loaded += (object sender, RoutedEventArgs e) =>
+            {
+                (sender as TitleBarPage).UpdateTitleBarColor();
+                UpdateButtonText();
+            };
         }
 
 
         private void SetTitleBar(UIElement titlebar)
         {
-            var window = App.StartupWindow;
+            var window = WindowHelper.GetWindowForElement(this as UIElement);
             if (!window.ExtendsContentIntoTitleBar)
             {
                 window.ExtendsContentIntoTitleBar = true;
@@ -68,9 +72,9 @@ namespace AppUIBasics.ControlPages
             UpdateTitleBarColor();
         }
 
-        private void UpdateButtonText()
+        public void UpdateButtonText()
         {
-            var window = App.StartupWindow;
+            var window = WindowHelper.GetWindowForElement(this as UIElement);
             if (window.ExtendsContentIntoTitleBar)
             {
                 customTitleBar.Content = "Reset to system TitleBar";
@@ -113,20 +117,22 @@ namespace AppUIBasics.ControlPages
         }
 
 
-        private void UpdateTitleBarColor()
+        public void UpdateTitleBarColor()
         {
             var res = Microsoft.UI.Xaml.Application.Current.Resources;
-            res["WindowCaptionBackground"] = currentBgColor;
-            //res["WindowCaptionBackgroundDisabled"] = currentBgColor;
-            res["WindowCaptionForeground"] = currentFgColor;
-            //res["WindowCaptionForegroundDisabled"] = currentFgColor;
+            var titleBarElement = WindowHelper.FindElementByName(this, "AppTitleBar");
 
-            TitleBarHelper.triggerTitleBarRepaint();
+            (titleBarElement as Border).Background = new SolidColorBrush(currentBgColor); // changing titlebar uielement's color
+            res["WindowCaptionForeground"] = currentFgColor;
+            //res["WindowCaptionForegroundDisabled"] = currentFgColor; //optional to set disabled state colors
+            var window = WindowHelper.GetWindowForElement(this);
+            TitleBarHelper.triggerTitleBarRepaint(window);
         }
 
         private void customTitleBar_Click(object sender, RoutedEventArgs e)
         {
-            SetTitleBar(App.appTitleBar);
+            UIElement titleBarElement = WindowHelper.FindElementByName(sender as UIElement, "AppTitleBar");
+            SetTitleBar(titleBarElement);
         }
         private void defaultTitleBar_Click(object sender, RoutedEventArgs e)
         {

--- a/WinUIGallery/Helper/TitleBarHelper.cs
+++ b/WinUIGallery/Helper/TitleBarHelper.cs
@@ -21,10 +21,10 @@ namespace WinUIGallery.DesktopWap.Helper
     internal class TitleBarHelper
     {
 
-        public static void triggerTitleBarRepaint()
+        public static void triggerTitleBarRepaint(Window window)
         {
             // to trigger repaint tracking task id 38044406
-            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(AppUIBasics.App.StartupWindow);
+            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(window);
             var activeWindow = AppUIBasics.Win32.GetActiveWindow();
             if (hwnd == activeWindow)
             {

--- a/WinUIGallery/Helper/WindowHelper.cs
+++ b/WinUIGallery/Helper/WindowHelper.cs
@@ -50,6 +50,19 @@ namespace AppUIBasics.Helper
             return null;
         }
 
+        static public UIElement FindElementByName(UIElement element, string name)
+        {
+            if (element.XamlRoot != null && element.XamlRoot.Content != null)
+            {
+                var ele = (element.XamlRoot.Content as FrameworkElement).FindName(name);
+                if (ele != null)
+                {
+                    return ele as UIElement;
+                }
+            }
+            return null;
+        }
+
         static public List<Window> ActiveWindows { get { return _activeWindows; }}
 
         static private List<Window> _activeWindows = new List<Window>();

--- a/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
@@ -136,17 +136,12 @@ namespace AppUIBasics
 #if !UNIVERSAL
                 WindowHelper.GetWindowForElement(this).Title = AppTitleText;
 #endif
+                var window = WindowHelper.GetWindowForElement(sender as UIElement);
+                window.ExtendsContentIntoTitleBar = true;
+                window.SetTitleBar(this.AppTitleBar);
             };
 
             NavigationViewControl.RegisterPropertyChangedCallback(NavigationView.PaneDisplayModeProperty, new DependencyPropertyChangedCallback(OnPaneDisplayModeChanged));
-
-            // Set the titlebar to be custom. This is also referenced by the TitleBarPage
-            App.appTitleBar = AppTitleBar;
-#if !UNIVERSAL
-            var window = App.StartupWindow;
-            window.ExtendsContentIntoTitleBar = true;
-            window.SetTitleBar(AppTitleBar);
-#endif
         }
 
         private void OnPaneDisplayModeChanged(DependencyObject sender, DependencyProperty dp)

--- a/WinUIGallery/SettingsPage.xaml.cs
+++ b/WinUIGallery/SettingsPage.xaml.cs
@@ -124,8 +124,8 @@ namespace AppUIBasics
                     }
                 }
             }
-
-            TitleBarHelper.triggerTitleBarRepaint();
+            var window = WindowHelper.GetWindowForElement(this);
+            TitleBarHelper.triggerTitleBarRepaint(window);
 
         }
 


### PR DESCRIPTION
## Description
Since the origin of WinUI controls gallery is single window, many items like StartupWindow which tells the window information are static and don't work in multi window scenario. Instead, we should call xamlroot to find window object as well as app titlebar object when app content has finished loading

Also made a change where dropdown color in Titlebar page changes app titlebar uielement's color instead of titlebar container color. So that it would be painting it below the text instead of over the text.

## Motivation and Context
Fix the issue where changes to the Window titlebar were applied to the wrong window.

## How Has This Been Tested?
Manual testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
