### PR TITLE
#1202 Restore Viewbox control to the gallery

### DIFF
--- a/WinUIGallery/ContentIncludes.props
+++ b/WinUIGallery/ContentIncludes.props
@@ -95,7 +95,7 @@
     <Content Include="Assets\ControlIcons\ToggleSwitchIcon.png" />
     <Content Include="Assets\ControlIcons\ToolTipIcon.png" />
     <Content Include="Assets\ControlIcons\VariableSizedWrapGridIcon.png" />
-    <Content Include="Assets\ControlIcons\ViewBoxIcon.png" />
+    <Content Include="Assets\ControlIcons\ViewboxIcon.png" />
     <Content Include="Assets\ControlIcons\NumberBoxIcon.png" />
 
     <Content Include="Assets\ControlImages\Acrylic.png" />
@@ -193,7 +193,7 @@
     <Content Include="Assets\ControlImages\ToolTip.png" />
     <Content Include="Assets\ControlImages\TreeView.png" />
     <Content Include="Assets\ControlImages\VariableSizedWrapGrid.png" />
-    <Content Include="Assets\ControlImages\ViewBox.png" />
+    <Content Include="Assets\ControlImages\Viewbox.png" />
     <Content Include="Assets\ControlImages\WebView.png" />
     <Content Include="Assets\ControlImages\XamlUICommand.png" />
     <Content Include="Assets\HomeHeaderTiles\gettingStarted.png" />

--- a/WinUIGallery/ControlPages/ViewBoxPage.xaml
+++ b/WinUIGallery/ControlPages/ViewBoxPage.xaml
@@ -9,7 +9,7 @@
 //
 //*********************************************************
 -->
-<Page x:Class="AppUIBasics.ControlPages.ViewBoxPage"
+<Page x:Class="AppUIBasics.ControlPages.ViewboxPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:AppUIBasics"

--- a/WinUIGallery/ControlPages/ViewBoxPage.xaml.cs
+++ b/WinUIGallery/ControlPages/ViewBoxPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿//*********************************************************
+//*********************************************************
 //
 // Copyright (c) Microsoft. All rights reserved.
 // THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
