### PR TITLE
User/ranjeshj/tabdragdrop3

### DIFF
--- a/WinUIGallery/TabViewPages/TabViewWindowingSamplePage.xaml.cs
+++ b/WinUIGallery/TabViewPages/TabViewWindowingSamplePage.xaml.cs
@@ -237,20 +237,6 @@ namespace AppUIBasics.TabViewPages
                 }
             };
 
-            var contextFlyout = new MenuFlyout();
-            var moveToNewWindowFlyout = new MenuFlyoutItem();
-
-            moveToNewWindowFlyout.Text = "Move to new window";
-            //moveToNewWindowFlyout.Click += MoveToNewWindowFlyout_Click;
-            contextFlyout.Items.Add(moveToNewWindowFlyout);
-
-            newTab.ContextFlyout = contextFlyout;
-
-            //void MoveToNewWindowFlyout_Click(object _sender, RoutedEventArgs e)
-            //{
-            //    MoveTabToNewWindow(newTab);
-            //}
-
             return newTab;
         }
 
@@ -265,7 +251,8 @@ namespace AppUIBasics.TabViewPages
 
         private void Tabs_AddTabButtonClick(TabView sender, object args)
         {
-            sender.TabItems.Add(new TabViewItem() { IconSource = new Microsoft.UI.Xaml.Controls.SymbolIconSource() { Symbol = Symbol.Placeholder }, Header = "New Item", Content = new MyTabContentControl() { DataContext = "New Item" } });
+            var tab = CreateNewTVI("New Item", "New Item");
+            sender.TabItems.Add(tab);
         }
 
         private void Tabs_TabCloseRequested(TabView sender, TabViewTabCloseRequestedEventArgs args)

--- a/WinUIGallery/TabViewPages/TabViewWindowingSamplePage.xaml.cs
+++ b/WinUIGallery/TabViewPages/TabViewWindowingSamplePage.xaml.cs
@@ -179,7 +179,7 @@ namespace AppUIBasics.TabViewPages
                         }
                     }
 
-                    // The TabView can only be in one tree at a time. Before moving it to the new TabView, remove it from the old.
+                    // The TabViewItem can only be in one tree at a time. Before moving it to the new TabView, remove it from the old.
                     // Note that this call can happen on a different thread if moving across windows. So make sure you call methods on
                     // the same thread as where the UI Elements were created.
 


### PR DESCRIPTION
Fix TabView multi window drag and drop sample. It was crashing before when trying to drag drop across windows because the code was not running on the appropriate thread. 