### PR TITLE
[Settings] Incorrect description

### DIFF
--- a/WinUIGallery/SettingsPage.xaml
+++ b/WinUIGallery/SettingsPage.xaml
@@ -72,7 +72,7 @@
                     </ComboBox>
                 </labs:SettingsCard>
 
-                <labs:SettingsCard Description="Select which app theme to display" Header="Navigation style">
+                <labs:SettingsCard Header="Navigation style">
                     <labs:SettingsCard.HeaderIcon>
                         <FontIcon Glyph="&#xF594;" />
                     </labs:SettingsCard.HeaderIcon>


### PR DESCRIPTION
The Navigation Style was using an incorrect description:

![image](https://user-images.githubusercontent.com/9866362/228523215-3a558629-1fa7-454a-84aa-39c4c49976a9.png)
