### PR TITLE
Accessibility fixes from internal repo

### DIFF
--- a/WinUIGallery/ControlPages/AutomationPropertiesPage.xaml
+++ b/WinUIGallery/ControlPages/AutomationPropertiesPage.xaml
@@ -45,7 +45,8 @@
                         Laborum pariatur nemo for veritatis yet explicabo eaque or esse. Ipsum ullam omnis so sed nequeporro but magna.</TextBlock>
                     <StackPanel Orientation="Horizontal">
                         <TextBlock x:Name="FontSizeLabel" VerticalAlignment="Center" FontSize="16" Margin="0,0,8,0" Text="Font size of text"/>
-                        <NumberBox x:Name="FontSizeNumberBox" Minimum="10" Maximum="32" Value="14" ValueChanged="FontSizeNumberBox_ValueChanged"/>
+                        <NumberBox x:Name="FontSizeNumberBox" AutomationProperties.LabeledBy="{x:Bind FontSizeLabel}"
+                                   Minimum="10" Maximum="32" Value="14" ValueChanged="FontSizeNumberBox_ValueChanged"/>
                     </StackPanel>
                 </StackPanel>
             </local:ControlExample.Example>

--- a/WinUIGallery/NewControlsPage.xaml
+++ b/WinUIGallery/NewControlsPage.xaml
@@ -127,7 +127,7 @@
                 <GroupStyle>
                     <GroupStyle.HeaderTemplate>
                         <DataTemplate x:DataType="local:GroupInfoList">
-                            <TextBlock x:Name="pageSubtitle" Text="{x:Bind Title}" Foreground="{ThemeResource ApplicationForegroundThemeBrush}" Style="{StaticResource SubtitleTextBlockStyle}"  Margin="4,32,0,0"/>
+                            <TextBlock x:Name="pageSubtitle" Text="{x:Bind Title}" Foreground="{ThemeResource ApplicationForegroundThemeBrush}" Style="{StaticResource SubtitleTextBlockStyle}"  Margin="4,32,0,0" AutomationProperties.HeadingLevel="Level1"/>
                         </DataTemplate>
                     </GroupStyle.HeaderTemplate>
                 </GroupStyle>

--- a/WinUIGallery/SamplePages/SampleSystemBackdropsWindow.xaml
+++ b/WinUIGallery/SamplePages/SampleSystemBackdropsWindow.xaml
@@ -12,7 +12,7 @@
                 <TextBlock Text="Current backdrop: " />
                 <TextBlock x:Name="tbCurrentBackdrop" />
             </StackPanel>
-            <Button x:Name="btnChangeBackdrop" AutomationProperties.Name="ChangeBackdropButton" Content="Change Backdrop" Click="ChangeBackdropButton_Click" />
+            <Button x:Name="btnChangeBackdrop" Content="Change Backdrop" Click="ChangeBackdropButton_Click" />
             <TextBlock x:Name="tbChangeStatus" />
         </StackPanel>
     </StackPanel>

--- a/WinUIGallery/SettingsPage.xaml
+++ b/WinUIGallery/SettingsPage.xaml
@@ -39,11 +39,11 @@
                     Style="{StaticResource SubtitleTextBlockStyle}"
                     Margin="0,12,0,0"
                     Text="Theme Mode" />
-                <StackPanel x:Name="ThemePanel" Margin="0,10,0,0">
-                    <RadioButton Tag="Light" Checked="OnThemeRadioButtonChecked" Content="Light" KeyDown="OnThemeRadioButtonKeyDown" />
-                    <RadioButton Tag="Dark" Checked="OnThemeRadioButtonChecked" Content="Dark" />
-                    <RadioButton Tag="Default" Checked="OnThemeRadioButtonChecked" Content="Use system setting" />
-                </StackPanel>
+                <RadioButtons x:Name="themeMode" Header="Application theme mode" Margin="0,10,0,0" SelectionChanged="themeMode_SelectionChanged">
+                    <RadioButton Tag="Light" Content="Light" />
+                    <RadioButton Tag="Dark" Content="Dark" />
+                    <RadioButton Tag="Default" Content="Use system setting" />
+                </RadioButtons>
                 
                 <TextBlock
                     Style="{StaticResource SubtitleTextBlockStyle}"

--- a/WinUIGallery/SettingsPage.xaml.cs
+++ b/WinUIGallery/SettingsPage.xaml.cs
@@ -65,8 +65,19 @@ namespace AppUIBasics
 
         private void OnSettingsPageLoaded(object sender, RoutedEventArgs e)
         {
-            var currentTheme = ThemeHelper.RootTheme.ToString();
-            (ThemePanel.Children.Cast<RadioButton>().FirstOrDefault(c => c?.Tag?.ToString() == currentTheme)).IsChecked = true;
+            var currentTheme = ThemeHelper.RootTheme;
+            switch (currentTheme)
+            {
+                case ElementTheme.Light:
+                    themeMode.SelectedIndex = 0;
+                    break;
+                case ElementTheme.Dark:
+                    themeMode.SelectedIndex = 1;
+                    break;
+                case ElementTheme.Default:
+                    themeMode.SelectedIndex = 2;
+                    break;
+            }
 
             NavigationRootPage navigationRootPage = NavigationRootPage.GetForElement(this);
             if (navigationRootPage != null)
@@ -82,9 +93,9 @@ namespace AppUIBasics
             }
         }
 
-        private void OnThemeRadioButtonChecked(object sender, RoutedEventArgs e)
+        private void themeMode_SelectionChanged(object sender, RoutedEventArgs e)
         {
-            var selectedTheme = ((RadioButton)sender)?.Tag?.ToString();
+            var selectedTheme = ((RadioButton)themeMode.SelectedItem)?.Tag?.ToString();
             var res = Microsoft.UI.Xaml.Application.Current.Resources;
             Action<Windows.UI.Color> SetTitleBarButtonForegroundColor = (Windows.UI.Color color) => { res["WindowCaptionForeground"] = color; };
 
@@ -116,13 +127,6 @@ namespace AppUIBasics
 
         }
 
-        private void OnThemeRadioButtonKeyDown(object sender, KeyRoutedEventArgs e)
-        {
-            if (e.Key == VirtualKey.Up)
-            {
-                NavigationRootPage.GetForElement(this).PageHeader.Focus(FocusState.Programmatic);
-            }
-        }
         private void spatialSoundBox_Checked(object sender, RoutedEventArgs e)
         {
             if (soundToggle.IsOn == true)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes the following:

Changes Theme on the settings page to use radiobuttons
Removes Automation Name from System Backdrops field so Narrator will use Content
Restores LabeledBy in actual Xaml that was still present in sample text
Adds Level to NewControls Groups

