### PR TITLE
Scroll viewer zoom to 2.0 on startup and rename control x:Name

### DIFF
--- a/WinUIGallery/ControlPages/ScrollViewerPage.xaml
+++ b/WinUIGallery/ControlPages/ScrollViewerPage.xaml
@@ -20,8 +20,8 @@
 
             <!-- There's a known issue with zooming where we get into a layout cycle if we specify a height but not a width.
                  As a workaround for now, set an explicit height/width to match the natural size of the image. -->
-            <ScrollViewer x:Name="Control1" Height="266" Width="400" ZoomMode="Enabled" IsTabStop="True" IsVerticalScrollChainingEnabled="True"
-                    ManipulationCompleted="Control1_ManipulationCompleted" VerticalAlignment="Top"
+            <ScrollViewer x:Name="ScrollViewerControl" Height="266" Width="400" ZoomMode="Enabled" IsTabStop="True" IsVerticalScrollChainingEnabled="True"
+                    ManipulationCompleted="ScrollViewerControl_ManipulationCompleted" VerticalAlignment="Top"
                     HorizontalAlignment="Left">
                 <Image Source="ms-appx:///Assets/SampleMedia/cliff.jpg" Stretch="None" HorizontalAlignment="Left"
                         VerticalAlignment="Top" AutomationProperties.Name="cliff"/>
@@ -52,8 +52,8 @@
                     </ComboBox>
 
                     <Slider Grid.Row="1" Grid.ColumnSpan="2" x:Name="ZoomSlider" Header="Zoom" IsEnabled="True"
-                        Maximum="{x:Bind Control1.MaxZoomFactor, Mode=OneWay}"
-                        Minimum="{x:Bind Control1.MinZoomFactor, Mode=OneWay}"
+                        Maximum="{x:Bind ScrollViewerControl.MaxZoomFactor, Mode=OneWay}"
+                        Minimum="{x:Bind ScrollViewerControl.MinZoomFactor, Mode=OneWay}"
                         Value="2"
                         Margin="0,10,0,0"
                         ValueChanged="ZoomSlider_ValueChanged" />
@@ -106,7 +106,7 @@
                 <x:String xml:space="preserve">
 &lt;ScrollViewer Height="270" ZoomMode="$(ZoomMode)"
             IsTabStop="True" IsVerticalScrollChainingEnabled="True"
-            ManipulationCompleted="Control1_ManipulationCompleted"
+            ManipulationCompleted="ScrollViewerControl_ManipulationCompleted"
             HorizontalScrollMode="$(HorizontalScrollMode)" HorizontalScrollBarVisibility="$(HorizontalScrollBarVisibility)"
             VerticalScrollMode="$(VerticalScrollMode)" VerticalScrollBarVisibility="$(VerticalScrollBarVisibility)"&gt;
     &lt;Image Source="ms-appx:///Assets/SampleMedia/cliff.jpg" AutomationProperties.Name="cliff" Stretch="None"

--- a/WinUIGallery/ControlPages/ScrollViewerPage.xaml.cs
+++ b/WinUIGallery/ControlPages/ScrollViewerPage.xaml.cs
@@ -19,28 +19,29 @@ namespace AppUIBasics.ControlPages
         public ScrollViewerPage()
         {
             this.InitializeComponent();
+            ScrollViewerControl.ZoomToFactor((float)2.0);
         }
 
         private void ZoomModeComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (Control1 != null && ZoomSlider != null)
