### PR TITLE
Fix double navigation when selecting search result item.

### DIFF
--- a/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
@@ -34,6 +34,7 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
 using WinUIGallery.DesktopWap;
 using AppUIBasics.ControlPages;
+using System.Threading.Channels;
 
 namespace AppUIBasics
 {
@@ -448,11 +449,11 @@ namespace AppUIBasics
             if (args.ChosenSuggestion != null && args.ChosenSuggestion is ControlInfoDataItem)
             {
                 var infoDataItem = args.ChosenSuggestion as ControlInfoDataItem;
-                var isSelectionChanged = EnsureItemIsVisibleInNavigation(infoDataItem.Title);
+                var hasChangedSelection = EnsureItemIsVisibleInNavigation(infoDataItem.Title);
 
-                // In case the menu selecion change, it has trigger the
-                // selecion changed event that will navigate to the page already
-                if (!isSelectionChanged)
+                // In case the menu has selection change, it menas it has trigger
+                // the selection changed event that will navigate to the page already
+                if (!hasChangedSelection)
                 {
                     Navigate(typeof(ItemPage), infoDataItem.UniqueId);
                 }

--- a/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
@@ -450,8 +450,8 @@ namespace AppUIBasics
                 var infoDataItem = args.ChosenSuggestion as ControlInfoDataItem;
                 var hasChangedSelection = EnsureItemIsVisibleInNavigation(infoDataItem.Title);
 
-                // In case the menu has selection change, it menas it has trigger
-                // the selection changed event that will navigate to the page already
+                // In case the menu selection has changed, it means that it has triggered
+                // the selection changed event, that will navigate to the page already
                 if (!hasChangedSelection)
                 {
                     Navigate(typeof(ItemPage), infoDataItem.UniqueId);

--- a/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
@@ -34,7 +34,6 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
 using WinUIGallery.DesktopWap;
 using AppUIBasics.ControlPages;
-using System.Threading.Channels;
 
 namespace AppUIBasics
 {

--- a/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
@@ -159,6 +159,8 @@ namespace AppUIBasics
             object targetPageArguments = null,
             Microsoft.UI.Xaml.Media.Animation.NavigationTransitionInfo navigationTransitionInfo = null)
         {
+            // Close any open teaching tips before navigation
+            CloseTeachingTips();
             NavigationRootPageArgs args = new NavigationRootPageArgs();
             args.NavigationRootPage = this;
             args.Parameter = targetPageArguments;
@@ -297,9 +299,6 @@ namespace AppUIBasics
 
         private void OnNavigationViewSelectionChanged(Microsoft.UI.Xaml.Controls.NavigationView sender, Microsoft.UI.Xaml.Controls.NavigationViewSelectionChangedEventArgs args)
         {
-            // Close any open teaching tips before navigation
-            CloseTeachingTips();
-
             if (args.IsSettingsSelected)
             {
                 if (rootFrame.CurrentSourcePageType != typeof(SettingsPage))
@@ -332,7 +331,7 @@ namespace AppUIBasics
                 {
                     Navigate(typeof(ItemPage), "Typography");
                 }
-                else if(selectedItem == ColorsItem)
+                else if (selectedItem == ColorsItem)
                 {
                     Navigate(typeof(ItemPage), "Colors");
                 }
@@ -449,9 +448,14 @@ namespace AppUIBasics
             if (args.ChosenSuggestion != null && args.ChosenSuggestion is ControlInfoDataItem)
             {
                 var infoDataItem = args.ChosenSuggestion as ControlInfoDataItem;
-                var itemId = infoDataItem.UniqueId;
-                EnsureItemIsVisibleInNavigation(infoDataItem.Title);
-                Navigate(typeof(ItemPage), itemId);
+                var isSelectionChanged = EnsureItemIsVisibleInNavigation(infoDataItem.Title);
+
+                // In case the menu selecion change, it has trigger the
+                // selecion changed event that will navigate to the page already
+                if (!isSelectionChanged)
+                {
+                    Navigate(typeof(ItemPage), infoDataItem.UniqueId);
+                }
             }
             else if (!string.IsNullOrEmpty(args.QueryText))
             {
@@ -459,7 +463,7 @@ namespace AppUIBasics
             }
         }
 
-        public void EnsureItemIsVisibleInNavigation(string name)
+        public bool EnsureItemIsVisibleInNavigation(string name)
         {
             bool changedSelection = false;
             foreach (object rawItem in NavigationView.MenuItems)
@@ -523,6 +527,7 @@ namespace AppUIBasics
                     break;
                 }
             }
+            return changedSelection;
         }
 
         private void UpdateAppTitleMargin(Microsoft.UI.Xaml.Controls.NavigationView sender)
@@ -628,9 +633,9 @@ namespace AppUIBasics
                 dispatcherQueue.TryEnqueue(
                     DispatcherQueuePriority.Low,
                     new DispatcherQueueHandler(() =>
-                {
-                    DebuggerAttachedCheckBox.IsChecked = true;
-                }));
+                    {
+                        DebuggerAttachedCheckBox.IsChecked = true;
+                    }));
             });
 
             var asyncAction = Windows.System.Threading.ThreadPool.RunAsync(workItem);


### PR DESCRIPTION
Fix double navigation

## Description

When a result item is selected, a method called `EnsureItemIsVisibleInNavigation` updates the selected item on the menu.

This triggers the `OnNavigationViewSelectionChanged` method, that navigates to the corresponding view.

But right after that, the navigation is called, causing it to navigate again.

https://github.com/microsoft/WinUI-Gallery/blob/2bf63f0697d3684ded6e66d4e48dfe68c3e8ba36/WinUIGallery/Navigation/NavigationRootPage.xaml.cs#L453-L454

## Motivation and Context
This may be related to the issue https://github.com/microsoft/WinUI-Gallery/issues/972

## How Has This Been Tested?
After the change, the app navigates only once to the view.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
