### PR TITLE
Replace ProjectReunion version variables with WindowsAppSdk ones

### DIFF
--- a/WinUIGallery/Directory.Build.props
+++ b/WinUIGallery/Directory.Build.props
@@ -1,4 +1,5 @@
-<Project>
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- We have two projects in the same directory here, so we'll add a differentiator folder to output directories. -->
     <GenerateProjectSpecificOutputFolder>true</GenerateProjectSpecificOutputFolder>
@@ -26,5 +27,6 @@
   </PropertyGroup>
     
   <!-- If we aren't building in the WinUI repo, import the necessary missing props we'd normally pick up from its Directory.Build.props hierarchy -->
-  <Import Project="Standalone.props" Condition="'$(IsInWinUIRepo)' != 'true'"/>
+  <!-- The UseStandalone property allows this to be overridden, in order to buildReleaseSamples to build without changing the entire repo -->
+  <Import Project="Standalone.props" Condition="'$(IsInWinUIRepo)' != 'true' OR '$(UseStandalone)' == 'true'"/>
 </Project>

--- a/WinUIGallery/Directory.Build.targets
+++ b/WinUIGallery/Directory.Build.targets
@@ -1,4 +1,5 @@
-<Project>
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" Condition="Exists($([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../')))"/>
   <PropertyGroup Condition="'$(WindowsPackageType)' == 'MSIX'">
     <!-- These are set in Directory.Build.targets because we need to import the publish profile first -->

--- a/WinUIGallery/WinUIGallery.DesktopWap.Package.wapproj
+++ b/WinUIGallery/WinUIGallery.DesktopWap.Package.wapproj
@@ -90,8 +90,8 @@
       <PublishProfile>Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfile>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup Condition="'$(ProjectReunionPackageVersion)' != ''">
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="[$(ProjectReunionPackageVersion)]" GeneratePathProperty="true">
+  <ItemGroup Condition="'$(WindowsAppSdkPackageVersion)' != ''">
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="[$(WindowsAppSdkPackageVersion)]" GeneratePathProperty="true">
       <IncludeAssets>build</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="[$(MicrosoftWindowsSDKBuildToolsNugetPackageVersion)]">

--- a/WinUIGallery/WinUIGallery.DesktopWap.csproj
+++ b/WinUIGallery/WinUIGallery.DesktopWap.csproj
@@ -52,14 +52,14 @@
     <PackageReference Update="System.Private.Uri" Version="4.3.2" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(ProjectReunionPackageVersion)' != ''">
+  <ItemGroup Condition="'$(WindowsAppSdkPackageVersion)' != ''">
     <PackageReference Remove="Microsoft.WinUI" />
     <PackageReference Remove="Microsoft.ProjectReunion.InteractiveExperiences.TransportPackage" />
     <PackageReference Include="Microsoft.WindowsAppSDK" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsInWinUIRepo)' != 'true'">
-    <PackageReference Update="Microsoft.WindowsAppSDK" Version="$(ProjectReunionPackageVersion)" Condition="'$(ProjectReunionPackageVersion)' != ''" />
+    <PackageReference Update="Microsoft.WindowsAppSDK" Version="$(WindowsAppSdkPackageVersion)" Condition="'$(WindowsAppSdkPackageVersion)' != ''" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WinUIGallery/standalone.props
+++ b/WinUIGallery/standalone.props
@@ -1,8 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- The NuGet versions of dependencies to build against. -->
-    <ProjectReunionPackageVersion>1.2.221209.1</ProjectReunionPackageVersion>
-    <ProjectReunionWinUIPackageVersion>1.2.221209.1</ProjectReunionWinUIPackageVersion>
+    <WindowsAppSdkPackageVersion>1.2.221109.1</WindowsAppSdkPackageVersion>
     <SamplesTargetFrameworkMoniker>net6.0-windows10.0.18362.0</SamplesTargetFrameworkMoniker>
     <MicrosoftNETCoreUniversalWindowsPlatformVersion>6.2.11</MicrosoftNETCoreUniversalWindowsPlatformVersion>
     <GraphicsWin2DVersion>1.0.4</GraphicsWin2DVersion>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change retires the ProjectReunionPackageVersion and ProjectReunionWinUIPackageVersion variables that date back to the early days of the project.  The variable WindowsAppSdkPackageVersion is more correct and intuitive.

## Motivation and Context
One less special case to remember