@@ -13,9 +13,9 @@ using Microsoft.UI.Xaml.Media;
 
 namespace AppUIBasics.ControlPages
 {
-    public sealed partial class ViewBoxPage : Page
+    public sealed partial class ViewboxPage : Page
     {
-        public ViewBoxPage()
+        public ViewboxPage()
         {
             this.InitializeComponent();
         }

--- a/WinUIGallery/DataModel/ControlInfoData.json
+++ b/WinUIGallery/DataModel/ControlInfoData.json
@@ -1881,9 +1881,9 @@
           "ApiNamespace": "Microsoft.UI.Xaml.Controls",
           "Subtitle": "A container control that scales its content to a specified size.",
           "ImagePath": "ms-appx:///Assets/ControlImages/Viewbox.png",
-          "ImageIconPath": "ms-appx:///Assets/ControlIcons/ViewBoxIcon.png",
+          "ImageIconPath": "ms-appx:///Assets/ControlIcons/ViewboxIcon.png",
           "Description": "Use a Viewbox control scale content up or down to a specified size.",
-          "Content": "<p>Look at the <i>ViewBoxPage.xaml</i> file in Visual Studio to see the full code for this page.</p>",
+          "Content": "<p>Look at the <i>ViewboxPage.xaml</i> file in Visual Studio to see the full code for this page.</p>",
           "IsNew": false,
           "IsUpdated": false,
           "Docs": [

--- a/WinUIGallery/WinUIGallery.DesktopWap.csproj
+++ b/WinUIGallery/WinUIGallery.DesktopWap.csproj
@@ -44,12 +44,12 @@
   </ItemGroup>
   <ItemGroup Condition="'$(IsInWinUIRepo)' != 'true'">
     <PackageReference Remove="ColorCode.Core" />
-    <PackageReference Include="ColorCode.WinUI" Version="2.0.14" />
+    <PackageReference Include="ColorCode.WinUI" Version="$(ColorCodeVersion)" />
     <PackageReference Update="Microsoft.Graphics.Win2D" Version="$(GraphicsWin2DVersion)" />
     <PackageReference Update="Microsoft.VCRTForwarders.140" Version="1.0.6" />
     <PackageReference Update="Microsoft.WinUI" Version="$(WinUIPackageVersion)" Condition="'$(WinUIPackageVersion)' != ''" />
     <!-- Get latest WinRT.Runtime.dll from C#/WinRT -->
-    <PackageReference Update="Microsoft.Windows.CsWinRT" Version="2.0.1" />
+    <PackageReference Update="Microsoft.Windows.CsWinRT" Version="$(MicrosoftCsWinRTPackageVersion)" />
     <PackageReference Update="System.Private.Uri" Version="4.3.2" />
   </ItemGroup>
 
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsInWinUIRepo)' != 'true'">
-    <PackageReference Update="Microsoft.WindowsAppSDK" Version="1.2.230217.4" Condition="'$(WindowsAppSdkPackageVersion)' != ''" />
+    <PackageReference Update="Microsoft.WindowsAppSDK" Version="$(WindowsAppSdkPackageVersion)" Condition="'$(WindowsAppSdkPackageVersion)' != ''" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WinUIGallery/WinUIGallery.DesktopWap.csproj
+++ b/WinUIGallery/WinUIGallery.DesktopWap.csproj
@@ -44,12 +44,12 @@
   </ItemGroup>
   <ItemGroup Condition="'$(IsInWinUIRepo)' != 'true'">
     <PackageReference Remove="ColorCode.Core" />
-    <PackageReference Include="ColorCode.WinUI" Version="$(ColorCodeVersion)" />
+    <PackageReference Include="ColorCode.WinUI" Version="2.0.14" />
     <PackageReference Update="Microsoft.Graphics.Win2D" Version="$(GraphicsWin2DVersion)" />
     <PackageReference Update="Microsoft.VCRTForwarders.140" Version="1.0.6" />
     <PackageReference Update="Microsoft.WinUI" Version="$(WinUIPackageVersion)" Condition="'$(WinUIPackageVersion)' != ''" />
     <!-- Get latest WinRT.Runtime.dll from C#/WinRT -->
-    <PackageReference Update="Microsoft.Windows.CsWinRT" Version="$(MicrosoftCsWinRTPackageVersion)" />
+    <PackageReference Update="Microsoft.Windows.CsWinRT" Version="2.0.1" />
     <PackageReference Update="System.Private.Uri" Version="4.3.2" />
   </ItemGroup>
 
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsInWinUIRepo)' != 'true'">
-    <PackageReference Update="Microsoft.WindowsAppSDK" Version="$(WindowsAppSdkPackageVersion)" Condition="'$(WindowsAppSdkPackageVersion)' != ''" />
+    <PackageReference Update="Microsoft.WindowsAppSDK" Version="1.2.230217.4" Condition="'$(WindowsAppSdkPackageVersion)' != ''" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Corrected "ViewBoxPage" name to "ViewboxPage" to re-enable the Viewbox control within the gallery. 
This resolves issue #1202 

## Description
<!--- Describe your changes in detail -->
Viewbox (note the lower case 'b') is the correct name of this control.  This despite erroneous and inconsistent Microsoft documentation found here: 
https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.viewbox?view=windows-app-sdk-1.2
This documentation begins by showing XAML "ViewBox" at the top of their documentation page, but then uses the correct spelling "Viewbox" of this Xaml control in subsequent XAML examples on the same page.

In the WinUI 3 gallery, data about all controls is contained in the ControlInfoData.json file within the DataModel folder.  This data file had the correct control name "Viewbox" assigned to UniqueId .  

On lines 265 through 267 of the ControlInfoDataSource.cs file, a fully qualified name for the type of the corresponding control page is formed as follows:  
                            string pageString = pageRoot + item.UniqueId + "Page";
                            Type pageType = Type.GetType(pageString);
                            item.IncludedInBuild = pageType != null;
However, since the ViewboxPage had been erroneously renamed "ViewBoxPage", the pageType was null and the Viewbox item.IncludedInBuild was set to false.  This subsequently caused both the menu items and control item to be disabled and ghosted.

The fix was easy: rename ViewBoxPage partial class to ViewboxPage.  For consistency I also renamed all corresponding icon and image names and a couple of references in the comments.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Without this fix, it was impossible for users to preview the Viewbox control within the gallery.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested the fix by accessing the Viewbox control page from the menu, the "All Controls" page, and the layout group page.  The Viewbox demo functions as expected.

IMPORTANT NOTE: Although this merge request successfully restores the Viewbox to the WinUI 3 gallery.  There remains a separate issue that the Viewbox and other control pages throw XamlParseExceptions when repeatedly opened.  See issue #1206 .

## Screenshots (if appropriate):
![Viewbox Restored](https://user-images.githubusercontent.com/78389339/222925150-2a896b21-1495-4fcf-91c4-8ae679ca692a.jpg)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
