### PR TITLE
Prepare for WinAppSDK 1.2

### DIFF
--- a/WinUIGallery/App.xaml
+++ b/WinUIGallery/App.xaml
@@ -86,7 +86,7 @@
 
             <x:String x:Key="ControlsName">All controls</x:String>
             <x:String x:Key="AppTitleName">WinUI 3 Gallery</x:String>
-            <x:String x:Key="WinUIVersion">WinAppSDK 1.1</x:String>
+            <x:String x:Key="WinUIVersion">WinAppSDK 1.2</x:String>
 
             <Style x:Key="OutputTextBlockStyle" BasedOn="{StaticResource BodyTextBlockStyle}" TargetType="TextBlock">
                 <Setter Property="Margin" Value="8,8,0,0" />

--- a/WinUIGallery/Properties/PublishProfiles/win10-arm64-unpackaged.pubxml
+++ b/WinUIGallery/Properties/PublishProfiles/win10-arm64-unpackaged.pubxml
@@ -11,9 +11,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun>True</PublishReadyToRun>
     <PublishAppxPackage>False</PublishAppxPackage>
-   <!-- 
-    See https://github.com/microsoft/CsWinRT/issues/373
-    <PublishTrimmed>True</PublishTrimmed>
-    -->
+    <PublishTrimmed>True</PublishTrimmed>      
   </PropertyGroup>
 </Project>

--- a/WinUIGallery/Properties/PublishProfiles/win10-arm64-unpackaged.pubxml
+++ b/WinUIGallery/Properties/PublishProfiles/win10-arm64-unpackaged.pubxml
@@ -11,6 +11,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun>True</PublishReadyToRun>
     <PublishAppxPackage>False</PublishAppxPackage>
-    <PublishTrimmed>True</PublishTrimmed>      
+    <PublishTrimmed>True</PublishTrimmed>
   </PropertyGroup>
 </Project>

--- a/WinUIGallery/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/WinUIGallery/Properties/PublishProfiles/win10-arm64.pubxml
@@ -11,9 +11,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun>True</PublishReadyToRun>
     <PublishAppxPackage>True</PublishAppxPackage>
-   <!-- 
-    See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>
-    -->
   </PropertyGroup>
 </Project>

--- a/WinUIGallery/Properties/PublishProfiles/win10-x64-unpackaged.pubxml
+++ b/WinUIGallery/Properties/PublishProfiles/win10-x64-unpackaged.pubxml
@@ -11,9 +11,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun>True</PublishReadyToRun>
     <PublishAppxPackage>False</PublishAppxPackage>
-   <!-- 
-    See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>
-    -->
   </PropertyGroup>
 </Project>

--- a/WinUIGallery/Properties/PublishProfiles/win10-x64.pubxml
+++ b/WinUIGallery/Properties/PublishProfiles/win10-x64.pubxml
@@ -11,9 +11,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun>True</PublishReadyToRun>
     <PublishAppxPackage>True</PublishAppxPackage>
-   <!-- 
-    See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>
-    -->
   </PropertyGroup>
 </Project>

--- a/WinUIGallery/Properties/PublishProfiles/win10-x86-unpackaged.pubxml
+++ b/WinUIGallery/Properties/PublishProfiles/win10-x86-unpackaged.pubxml
@@ -11,9 +11,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun>True</PublishReadyToRun>
     <PublishAppxPackage>False</PublishAppxPackage>
-   <!-- 
-    See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>
-    -->
   </PropertyGroup>
 </Project>

--- a/WinUIGallery/Properties/PublishProfiles/win10-x86.pubxml
+++ b/WinUIGallery/Properties/PublishProfiles/win10-x86.pubxml
@@ -11,9 +11,6 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun>False</PublishReadyToRun>
     <PublishAppxPackage>True</PublishAppxPackage>
-   <!-- 
-    See https://github.com/microsoft/CsWinRT/issues/373
     <PublishTrimmed>True</PublishTrimmed>
-    -->
   </PropertyGroup>
 </Project>

--- a/WinUIGallery/WinUIGallery.DesktopWap.Package.wapproj
+++ b/WinUIGallery/WinUIGallery.DesktopWap.Package.wapproj
@@ -94,7 +94,8 @@
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="[$(ProjectReunionPackageVersion)]" GeneratePathProperty="true">
       <IncludeAssets>build</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.197">
+
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="[$(MicrosoftWindowsSDKBuildToolsNugetPackageVersion)]">
       <IncludeAssets>build</IncludeAssets>
     </PackageReference>
   </ItemGroup>

--- a/WinUIGallery/WinUIGallery.DesktopWap.csproj
+++ b/WinUIGallery/WinUIGallery.DesktopWap.csproj
@@ -50,7 +50,6 @@
     <PackageReference Update="ColorCode.WinUI" Version="$(ColorCodeVersion)" />
     <PackageReference Update="Microsoft.Graphics.Win2D" Version="$(GraphicsWin2DVersion)" />
     <PackageReference Update="Microsoft.VCRTForwarders.140" Version="1.0.6" />
