### PR TITLE
fix incorrect links

### DIFF
--- a/WinUIGallery/DataModel/ControlInfoData.json
+++ b/WinUIGallery/DataModel/ControlInfoData.json
@@ -9,6 +9,7 @@
       "ImageIconPath": "",
       "Description": "",
       "IsSpecialSection": true,
+      "Folder": "DesignGuidance",
       "Items": [
         {
           "UniqueId": "Typography",

--- a/WinUIGallery/DataModel/ControlInfoDataSource.cs
+++ b/WinUIGallery/DataModel/ControlInfoDataSource.cs
@@ -91,7 +91,7 @@ namespace AppUIBasics.Data
     /// </summary>
     public class ControlInfoDataGroup
     {
-        public ControlInfoDataGroup(string uniqueId, string title, string subtitle, string imagePath, string imageIconPath, string description, string apiNamespace, bool isSpecialSection)
+        public ControlInfoDataGroup(string uniqueId, string title, string subtitle, string imagePath, string imageIconPath, string description, string apiNamespace, string folder, bool isSpecialSection)
         {
             this.UniqueId = uniqueId;
             this.Title = title;
@@ -100,6 +100,7 @@ namespace AppUIBasics.Data
             this.Description = description;
             this.ImagePath = imagePath;
             this.ImageIconPath = imageIconPath;
+            this.Folder = folder;
             this.Items = new ObservableCollection<ControlInfoDataItem>();
             this.IsSpecialSection = isSpecialSection;
         }
@@ -112,6 +113,7 @@ namespace AppUIBasics.Data
         public string ImageIconPath { get; private set; }
         public string ApiNamespace { get; private set; } = "";
         public bool IsSpecialSection { get; set; }
+        public string Folder { get; private set; }
         public ObservableCollection<ControlInfoDataItem> Items { get; private set; }
 
         public override string ToString()
@@ -214,6 +216,7 @@ namespace AppUIBasics.Data
                     JsonObject groupObject = groupValue.GetObject();
 
                     var usesCustomNavigationItems = groupObject.ContainsKey("IsSpecialSection") ? groupObject["IsSpecialSection"].GetBoolean() : false;
+                    var folder = groupObject.ContainsKey("Folder") ? groupObject["Folder"].GetString() : string.Empty;
                     ControlInfoDataGroup group = new ControlInfoDataGroup(groupObject["UniqueId"].GetString(),
                                                                           groupObject["Title"].GetString(),
                                                                           groupObject["ApiNamespace"].GetString(),
@@ -221,6 +224,7 @@ namespace AppUIBasics.Data
                                                                           groupObject["ImagePath"].GetString(),
                                                                           groupObject["ImageIconPath"].GetString(),
                                                                           groupObject["Description"].GetString(),
+                                                                          folder,
                                                                           usesCustomNavigationItems);
 
                     foreach (JsonValue itemValue in groupObject["Items"].GetArray())

--- a/WinUIGallery/ItemPage.xaml.cs
+++ b/WinUIGallery/ItemPage.xaml.cs
@@ -80,7 +80,9 @@ namespace AppUIBasics
         protected override async void OnNavigatedTo(NavigationEventArgs e)
         {
             NavigationRootPageArgs args = (NavigationRootPageArgs)e.Parameter;
-            var item = await ControlInfoDataSource.Instance.GetItemAsync((String)args.Parameter);
+            var uniqueId = (string)args.Parameter;
+            var group = await ControlInfoDataSource.Instance.GetGroupFromItemAsync(uniqueId);
+            var item = group?.Items.FirstOrDefault(x => x.UniqueId.Equals(uniqueId));
 
             if (item != null)
             {
@@ -91,7 +93,8 @@ namespace AppUIBasics
 
                 if (pageType != null)
                 {
-                    pageHeader.SetSourceLinks("https://github.com/microsoft/WinUI-Gallery/tree/main/WinUIGallery/ControlPages/", pageType.Name);
+                    var pageName = string.IsNullOrEmpty(group.Folder) ? pageType.Name : $"{group.Folder}/{pageType.Name}";
+                    pageHeader.SetSourceLinks("https://github.com/microsoft/WinUI-Gallery/tree/main/WinUIGallery/ControlPages/", pageName);
                     System.Diagnostics.Debug.WriteLine(string.Format("[ItemPage] Navigate to {0}", pageType.ToString()));
                     this.contentFrame.Navigate(pageType);
                 }


### PR DESCRIPTION
## Description
add **Folder** property ControlInfoDataGroup
if present it will be appended to base URL when navigating to source code for all child items.

## Motivation and Context
fixes #1232

## How Has This Been Tested?
Manual

## Screenshots (if appropriate):

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
