### PR TITLE
Add a custom showmode example in flyout page

### DIFF
--- a/WinUIGallery/ControlPages/FlyoutPage.xaml
+++ b/WinUIGallery/ControlPages/FlyoutPage.xaml
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
 //*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
@@ -49,6 +49,42 @@
 &lt;/Button&gt;
                 </x:String>
             </local:ControlExample.Xaml>
+        </local:ControlExample>
+
+        <local:ControlExample HeaderText="Flyout with different ShowMode">
+            <local:ControlExample.Example>
+                <Button Content="Click for flyout">
+                    <Button.Flyout>
+                        <Flyout x:Name="CustomFlyout" ShowMode="{x:Bind ShowMode, Mode=OneWay}">
+                            <TextBlock Text="This is a flyout"/>
+                        </Flyout>
+                    </Button.Flyout>
+                </Button>
+            </local:ControlExample.Example>
+
+            <local:ControlExample.Options>
+                <ComboBox x:Name="FlyoutShowModeBox" Header="ShowMode" SelectedIndex="0" SelectionChanged="FlyoutShowModeBox_SelectionChanged">
+                    <x:String>Auto</x:String>
+                    <x:String>Standard</x:String>
+                    <x:String>Transient</x:String>
+                    <x:String>TransientWithDismissOnPointerMoveAway</x:String>
+                </ComboBox>
+            </local:ControlExample.Options>
+
+            <local:ControlExample.Xaml>
+                <x:String xml:space="preserve">
+&lt;Button Content="Click for flyout"&gt;
+    &lt;Button.Flyout&gt;
+        &lt;Flyout ShowMode="$(ShowMode)"&gt;
+            &lt;TextBlock Text="This is a flyout" /&gt;
+        &lt;/Flyout&gt;
+    &lt;/Button.Flyout&gt;
+&lt;/Button&gt;
+                </x:String>
+            </local:ControlExample.Xaml>
+            <local:ControlExample.Substitutions>
+                <local:ControlExampleSubstitution Key="ShowMode" Value="{x:Bind CustomFlyout.ShowMode, Mode=OneWay}"/>
+            </local:ControlExample.Substitutions>
         </local:ControlExample>
     </StackPanel>
 </Page>

--- a/WinUIGallery/ControlPages/FlyoutPage.xaml.cs
+++ b/WinUIGallery/ControlPages/FlyoutPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿//*********************************************************
+//*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
 // THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
@@ -27,6 +27,30 @@ namespace AppUIBasics.ControlPages
             {
                 f.Hide();
             }
+        }
+
+        private FlyoutShowMode _showMode = FlyoutShowMode.Auto;
+        public FlyoutShowMode ShowMode
+        {
+            get => _showMode;
+            set
+            {
+                CustomFlyout.ShowMode = value;
+                _showMode = value;
+            }
+        }
+
+        private void FlyoutShowModeBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            switch (e.AddedItems[0].ToString())
+            {
+                case "Auto": ShowMode = FlyoutShowMode.Auto; break;
+                case "Standard": ShowMode = FlyoutShowMode.Standard; break;
+                case "Transient": ShowMode = FlyoutShowMode.Transient; break;
+                default: ShowMode = FlyoutShowMode.TransientWithDismissOnPointerMoveAway;
+                    break;
+            }
+
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As title.

## Motivation and Context
Found something not working about changing the flyout mode in the current version of winui, so I added this example and confirmed it.
The [issue here](https://github.com/microsoft/microsoft-ui-xaml/issues/7987)

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/42881734/205444921-2b51f446-9b4a-4ca2-aaed-4a8070c2d3c2.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
