### PR TITLE
Fix RadialGradientBrush keyboard behavior

### DIFF
--- a/WinUIGallery/ControlPages/RadialGradientBrushPage.xaml.cs
+++ b/WinUIGallery/ControlPages/RadialGradientBrushPage.xaml.cs
@@ -63,6 +63,8 @@ namespace AppUIBasics.ControlPages
                 CenterYSlider.Value = RadiusYSlider.Value = OriginYSlider.Value = 0.5;
                 CenterXSlider.StepFrequency = RadiusXSlider.StepFrequency = OriginXSlider.StepFrequency = 0.02;
                 CenterYSlider.StepFrequency = RadiusYSlider.StepFrequency = OriginYSlider.StepFrequency = 0.02;
+                CenterXSlider.SmallChange = RadiusXSlider.SmallChange = OriginXSlider.SmallChange = 0.05;
+                CenterYSlider.SmallChange = RadiusYSlider.SmallChange = OriginYSlider.SmallChange = 0.05;
             }
         }
 


### PR DESCRIPTION
With #1168, the keyboard behavior was fixed for absolute mapping mode, however switching back to RelativeToBoundingBox now left that keyboard behavior in a broken state.