### PR TITLE
Enable downlevel dragging of custom titlebar by adding Win 10 compatibility to the app manifest

### DIFF
--- a/WinUIGallery/app.manifest
+++ b/WinUIGallery/app.manifest
@@ -8,4 +8,11 @@
       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
     </windowsSettings>
   </application>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
 </assembly>


### PR DESCRIPTION
## Description
We are using WS_EX_LAYERED for the drag area of the title bar and it is created as a child window.
When a compability section is left out of the manifest, CreateWindow cannot create a child window with that attribute and the result is that you cannot drag using the title bar. The GUID used here is for Windows 10.

Adding this section to the manifest of your app will fix the issue.

## Motivation and Context
This fixes the issue where the WinUI custom titlebar is not draggable.

## How Has This Been Tested?
Manual testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