-    <PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="3.8.0-4.20472.6" />
     <PackageReference Update="Microsoft.WinUI" Version="$(WinUIPackageVersion)" Condition="'$(WinUIPackageVersion)' != ''" />
      <!-- Get latest WinRT.Runtime.dll from C#/WinRT -->
     <PackageReference Update="Microsoft.Windows.CsWinRT" Version="$(MicrosoftCsWinRTPackageVersion)" />

--- a/WinUIGallery/standalone.props
+++ b/WinUIGallery/standalone.props
@@ -1,28 +1,27 @@
 <Project>
   <PropertyGroup>
     <!-- The NuGet versions of dependencies to build against. -->
-    <ProjectReunionPackageVersion>1.1.0</ProjectReunionPackageVersion>
-    <ProjectReunionWinUIPackageVersion>1.1.0</ProjectReunionWinUIPackageVersion>
+    <ProjectReunionPackageVersion>1.2.220930.4-preview2</ProjectReunionPackageVersion>
+    <ProjectReunionWinUIPackageVersion>1.2.220930.4-preview2</ProjectReunionWinUIPackageVersion>
     <SamplesTargetFrameworkMoniker>net6.0-windows10.0.18362.0</SamplesTargetFrameworkMoniker>
     <MicrosoftNETCoreUniversalWindowsPlatformVersion>6.2.11</MicrosoftNETCoreUniversalWindowsPlatformVersion>
     <GraphicsWin2DVersion>1.0.3.1</GraphicsWin2DVersion>
     <ColorCodeVersion>2.0.13</ColorCodeVersion>
     <MicrosoftWindowsSDKBuildToolsNugetPackageVersion>10.0.22621.1</MicrosoftWindowsSDKBuildToolsNugetPackageVersion>
     <MicrosoftCsWinRTPackageVersion>2.0.0</MicrosoftCsWinRTPackageVersion>
-    <!-- Where to place the files generated from CSWinRT from WinUIGallery.Desktop.-->
-    <GeneratedFilesDir>obj\generated</GeneratedFilesDir>
     <!-- We have multiple projects in the same directory, which means we need to separate their output paths-->
     <BaseIntermediateOutputPath>obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
     <BaseOutputPath>bin\$(MSBuildProjectName)\</BaseOutputPath>
     <!-- 
-         For Desktop, the .NET 5 SDK automatically includes every .cs file in the project directory.  It normally
+         For Desktop, the .NET 6 SDK automatically includes every .cs file in the project directory.  It normally
          also excludes items under the obj/bin folders based on the value of BaseIntermediateOutputPath/BaseOutputPath.
          However, because we overwrite those to output to subdirectories, the outputs of the UWP WinUI Gallery
          are erroneously included.  Explicitly exclude them here
     -->
     <DefaultItemExcludes>obj\**;bin\**;$(DefaultItemExcludes)</DefaultItemExcludes>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(VisualStudioVersion)' == '15.0'">
-      <SamplesTargetFrameworkMoniker>net5.0-windows10.0.18362.0</SamplesTargetFrameworkMoniker>
+  <PropertyGroup Condition="'$(IsInWinUIRepo)' != 'true'">
+    <!-- Where to place the files generated from CSWinRT from WinUIGallery.Desktop.-->
+    <GeneratedFilesDir>obj\generated</GeneratedFilesDir>
   </PropertyGroup>
 </Project>

--- a/WinUIGallery/standalone.props
+++ b/WinUIGallery/standalone.props
@@ -7,8 +7,8 @@
     <MicrosoftNETCoreUniversalWindowsPlatformVersion>6.2.11</MicrosoftNETCoreUniversalWindowsPlatformVersion>
     <GraphicsWin2DVersion>1.0.3.1</GraphicsWin2DVersion>
     <ColorCodeVersion>2.0.13</ColorCodeVersion>
-    <MicrosoftWindowsSDKBuildToolsNugetPackageVersion>10.0.22563-preview</MicrosoftWindowsSDKBuildToolsNugetPackageVersion>
-    <MicrosoftCsWinRTPackageVersion>1.6.4</MicrosoftCsWinRTPackageVersion>
+    <MicrosoftWindowsSDKBuildToolsNugetPackageVersion>10.0.22621.1</MicrosoftWindowsSDKBuildToolsNugetPackageVersion>
+    <MicrosoftCsWinRTPackageVersion>2.0.0</MicrosoftCsWinRTPackageVersion>
     <!-- Where to place the files generated from CSWinRT from WinUIGallery.Desktop.-->
     <GeneratedFilesDir>obj\generated</GeneratedFilesDir>
     <!-- We have multiple projects in the same directory, which means we need to separate their output paths-->


### PR DESCRIPTION
## Description
There are signifcant changes in the WInAppSDK 1.2 release and this feature branch is the place to make necessary code changes to the WinUI Gallery to allow it to run on 1.2-preview2 (and eventually the stabel release).  When the stable release arrives, this branch will be merged into main, so this branch is temporary.

This change points to the 1.2-preview2 release and updates to CsWinRT 2.0.  That change does require VS 2022 and .Net 6.

## Motivation and Context
Prepare for the upcoming release and give everyone a chance to give it a spin.

## How Has This Been Tested?
Manual Testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
