### PR TITLE
Fix use of relative Uris

### DIFF
--- a/WinUIGallery/ControlPages/TitleBarPage.xaml.cs
+++ b/WinUIGallery/ControlPages/TitleBarPage.xaml.cs
@@ -8,24 +8,10 @@
 //
 //*********************************************************
 using AppUIBasics.Helper;
-using System;
-using Microsoft;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Navigation;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
-using WinRT;
-using System.Runtime.InteropServices;
 using WinUIGallery.DesktopWap.Helper;
 using Microsoft.UI.Xaml.Shapes;
 using System.Threading.Tasks;
@@ -131,12 +117,14 @@ namespace AppUIBasics.ControlPages
         {
             UIElement titleBarElement = UIHelper.FindElementByName(sender as UIElement, "AppTitleBar");
             SetTitleBar(titleBarElement);
+
             // announce visual change to automation
             UIHelper.AnnounceActionForAccessibility(sender as UIElement, "TitleBar size and width changed", "TitleBarChangedNotificationActivityId");
         }
         private void defaultTitleBar_Click(object sender, RoutedEventArgs e)
         {
             SetTitleBar(null);
+
             // announce visual change to automation
             UIHelper.AnnounceActionForAccessibility(sender as UIElement, "TitleBar size and width changed", "TitleBarChangedNotificationActivityId");
         }

--- a/WinUIGallery/Controls/ControlExample.xaml.cs
+++ b/WinUIGallery/Controls/ControlExample.xaml.cs
@@ -133,9 +133,9 @@ namespace AppUIBasics
         }
 
         public static readonly DependencyProperty XamlSourceProperty = DependencyProperty.Register("XamlSource", typeof(object), typeof(ControlExample), new PropertyMetadata(null));
-        public Uri XamlSource
+        public string XamlSource
         {
-            get { return (Uri)GetValue(XamlSourceProperty); }
+            get { return (string)GetValue(XamlSourceProperty); }
             set { SetValue(XamlSourceProperty, value); }
         }
 
@@ -147,9 +147,9 @@ namespace AppUIBasics
         }
 
         public static readonly DependencyProperty CSharpSourceProperty = DependencyProperty.Register("CSharpSource", typeof(object), typeof(ControlExample), new PropertyMetadata(null));
-        public Uri CSharpSource
+        public string CSharpSource
         {
-            get { return (Uri)GetValue(CSharpSourceProperty); }
+            get { return (string)GetValue(CSharpSourceProperty); }
             set { SetValue(CSharpSourceProperty, value); }
         }
 
@@ -357,7 +357,7 @@ namespace AppUIBasics
             if (XamlSource != null)
             {
                 // Most of them don't have this, but the xaml source name is a really good file name
-                string xamlSource = new Uri("ms-appx:///" + Path.Combine("ControlPagesSampleCode", XamlSource.LocalPath)).LocalPath;
+                string xamlSource = new Uri(XamlSource, UriKind.Relative).LocalPath;
                 string fileName = Path.GetFileNameWithoutExtension(xamlSource);
                 if (!String.IsNullOrWhiteSpace(fileName))
                 {

--- a/WinUIGallery/Controls/SampleCodePresenter.xaml.cs
+++ b/WinUIGallery/Controls/SampleCodePresenter.xaml.cs
@@ -43,9 +43,9 @@ namespace AppUIBasics.Controls
         }
 
         public static readonly DependencyProperty CodeSourceFileProperty = DependencyProperty.Register("CodeSourceFile", typeof(object), typeof(SampleCodePresenter), new PropertyMetadata(null, OnDependencyPropertyChanged));
-        public Uri CodeSourceFile
+        public string CodeSourceFile
         {
-            get { return (Uri)GetValue(CodeSourceFileProperty); }
+            get { return (string)GetValue(CodeSourceFileProperty); }
             set { SetValue(CodeSourceFileProperty, value); }
         }
 
@@ -137,15 +137,9 @@ namespace AppUIBasics.Controls
             GenerateSyntaxHighlightedContent();
         }
 
-        private Uri GetDerivedSource(Uri rawSource)
+        private Uri GetDerivedSource(string sourceRelativePath)
         {
-            // Get the full path of the source string
-            string concatString = "";
-            for (int i = 2; i < rawSource.Segments.Length; i++)
-            {
-                concatString += rawSource.Segments[i];
-            }
-            Uri derivedSource = new Uri(new Uri("ms-appx:///ControlPagesSampleCode/"), concatString);
+            Uri derivedSource = new Uri(new Uri("ms-appx:///ControlPagesSampleCode/"), sourceRelativePath);
 
             return derivedSource;
         }
@@ -168,11 +162,11 @@ namespace AppUIBasics.Controls
             }
         }
 
-        private async void FormatAndRenderSampleFromFile(Uri source, ContentPresenter presenter, ILanguage highlightLanguage)
+        private async void FormatAndRenderSampleFromFile(string sourceRelativePath, ContentPresenter presenter, ILanguage highlightLanguage)
         {
-            if (source != null && source.AbsolutePath.EndsWith("txt"))
+            if (sourceRelativePath != null && sourceRelativePath.EndsWith("txt"))
             {
-                Uri derivedSource = GetDerivedSource(source);
+                Uri derivedSource = GetDerivedSource(sourceRelativePath);
                 var file = await StorageFile.GetFileFromApplicationUriAsync(derivedSource);
                 string sampleString = await FileIO.ReadTextAsync(file);
 


### PR DESCRIPTION
## Description
Both XamlSource and CodeSource variables use relative URIs, but are inferred to be absolute. This leads to false lookups under 
ms-resource://Files/<value> which doesn't exist.  The fix is to specify the relative paths as strings until we are ready to use them in an actual URI.

Also fixes for whitespace and unused namespaces.