### PR TITLE
fix: typo in ListViewPage.xaml.cs

### DIFF
--- a/WinUIGallery/ControlPages/ListViewPage.xaml.cs
+++ b/WinUIGallery/ControlPages/ListViewPage.xaml.cs
@@ -155,7 +155,7 @@ namespace AppUIBasics.ControlPages
                     // Find the insertion index:
                     Windows.Foundation.Point pos = e.GetPosition(target.ItemsPanelRoot);
 
-                    // If the target ListView has items in it, use the heigh of the first item
+                    // If the target ListView has items in it, use the height of the first item
                     //      to find the insertion index.
                     int index = 0;
                     if (target.Items.Count != 0)


### PR DESCRIPTION
Thank you for WinUI-Gallery help, I was using it and found a typo and would like to send a PR.

## Description

`heigh => height` in `ListViewPage.xaml.cs`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
