### PR TITLE
Changed the zoom value to 2

### DIFF
--- a/WinUIGallery/ControlPages/ScrollViewerPage.xaml
+++ b/WinUIGallery/ControlPages/ScrollViewerPage.xaml
@@ -54,7 +54,7 @@
                     <Slider Grid.Row="1" Grid.ColumnSpan="2" x:Name="ZoomSlider" Header="Zoom" IsEnabled="True"
                         Maximum="{x:Bind Control1.MaxZoomFactor, Mode=OneWay}"
                         Minimum="{x:Bind Control1.MinZoomFactor, Mode=OneWay}"
-                        Value="1"
+                        Value="2"
                         Margin="0,10,0,0"
                         ValueChanged="ZoomSlider_ValueChanged" />
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed the zoom value in the ScrollViewer page from 1 to 2.

## Motivation and Context
This was required because scrolling features in the page were not visible due to the zoom placed on the image. The zoom needed to be at a higher value (<=2) in order to see the scrolling features.