### PR TITLE
Enable ScrollViewer Zoom and add tab stop

### DIFF
--- a/WinUIGallery/ControlPages/ScrollViewerPage.xaml
+++ b/WinUIGallery/ControlPages/ScrollViewerPage.xaml
@@ -20,7 +20,7 @@
 
             <!-- There's a known issue with zooming where we get into a layout cycle if we specify a height but not a width.
                  As a workaround for now, set an explicit height/width to match the natural size of the image. -->
-            <ScrollViewer x:Name="Control1" Height="266" Width="400" ZoomMode="Disabled" IsVerticalScrollChainingEnabled="True"
+            <ScrollViewer x:Name="Control1" Height="266" Width="400" ZoomMode="Enabled" IsTabStop="True" IsVerticalScrollChainingEnabled="True"
                     ManipulationCompleted="Control1_ManipulationCompleted" VerticalAlignment="Top"
                     HorizontalAlignment="Left">
                 <Image Source="ms-appx:///Assets/SampleMedia/cliff.jpg" Stretch="None" HorizontalAlignment="Left"


### PR DESCRIPTION
## Description
At startup time ZoomModeComboBox_SelectionChanged is called, but ZoomSlider is still Null. So Control1.ZoomMode remains ZoomMode.Disabled. You end up with a UI that says ZoomMode is Enabled when in fact its Disabled.

This change has fixed two issues on ScrollViewer:
Zoom not working
ScrollViewer not getting focus.

## Motivation and Context
Zoom in/ out on Scrollbar in XCG is not working.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Touch works
Ctrl +/- works
Zoom ctrl works
Ctrl + mouse wheel works

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
