### PR TITLE
Using segmented control for colors page

### DIFF
--- a/WinUIGallery/ControlPages/DesignGuidance/ColorsPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/ColorsPage.xaml
@@ -7,6 +7,8 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:labs="using:CommunityToolkit.Labs.WinUI"
+    Loaded="Page_Loaded"
     mc:Ignorable="d">
 
     <Page.Resources>
@@ -33,55 +35,15 @@
             <RichTextBlock Margin="0,0,0,24">
                 <Paragraph>The colors below are provided as part of WinUI 3. You can reference them in your app using ThemeResource bindings. For example: Color="{ThemeResource CardBackgroundFillColorDefault}"</Paragraph>
             </RichTextBlock>
+        
         </StackPanel>
-        <Grid
-            x:Name="SelectionElement"
-            Grid.Row="1"
-            HorizontalAlignment="Stretch">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-
-            <ToggleButton
-                HorizontalAlignment="Stretch"
-                Checked="ToggleButton_Checked"
-                CornerRadius="4,0,0,4"
-                IsChecked="True">
-                Text
-            </ToggleButton>
-            <ToggleButton
-                Grid.Column="1"
-                HorizontalAlignment="Stretch"
-                Checked="ToggleButton_Checked"
-                CornerRadius="0">
-                Fill
-            </ToggleButton>
-            <ToggleButton
-                Grid.Column="2"
-                HorizontalAlignment="Stretch"
-                Checked="ToggleButton_Checked"
-                CornerRadius="0">
-                Stroke
-            </ToggleButton>
-            <ToggleButton
-                Grid.Column="3"
-                HorizontalAlignment="Stretch"
-                Checked="ToggleButton_Checked"
-                CornerRadius="0">
-                Background
-            </ToggleButton>
-            <ToggleButton
-                Grid.Column="4"
-                HorizontalAlignment="Stretch"
-                Checked="ToggleButton_Checked"
-                CornerRadius="0,4,4,0">
-                Signal
-            </ToggleButton>
-        </Grid>
+        <labs:Segmented x:Name="PageSelector" HorizontalAlignment="Stretch" Grid.Row="1" SelectedIndex="0">
+            <labs:SegmentedItem Content="Text"/>
+            <labs:SegmentedItem Content="Fill"/>
+            <labs:SegmentedItem Content="Stroke"/>
+            <labs:SegmentedItem Content="Background"/>
+            <labs:SegmentedItem Content="Signal"/>
+        </labs:Segmented>
 
         <Frame x:Name="NavigationFrame"   Grid.Row="2" />
     </Grid>

--- a/WinUIGallery/ControlPages/DesignGuidance/ColorsPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/ColorsPage.xaml
@@ -8,7 +8,6 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:labs="using:CommunityToolkit.Labs.WinUI"
-    Loaded="Page_Loaded"
     mc:Ignorable="d">
 
     <Page.Resources>
@@ -37,7 +36,7 @@
             </RichTextBlock>
         
         </StackPanel>
-        <labs:Segmented x:Name="PageSelector" HorizontalAlignment="Stretch" Grid.Row="1" SelectedIndex="0">
+        <labs:Segmented x:Name="PageSelector" SelectionChanged="OnSelectionChanged" Loaded="OnLoaded" HorizontalAlignment="Stretch" Grid.Row="1">
             <labs:SegmentedItem Content="Text"/>
             <labs:SegmentedItem Content="Fill"/>
             <labs:SegmentedItem Content="Stroke"/>

--- a/WinUIGallery/ControlPages/DesignGuidance/ColorsPage.xaml.cs
+++ b/WinUIGallery/ControlPages/DesignGuidance/ColorsPage.xaml.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
 using WinUIGallery.DesktopWap.Controls.DesignGuidance.ColorSections;
 
 namespace AppUIBasics.ControlPages
@@ -12,41 +11,34 @@ namespace AppUIBasics.ControlPages
         public ColorsPage()
         {
             this.InitializeComponent();
-            NavigationFrame.Navigate(typeof(TextSection));
+        }
+        private void OnSelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            switch (PageSelector.SelectedIndex)
+            {
+                case 0:
+                    NavigationFrame.Navigate(typeof(TextSection));
+                    break;
+                case 1:
+                    NavigationFrame.Navigate(typeof(FillSection));
+                    break;
+                case 2:
+                    NavigationFrame.Navigate(typeof(StrokeSection));
+                    break;
+                case 3:
+                    NavigationFrame.Navigate(typeof(BackgroundSection));
+                    break;
+                case 4:
+                    NavigationFrame.Navigate(typeof(SignalSection));
+                    break;
+            }
         }
 
