### PR TITLE
With retarget of app to 19041, wapproj also needs update to prevent nuget errors

### DIFF
--- a/WinUIGallery/WinUIGallery.DesktopWap.Package.wapproj
+++ b/WinUIGallery/WinUIGallery.DesktopWap.Package.wapproj
@@ -38,8 +38,8 @@
   <Import Project="common.props" />
   <PropertyGroup>
     <ProjectGuid>4c7b20d7-5f5c-440e-8da3-b19a328cc8bd</ProjectGuid>
-    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <DefaultLanguage>en-US</DefaultLanguage>
     <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
     <EntryPointProjectUniqueName>WinUIGallery.DesktopWap.csproj</EntryPointProjectUniqueName>


### PR DESCRIPTION
With the UI refresh, the app was retargeted to 19041, but the wapproj was not.  This was causing nuget restore errors (though the build would still succeed), and the potential for runtime versioning issues.  The wapproj needs to specify a TargetPlatformMinVersion >= the app's TargetFrameworkVersion.
