### PR TITLE
Fix ContentDialog theme color

### DIFF
--- a/WinUIGallery/ControlPages/ContentDialogPage.xaml.cs
+++ b/WinUIGallery/ControlPages/ContentDialogPage.xaml.cs
@@ -35,6 +35,7 @@ namespace AppUIBasics.ControlPages
             dialog.CloseButtonText = "Cancel";
             dialog.DefaultButton = ContentDialogButton.Primary;
             dialog.Content = new ContentDialogContent();
+            dialog.RequestedTheme = (VisualTreeHelper.GetParent(sender as Button) as StackPanel).ActualTheme;
 
             var result = await dialog.ShowAsync();
 


### PR DESCRIPTION
## Description
The theme color of the ContentDialog in the example only changes with the system.

Make its theme color follow the Toggle Theme button.

## Screenshots

![image](https://user-images.githubusercontent.com/20025591/231535493-735c0227-7e5a-43e2-8710-93943e34b107.png)
![image](https://user-images.githubusercontent.com/20025591/231535597-38c271c1-a6b9-48db-8814-ad0556223735.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