+            if (ScrollViewerControl != null && ZoomSlider != null)
             {
                 if (sender is ComboBox cb)
                 {
                     switch (cb.SelectedIndex)
                     {
                         case 0: // Enabled
-                            Control1.ZoomMode = ZoomMode.Enabled;
+                            ScrollViewerControl.ZoomMode = ZoomMode.Enabled;
                             ZoomSlider.IsEnabled = true;
                             break;
                         case 1: // Disabled
-                            Control1.ZoomMode = ZoomMode.Disabled;
-                            Control1.ChangeView(null, null, (float)1.0);
+                            ScrollViewerControl.ZoomMode = ZoomMode.Disabled;
+                            ScrollViewerControl.ChangeView(null, null, (float)1.0);
                             ZoomSlider.Value = 1;
                             ZoomSlider.IsEnabled = false;
                             break;
                         default: // Enabled
-                            Control1.ZoomMode = ZoomMode.Enabled;
+                            ScrollViewerControl.ZoomMode = ZoomMode.Enabled;
                             ZoomSlider.IsEnabled = true;
                             break;
                     }
@@ -50,31 +51,31 @@ namespace AppUIBasics.ControlPages
 
         private void ZoomSlider_ValueChanged(object sender, RangeBaseValueChangedEventArgs e)
         {
-            if (Control1 != null)
+            if (ScrollViewerControl != null)
             {
-                Control1.ChangeView(null, null, (float)e.NewValue);
+                ScrollViewerControl.ChangeView(null, null, (float)e.NewValue);
             }
         }
 
         private void hsmCombo_SelectionChanged_1(object sender, SelectionChangedEventArgs e)
         {
-            if (Control1 != null)
+            if (ScrollViewerControl != null)
             {
                 if (sender is ComboBox cb)
                 {
                     switch (cb.SelectedIndex)
                     {
                         case 0: // Auto
-                            Control1.HorizontalScrollMode = ScrollMode.Auto;
+                            ScrollViewerControl.HorizontalScrollMode = ScrollMode.Auto;
                             break;
                         case 1: //Enabled
-                            Control1.HorizontalScrollMode = ScrollMode.Enabled;
+                            ScrollViewerControl.HorizontalScrollMode = ScrollMode.Enabled;
                             break;
                         case 2: // Disabled
-                            Control1.HorizontalScrollMode = ScrollMode.Disabled;
+                            ScrollViewerControl.HorizontalScrollMode = ScrollMode.Disabled;
                             break;
                         default:
-                            Control1.HorizontalScrollMode = ScrollMode.Enabled;
+                            ScrollViewerControl.HorizontalScrollMode = ScrollMode.Enabled;
                             break;
                     }
                 }
@@ -83,26 +84,26 @@ namespace AppUIBasics.ControlPages
 
         private void hsbvCombo_SelectionChanged_1(object sender, SelectionChangedEventArgs e)
         {
-            if (Control1 != null)
+            if (ScrollViewerControl != null)
             {
                 if (sender is ComboBox cb)
                 {
                     switch (cb.SelectedIndex)
                     {
                         case 0: // Auto
-                            Control1.HorizontalScrollBarVisibility = ScrollBarVisibility.Auto;
+                            ScrollViewerControl.HorizontalScrollBarVisibility = ScrollBarVisibility.Auto;
                             break;
                         case 1: //Visible
-                            Control1.HorizontalScrollBarVisibility = ScrollBarVisibility.Visible;
+                            ScrollViewerControl.HorizontalScrollBarVisibility = ScrollBarVisibility.Visible;
                             break;
                         case 2: // Hidden
-                            Control1.HorizontalScrollBarVisibility = ScrollBarVisibility.Hidden;
+                            ScrollViewerControl.HorizontalScrollBarVisibility = ScrollBarVisibility.Hidden;
                             break;
                         case 3: // Disabled
-                            Control1.HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled;
+                            ScrollViewerControl.HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled;
                             break;
                         default:
-                            Control1.HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled;
+                            ScrollViewerControl.HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled;
                             break;
                     }
                 }
@@ -111,23 +112,23 @@ namespace AppUIBasics.ControlPages
 
         private void vsmCombo_SelectionChanged_1(object sender, SelectionChangedEventArgs e)
         {
-            if (Control1 != null)
+            if (ScrollViewerControl != null)
             {
                 if (sender is ComboBox cb)
                 {
                     switch (cb.SelectedIndex)
                     {
                         case 0: // Auto
-                            Control1.VerticalScrollMode = ScrollMode.Auto;
+                            ScrollViewerControl.VerticalScrollMode = ScrollMode.Auto;
                             break;
                         case 1: //Enabled
-                            Control1.VerticalScrollMode = ScrollMode.Enabled;
+                            ScrollViewerControl.VerticalScrollMode = ScrollMode.Enabled;
                             break;
                         case 2: // Disabled
-                            Control1.VerticalScrollMode = ScrollMode.Disabled;
+                            ScrollViewerControl.VerticalScrollMode = ScrollMode.Disabled;
                             break;
                         default:
-                            Control1.VerticalScrollMode = ScrollMode.Enabled;
+                            ScrollViewerControl.VerticalScrollMode = ScrollMode.Enabled;
                             break;
                     }
                 }
@@ -136,26 +137,26 @@ namespace AppUIBasics.ControlPages
 
         private void vsbvCombo_SelectionChanged_1(object sender, SelectionChangedEventArgs e)
         {
-            if (Control1 != null)
+            if (ScrollViewerControl != null)
             {
                 if (sender is ComboBox cb)
                 {
                     switch (cb.SelectedIndex)
                     {
                         case 0: // Auto
-                            Control1.VerticalScrollBarVisibility = ScrollBarVisibility.Auto;
+                            ScrollViewerControl.VerticalScrollBarVisibility = ScrollBarVisibility.Auto;
                             break;
                         case 1: //Visible
-                            Control1.VerticalScrollBarVisibility = ScrollBarVisibility.Visible;
+                            ScrollViewerControl.VerticalScrollBarVisibility = ScrollBarVisibility.Visible;
                             break;
                         case 2: // Hidden
-                            Control1.VerticalScrollBarVisibility = ScrollBarVisibility.Hidden;
+                            ScrollViewerControl.VerticalScrollBarVisibility = ScrollBarVisibility.Hidden;
                             break;
                         case 3: // Disabled
-                            Control1.VerticalScrollBarVisibility = ScrollBarVisibility.Disabled;
+                            ScrollViewerControl.VerticalScrollBarVisibility = ScrollBarVisibility.Disabled;
                             break;
                         default:
-                            Control1.VerticalScrollBarVisibility = ScrollBarVisibility.Visible;
+                            ScrollViewerControl.VerticalScrollBarVisibility = ScrollBarVisibility.Visible;
                             break;
                     }
                 }
@@ -164,25 +165,25 @@ namespace AppUIBasics.ControlPages
 
         private void Page_SizeChanged(object sender, SizeChangedEventArgs e)
         {
-            if (Grid.GetColumnSpan(Control1) == 1)
+            if (Grid.GetColumnSpan(ScrollViewerControl) == 1)
             {
-                Control1.Width = (e.NewSize.Width / 2) - 50;
+                ScrollViewerControl.Width = (e.NewSize.Width / 2) - 50;
             }
             else
             {
-                Control1.Width = e.NewSize.Width - 50;
+                ScrollViewerControl.Width = e.NewSize.Width - 50;
             }
 
         }
 
-        private void Control1_ViewChanged(object sender, ScrollViewerViewChangedEventArgs e)
+        private void ScrollViewerControl_ViewChanged(object sender, ScrollViewerViewChangedEventArgs e)
         {
-            ZoomSlider.Value = Control1.ZoomFactor;
+            ZoomSlider.Value = ScrollViewerControl.ZoomFactor;
         }
 
-        private void Control1_ManipulationCompleted(object sender, ManipulationCompletedRoutedEventArgs e)
+        private void ScrollViewerControl_ManipulationCompleted(object sender, ManipulationCompletedRoutedEventArgs e)
         {
-            ZoomSlider.Value = Control1.ZoomFactor;
+            ZoomSlider.Value = ScrollViewerControl.ZoomFactor;
         }
     }
 }


### PR DESCRIPTION
## Description
Updated the scroll viewer starting zoom to be 2.0 so when users select the control it is more clear what the scroll viewer does. Also renamed the x:name for the scrollviewer form `Control1` to `ScrollViewerControl` to make the name more meaningful.

## Motivation and Context
This is a PR to fix issue #121. I picked this because it was the only issue marked as `good first issue` and was a relatively easy fix.

## How Has This Been Tested?
I believe this issue is isolated to the scroll viewer page. If there are tests that need updated I can do this.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
