### PR TITLE
fix keyboarding in radial gradient page

### DIFF
--- a/WinUIGallery/ControlPages/RadialGradientBrushPage.xaml.cs
+++ b/WinUIGallery/ControlPages/RadialGradientBrushPage.xaml.cs
@@ -52,7 +52,8 @@ namespace AppUIBasics.ControlPages
                 CenterYSlider.Value = RadiusYSlider.Value = OriginYSlider.Value = rectSize.Width / 2;
                 CenterXSlider.StepFrequency = RadiusXSlider.StepFrequency = OriginXSlider.StepFrequency = rectSize.Width / 50;
                 CenterYSlider.StepFrequency = RadiusYSlider.StepFrequency = OriginYSlider.StepFrequency = rectSize.Height / 50;
-                CenterXSlider.SmallChange = RadiusYSlider.SmallChange = OriginYSlider.SmallChange = 10;
+                CenterXSlider.SmallChange = RadiusXSlider.SmallChange = OriginXSlider.SmallChange = 10;
+                CenterYSlider.SmallChange = RadiusYSlider.SmallChange = OriginYSlider.SmallChange = 10;
             }
             else
             {

--- a/WinUIGallery/ControlPages/RadialGradientBrushPage.xaml.cs
+++ b/WinUIGallery/ControlPages/RadialGradientBrushPage.xaml.cs
@@ -50,8 +50,9 @@ namespace AppUIBasics.ControlPages
                 CenterYSlider.Maximum = RadiusYSlider.Maximum = OriginYSlider.Maximum = rectSize.Width;
                 CenterXSlider.Value = RadiusXSlider.Value = OriginXSlider.Value = rectSize.Width / 2;
                 CenterYSlider.Value = RadiusYSlider.Value = OriginYSlider.Value = rectSize.Width / 2;
-                CenterXSlider.StepFrequency = RadiusXSlider.StepFrequency = OriginXSlider.StepFrequency = rectSize.Width/50;
-                CenterYSlider.StepFrequency = RadiusYSlider.StepFrequency = OriginYSlider.StepFrequency = rectSize.Height/50;
+                CenterXSlider.StepFrequency = RadiusXSlider.StepFrequency = OriginXSlider.StepFrequency = rectSize.Width / 50;
+                CenterYSlider.StepFrequency = RadiusYSlider.StepFrequency = OriginYSlider.StepFrequency = rectSize.Height / 50;
+                CenterXSlider.SmallChange = RadiusYSlider.SmallChange = OriginYSlider.SmallChange = 10;
             }
             else
             {


### PR DESCRIPTION
Keyboard arrow on radial gradient brush page looks broken because the steps are too small. 