-        private void ToggleButton_Checked(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+        private void Page_Loaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
-            if(sender is ToggleButton item)
-            {
-                switch (item.Content)
-                {
-                    case "Text":
-                        NavigationFrame.Navigate(typeof(TextSection));
-                        break;
-                    case "Fill":
-                        NavigationFrame.Navigate(typeof(FillSection));
-                        break;
-                    case "Stroke":
-                        NavigationFrame.Navigate(typeof(StrokeSection));
-                        break;
-                    case "Background":
-                        NavigationFrame.Navigate(typeof(BackgroundSection));
-                        break;
-                    case "Signal":
-                        NavigationFrame.Navigate(typeof(SignalSection));
-                        break;
-                }
-            }
-            foreach(var child in SelectionElement.Children)
-            {
-                if (child != sender)
-                {
-                    if (child is ToggleButton button)
-
-                        button.IsChecked = false;
-                }
-            }
+            PageSelector.SelectionChanged -= OnSelectionChanged;
+            NavigationFrame.Navigate(typeof(TextSection));
+            PageSelector.SelectionChanged += OnSelectionChanged;
         }
     }
 }

--- a/WinUIGallery/ControlPages/DesignGuidance/ColorsPage.xaml.cs
+++ b/WinUIGallery/ControlPages/DesignGuidance/ColorsPage.xaml.cs
@@ -34,11 +34,9 @@ namespace AppUIBasics.ControlPages
             }
         }
 
-        private void Page_Loaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+        private void OnLoaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
-            PageSelector.SelectionChanged -= OnSelectionChanged;
-            NavigationFrame.Navigate(typeof(TextSection));
-            PageSelector.SelectionChanged += OnSelectionChanged;
+            PageSelector.SelectedItem = PageSelector.Items[0];
         }
     }
 }

--- a/WinUIGallery/WinUIGallery.DesktopWap.csproj
+++ b/WinUIGallery/WinUIGallery.DesktopWap.csproj
@@ -29,7 +29,7 @@
   <ItemGroup>
     <PackageReference Include="ColorCode.Core" />
     <PackageReference Include="CommunityToolkit.Labs.WinUI.SegmentedControl" Version="0.0.2" />
-    <PackageReference Include="CommunityToolkit.Labs.WinUI.SettingsControls" Version="0.0.17" />
+    <PackageReference Include="CommunityToolkit.Labs.WinUI.SettingsControls" Version="0.0.16" />
     <PackageReference Include="CommunityToolkit.WinUI.UI" Version="7.1.2" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Animations" Version="7.1.2" />
     <PackageReference Include="Microsoft.Graphics.Win2D" />

--- a/WinUIGallery/WinUIGallery.DesktopWap.csproj
+++ b/WinUIGallery/WinUIGallery.DesktopWap.csproj
@@ -28,7 +28,8 @@
        in the WinUI repo, or the next ItemGroup below when standalone. -->
   <ItemGroup>
     <PackageReference Include="ColorCode.Core" />
-    <PackageReference Include="CommunityToolkit.Labs.WinUI.SettingsControls" Version="0.0.16" />
+    <PackageReference Include="CommunityToolkit.Labs.WinUI.SegmentedControl" Version="0.0.2" />
+    <PackageReference Include="CommunityToolkit.Labs.WinUI.SettingsControls" Version="0.0.17" />
     <PackageReference Include="CommunityToolkit.WinUI.UI" Version="7.1.2" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Animations" Version="7.1.2" />
     <PackageReference Include="Microsoft.Graphics.Win2D" />


### PR DESCRIPTION
This PR removes the ToggleButtons with the Segmented control from the Windows Community Toolkit, as per design spec.

![SegmentedControl](https://user-images.githubusercontent.com/9866362/224491787-e5940061-7bee-49a2-b4d2-6ff52bec4079.gif)
