### PR TITLE
#1130 Corrected source code comments displayed to user

### DIFF
--- a/WinUIGallery/ControlPages/GridViewPage.xaml
+++ b/WinUIGallery/ControlPages/GridViewPage.xaml
@@ -171,8 +171,8 @@ some parts of the GridViewItems (i.e. the margins). --&gt;
     &lt;/GridView.ItemsPanel&gt;                  
 &lt;/GridView&gt;      
                     
-&lt;!-- In this example, the ListView's ItemTemplate property is bound to a data template (shown below)
-called StyledGridTemplate, defined in the Page.Resources section of the XAML file. 
+&lt;!-- In this example, the GridView's ItemTemplate property is bound to a data template (shown below)
+called ImageOverlayTemplate, defined in the Page.Resources section of the XAML file. 
                     
 The data template is defined to display a CustomDataObject object (same type as in above sample). --&gt;
                     


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changed ListView to GridView and changed the template name to ImageOverlayTemplate.

## Description
<!--- Describe your changes in detail -->
On the GridView control page in the second "GridView with Layout Customization" example, within the comments of the psuedo XAML code I changed the erroneous reference to "ListView" to the correct reference of "GridView" and corrected the template name to "ImageOverlayTemplate".

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This resolves issue #1130 
The incorrect comment that existed previously would be confusing to a user attempting to follow the provided psuedo source code.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran the corrected version of WinUI Gallery on my local computer and the comment is now displaying correctly.  See screen shot below.

## Screenshots (if appropriate):
![Changes](https://user-images.githubusercontent.com/78389339/222400083-6ba7149f-1afc-4884-ac27-0a24dac8cf02.jpg)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
