### PR TITLE
Adding accessible name to copy link button

### DIFF
--- a/WinUIGallery/Controls/PageHeader.xaml
+++ b/WinUIGallery/Controls/PageHeader.xaml
@@ -125,6 +125,7 @@
                     Height="32"
                     Margin="4,0,4,0"
                     Click="OnCopyLinkButtonClick"
+                    AutomationProperties.Name="Copy link"
                     ToolTipService.ToolTip="Copy link">
                     <Button.Content>
                         <FontIcon


### PR DESCRIPTION
The copy link button was missing an accessible name, resulting in it not being announced (correctly) by Narrator.