### PR TITLE
[Accessibility][Keyboard support] Add access keys & arrow keys docs and add clarify guidance

### DIFF
--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
@@ -88,8 +88,8 @@
             <core:ControlExample.Xaml>
                 <x:String xml:space="preserve">
 &lt;StackPanel Spacing="4"&gt;
-    &lt;TextBlock Text="(not present)" /&gt;
     &lt;Button Content="First" /&gt;
+    &lt;TextBlock Text="(not present)" /&gt;
     &lt;Button Content="Second" /&gt;
     &lt;Button Content="(not present)" IsEnabled="False" /&gt;
     &lt;Button Content="Third" /&gt;
@@ -442,9 +442,9 @@
                         Grid.Column="2"
                         Click="MakeChartreuseButton_Click"
                         Content="Chartreuse"
-                        ToolTipService.ToolTip="A greenish-yellow (Ctrl+C)">
+                        ToolTipService.ToolTip="A greenish-yellow (Ctrl+G)">
                         <Button.KeyboardAccelerators>
-                            <KeyboardAccelerator Key="C" Modifiers="Control" />
+                            <KeyboardAccelerator Key="G" Modifiers="Control" />
                         </Button.KeyboardAccelerators>
                     </Button>
 
@@ -452,7 +452,7 @@
                         Grid.Row="2"
                         Grid.ColumnSpan="4"
                         Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="Ctrl+R, Ctrl+B, and Ctrl-C trigger Red, Blue, and Chartreuse respectively" />
+                        Text="Ctrl+R, Ctrl+B, and Ctrl+G trigger Red, Blue, and Chartreuse respectively" />
                 </Grid>
             </core:ControlExample.Example>
 

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
@@ -219,7 +219,33 @@
 
         <RichTextBlock>
             <Paragraph>
-                
+                Users expect groups of similar, related controls to be navigable via <Bold>Arrow keys</Bold>, too. This can be instead of
+                <Italic>or</Italic> in addition to tab navigation, depending on the situation.
+                <LineBreak />
+            </Paragraph>
+            <Paragraph>
+                Groups of controls that support arrow key navigation typically support Home/End and PgUp/PgDn, too.
+                <LineBreak />
+            </Paragraph>
+            <Paragraph>
+                See
+                <Hyperlink
+                    NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/input/keyboard-interactions#navigation">
+                    Keyboard navigation
+                </Hyperlink>,
+                <Hyperlink
+                    NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/input/keyboard-interactions#home-and-end-keys">
+                    Home and End keys
+                </Hyperlink>,
+                <Hyperlink
+                    NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/input/keyboard-interactions#page-up-and-page-down-keys">
+                    Page up and Page down keys
+                </Hyperlink>,
+                and
+                <Hyperlink
+                    NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/input/keyboard-interactions#control-group">
+                    Control group
+                </Hyperlink>.
             </Paragraph>
         </RichTextBlock>
 
@@ -231,7 +257,7 @@
 
         <RichTextBlock>
             <Paragraph>
-                Most controls that group elements support arrow keys by default:
+                Most controls that group elements support arrow keys (and Home/End and PgUp/PgDn) by default:
             </Paragraph>
         </RichTextBlock>
 
@@ -288,13 +314,9 @@
             <Paragraph>
                 See
                 <Hyperlink
-                    NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/input/keyboard-interactions#navigation">
-                    Keyboard navigation
-                </Hyperlink>,
-                <Hyperlink
                     NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/input/focus-navigation">
                     Focus navigation for keyboard, gamepad, remote control, and accessibility tools
-                </Hyperlink>, and
+                </Hyperlink> and
                 <Hyperlink
                     NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/accessibility/keyboard-accessibility">
                     Keyboard accessibility

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
@@ -594,24 +594,49 @@ private void MakeChartreuseButton_Click(object sender, RoutedEventArgs e)
 
         <core:ControlExample>
             <core:ControlExample.Example>
-                <StackPanel Orientation="Vertical">
+                <StackPanel
+                    Orientation="Vertical">
                     <MenuBar>
-                        <MenuBarItem Title="File" AccessKey="F">
-                            <MenuFlyoutItem Text="New" AccessKey="N" />
-                            <MenuFlyoutItem Text="Open..." AccessKey="O" />
-                            <MenuFlyoutItem Text="Save" AccessKey="S" />
-                            <MenuFlyoutItem Text="Exit" AccessKey="E" />
+                        <MenuBarItem
+                            Title="File"
+                            AccessKey="F">
+                            <MenuFlyoutItem
+                                Text="New"
+                                AccessKey="N" />
+                            <MenuFlyoutItem
+                                Text="Open..."
+                                AccessKey="O" />
+                            <MenuFlyoutItem
+                                Text="Save"
+                                AccessKey="S" />
+                            <MenuFlyoutItem
+                                Text="Exit"
+                                AccessKey="E" />
                         </MenuBarItem>
 
-                        <MenuBarItem Title="Edit" AccessKey="E">
-                            <MenuFlyoutItem Text="Undo" AccessKey="U" />
-                            <MenuFlyoutItem Text="Cut" AccessKey="X" />
-                            <MenuFlyoutItem Text="Copy" AccessKey="C" />
-                            <MenuFlyoutItem Text="Paste" AccessKey="V" />
+                        <MenuBarItem
+                            Title="Edit"
+                            AccessKey="E">
+                            <MenuFlyoutItem
+                                Text="Undo"
+                                AccessKey="U" />
+                            <MenuFlyoutItem
+                                Text="Cut"
+                                AccessKey="X" />
+                            <MenuFlyoutItem
+                                Text="Copy"
+                                AccessKey="C" />
+                            <MenuFlyoutItem
+                                Text="Paste"
+                                AccessKey="V" />
                         </MenuBarItem>
 
-                        <MenuBarItem Title="Help" AccessKey="H">
-                            <MenuFlyoutItem Text="About" AccessKey="A" />
+                        <MenuBarItem
+                            Title="Help"
+                            AccessKey="H">
+                            <MenuFlyoutItem
+                                Text="About"
+                                AccessKey="A" />
                         </MenuBarItem>
                     </MenuBar>
                     <TextBlock
@@ -620,7 +645,8 @@ private void MakeChartreuseButton_Click(object sender, RoutedEventArgs e)
                 </StackPanel>
             </core:ControlExample.Example>
             <core:ControlExample.Xaml>
-                <x:String xml:space="preserve">
+                <x:String
+                    xml:space="preserve">
 &lt;MenuBar&gt;
     &lt;MenuBarItem Title="File" AccessKey="F"&gt;
         &lt;MenuFlyoutItem Text="New" AccessKey="N" /&gt;
@@ -640,155 +666,6 @@ private void MakeChartreuseButton_Click(object sender, RoutedEventArgs e)
         &lt;MenuFlyoutItem Text="About" AccessKey="A" /&gt;
     &lt;/MenuBarItem&gt;
 &lt;/MenuBar&gt;
-                </x:String>
-            </core:ControlExample.Xaml>
-        </core:ControlExample>
-
-        <TextBlock
-            Margin="0,20,0,0"
-            Style="{ThemeResource SubtitleTextBlockStyle}"
-            Text="Landmarks and headings" />
-        <TextBlock>
-            Landmarks and headings define sections of a user interface that aid in more efficient navigation for
-            users of assistive technology (AT). Marking up the content into landmarks and headings provides a
-            screen reader user the option to skim content similar to the way a sighted user would.
-        </TextBlock>
-        <core:ControlExample>
-            <core:ControlExample.Example>
-                <StackPanel>
-                    <TextBlock
-                        Margin="0,0,0,10"
-                        HorizontalAlignment="Left"
-                        Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="The sample below showcases landmarks."
-                        TextWrapping="Wrap" />
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="200" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
-
-                        <!--  The navigation pane for our app  -->
-                        <StackPanel
-                            Grid.Column="0"
-                            Padding="6"
-                            AutomationProperties.LandmarkType="Main"
-                            Background="{ThemeResource CardStrokeColorDefaultBrush}"
-                            CornerRadius="{StaticResource ControlCornerRadius}"
-                            Spacing="8">
-                            <AutoSuggestBox AutomationProperties.LandmarkType="Search" PlaceholderText="Search" />
-                            <Button Content="Open settings" />
-                        </StackPanel>
-
-                        <!--  The main content of our app  -->
-                        <StackPanel
-                            Grid.Column="1"
-                            Padding="6"
-                            AutomationProperties.LandmarkType="Main">
-                            <TextBlock TextWrapping="WrapWholeWords">
-                                Loren ipsum dolor sit anet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-                                Ut enim ad minim venian, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea cannodo consequat.
-                                Duis aute irure dolor in reprehenderit in voluptate velit esse cilium dolore eu fugiat nulla pariatur.
-                                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborun
-                            </TextBlock>
-                        </StackPanel>
-                    </Grid>
-                </StackPanel>
-            </core:ControlExample.Example>
-            <core:ControlExample.Xaml>
-                <x:String xml:space="preserve">
-&lt;Grid&gt;
-&lt;Grid.ColumnDefinitions&gt;
-	&lt;ColumnDefinition Width="200"/&gt;
-	&lt;ColumnDefinition Width="*"/&gt;
-&lt;/Grid.ColumnDefinitions&gt;
-
-&lt;!-- The navigation pane for our app  --&gt;
-&lt;StackPanel Grid.Column="0" AutomationProperties.LandmarkType="Main" Padding="6" Spacing="8"
-	Background="{ThemeResource CardStrokeColorDefaultBrush}"&gt;
-	&lt;AutoSuggestBox AutomationProperties.LandmarkType="Search" PlaceholderText="Search"/&gt;
-	&lt;Button Content="Open settings"/&gt;
-&lt;/StackPanel&lt;
-
-&lt;!-- The main content of our app  --&gt;
-&lt;StackPanel Grid.Column="1" AutomationProperties.LandmarkType="Main" Padding="6"&gt;
-	&lt;TextBlock TextWrapping="WrapWholeWords"&gt;
-		Loren ipsum dolor sit anet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-		Ut enim ad minim venian, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea cannodo consequat.
-		Duis aute irure dolor in reprehenderit in voluptate velit esse cilium dolore eu fugiat nulla pariatur.
-		Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborun
-	&lt;/TextBlock&gt;
-&lt;/StackPanel&gt;
-&lt;/Grid&gt;
-                    </x:String>
-            </core:ControlExample.Xaml>
-        </core:ControlExample>
-
-        <core:ControlExample>
-            <core:ControlExample.Example>
-                <StackPanel HorizontalAlignment="Left">
-                    <TextBlock
-                        Margin="0,0,0,10"
-                        HorizontalAlignment="Left"
-                        Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="The sample below showcases headings."
-                        TextWrapping="Wrap" />
-                    <StackPanel MaxWidth="500">
-                        <!--  Here is the main header for the whole text. It gets HeadingLevel 1  -->
-                        <TextBlock AutomationProperties.HeadingLevel="Level1" FontSize="26">Lorem ipsums</TextBlock>
-                        <!--  The following TextBlock is the header for the standard lorem ipsum text, thus it is only HeadingLevel 2  -->
-                        <TextBlock AutomationProperties.HeadingLevel="Level2" FontSize="22">Lorem ipsum</TextBlock>
-                        <TextBlock TextWrapping="WrapWholeWords">
-                            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                            Pellentesque feugiat velit pulvinar, vehicula nisi at, molestie risus.
-                            Duis consequat auctor libero vitae consectetur. Nullam efficitur euismod lacinia.
-                        </TextBlock>
-
-                        <TextBlock AutomationProperties.HeadingLevel="Level2" FontSize="22">Cat ipsum</TextBlock>
-                        <!--  This is the header for the standard cat ipsum section, which is hierarchically below the cat ipsum header, resulting in HeadingLevel 3  -->
-                        <TextBlock AutomationProperties.HeadingLevel="3" FontSize="18">Standard</TextBlock>
-                        <TextBlock TextWrapping="WrapWholeWords">
-                            Mice litter kitter kitty litty little kitten big roar roar feed me
-                            but i will ruin the couch with my claws and hunt by meowing loudly at 5am next to human.
-                        </TextBlock>
-                        <TextBlock AutomationProperties.HeadingLevel="3" FontSize="18">Cat breeds</TextBlock>
-                        <TextBlock TextWrapping="WrapWholeWords">
-                            Tabby abyssinian for jaguar. Thai russian blue and ragdoll, ocicat.
-                            Mouser puma so american bobtail for donskoy balinese . Scottish fold manx so siamese.
-                        </TextBlock>
-
-                        <TextBlock AutomationProperties.HeadingLevel="2" FontSize="22">Bacon ipsum</TextBlock>
-                        <TextBlock TextWrapping="WrapWholeWords">
-                            Bacon ipsum dolor amet meatball nulla labore,
-                            tempor sirloin chicken frankfurter tail drumstick ex cupim ground round.
-                        </TextBlock>
-                    </StackPanel>
-                </StackPanel>
-            </core:ControlExample.Example>
-            <core:ControlExample.Xaml>
-                <x:String xml:space="preserve">
-&lt;StackPanel MaxWidth="500"&gt;
-&lt;!-- Here is the main header for the whole text. It gets HeadingLevel 1 --&gt;
-&lt;TextBlock AutomationProperties.HeadingLevel="Level1" FontSize="26"&gt;Lorem ipsums&lt;/TextBlock&gt;
-&lt;!-- The following TextBlock is the header for the standard lorem ipsum text, thus it is only HeadingLevel 2--&gt;
-&lt;TextBlock AutomationProperties.HeadingLevel="Level2" FontSize="22"&gt;Lorem ipsum&lt;/TextBlock&gt;
-&lt;TextBlock TextWrapping="WrapWholeWords"&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
-                Pellentesque feugiat velit pulvinar, vehicula nisi at, molestie risus. 
-                Duis consequat auctor libero vitae consectetur. Nullam efficitur euismod lacinia.&lt;/TextBlock&gt;
-    
-&lt;TextBlock AutomationProperties.HeadingLevel="Level2" FontSize="22"&gt;Cat ipsum&lt;/TextBlock&gt;
-&lt;!-- This is the header for the standard cat ipsum section, which is hierarchically below the cat ipsum header, resulting in HeadingLevel 3 --&gt;
-&lt;TextBlock AutomationProperties.HeadingLevel="3" FontSize="18"&gt;Standard&lt;/TextBlock&gt;
-&lt;TextBlock TextWrapping="WrapWholeWords">Mice litter kitter kitty litty little kitten big roar roar feed me 
-                but i will ruin the couch with my claws and hunt by meowing loudly at 5am next to human.&lt;/TextBlock&gt;
-&lt;TextBlock AutomationProperties.HeadingLevel="3" FontSize="18"&gt;Cat breeds&lt;/TextBlock&gt;
-&lt;TextBlock TextWrapping="WrapWholeWords">Tabby abyssinian for jaguar. Thai russian blue and ragdoll, ocicat. 
-                Mouser puma so american bobtail for donskoy balinese . Scottish fold manx so siamese.&lt;/TextBlock&gt;
-    
-&lt;TextBlock AutomationProperties.HeadingLevel="2" FontSize="22"&gt;Bacon ipsum&lt;/TextBlock&gt;
-&lt;TextBlock TextWrapping="WrapWholeWords">Bacon ipsum dolor amet meatball nulla labore, 
-                tempor sirloin chicken frankfurter tail drumstick ex cupim ground round.&lt;/TextBlock&gt;
-&lt;/StackPanel&gt;
                 </x:String>
             </core:ControlExample.Xaml>
         </core:ControlExample>

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
@@ -197,8 +197,44 @@
         <TextBlock
             Margin="0,20,0,0"
             Style="{ThemeResource SubtitleTextBlockStyle}"
-            Text="Keyboard Shortcuts" />
-        <TextBlock Text="It is imperative that you provide an easy way for users to discover your app's shortcut keys (e.g. using tooltips, accessible names, accessible descriptions, etc.)" />
+            AutomationProperties.HeadingLevel="Level2"
+            Text="Keyboard shortcuts" />
+
+        <RichTextBlock>
+            <Paragraph>
+                Keyboard shortcuts are extremely helpful for Narrator users, keyboard users, and power users.
+                Since these groups often find it difficult to quickly jump between sections of UI like mouse users,
+                adding a few keyboard shortcuts for common actions can make your app much easier to use.
+                <LineBreak />
+            </Paragraph>
+            <Paragraph>
+                WinUI offers 2 types of keyboard shortcuts: <Bold>Accelerators</Bold> and <Bold>Access keys</Bold>.
+                Accelerators invoke specific app commands, while access keys set focus to specific parts of your UI.
+            </Paragraph>
+        </RichTextBlock>
+
+        <TextBlock
+            Margin="0,20,0,0"
+            Style="{ThemeResource BodyStrongTextBlockStyle}"
+            AutomationProperties.HeadingLevel="Level3"
+            Text="Accelerators" />
+
+        <RichTextBlock>
+            <Paragraph>
+                Accelerators are hotkeys (typically starting with the Ctrl key) that invoke specific app commands.
+                <LineBreak />
+            </Paragraph>
+            <Paragraph>
+                It's important to provide an easy way of discovering keyboard accelerators. For example, with tooltips, visible labels, AutomationProperties.AcceleratorKey, accessible descriptions, etc.
+                By default, WinUI adds a tooltip with the hotkey, but consider including the accelerator manually if you use a custom tooltip.
+                <LineBreak />
+            </Paragraph>
+            <Paragraph>
+                See
+                <Hyperlink NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/input/keyboard-accelerators">Keyboard accelerators</Hyperlink>.
+            </Paragraph>
+        </RichTextBlock>
+
         <core:ControlExample>
             <core:ControlExample.Example>
                 <Grid ColumnSpacing="8" RowSpacing="8">
@@ -211,12 +247,13 @@
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
 
                     <Rectangle
                         x:Name="ColorRectangle"
-                        Grid.ColumnSpan="2"
+                        Grid.ColumnSpan="3"
                         Height="30"
                         Fill="Red"
                         RadiusX="4"
@@ -224,10 +261,8 @@
 
                     <Button
                         Grid.Row="1"
-                        AutomationProperties.AcceleratorKey="R"
                         Click="MakeRedButton_Click"
-                        Content="Red"
-                        ToolTipService.ToolTip="Shortcut: Ctrl+R">
+                        Content="Red">
                         <Button.KeyboardAccelerators>
                             <KeyboardAccelerator Key="R" Modifiers="Control" />
                         </Button.KeyboardAccelerators>
@@ -236,20 +271,30 @@
                     <Button
                         Grid.Row="1"
                         Grid.Column="1"
-                        AutomationProperties.AcceleratorKey="B"
                         Click="MakeBlueButton_Click"
-                        Content="Blue"
-                        ToolTipService.ToolTip="Shortcut: Ctrl+B">
+                        Content="Blue">
                         <Button.KeyboardAccelerators>
                             <KeyboardAccelerator Key="B" Modifiers="Control" />
                         </Button.KeyboardAccelerators>
                     </Button>
 
+                    <!-- Including the hotkey in a custom tooltip -->
+                    <Button
+                        Grid.Row="1"
+                        Grid.Column="2"
+                        Click="MakeChartreuseButton_Click"
+                        Content="Chartreuse"
+                        ToolTipService.ToolTip="A greenish-yellow (Ctrl+G)">
+                        <Button.KeyboardAccelerators>
+                            <KeyboardAccelerator Key="G" Modifiers="Control" />
+                        </Button.KeyboardAccelerators>
+                    </Button>
+
                     <TextBlock
                         Grid.Row="2"
-                        Grid.ColumnSpan="3"
+                        Grid.ColumnSpan="4"
                         Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="Using KeyboardAccelarator and the AutomationProperties.AcceleratorKey property to create a shortcut. Accelerator keys consist of the Ctrl key + a letter key." />
+                        Text="Using KeyboardAccelarator and the AutomationProperties.AcceleratorKey property to create a shortcut" />
                 </Grid>
             </core:ControlExample.Example>
 
@@ -264,11 +309,12 @@
 &lt;Grid.ColumnDefinitions&gt;
 	&lt;ColumnDefinition Width="Auto"/&gt;
 	&lt;ColumnDefinition Width="Auto"/&gt;
+	&lt;ColumnDefinition Width="Auto"/&gt;
 &lt;/Grid.ColumnDefinitions&gt;
 
 &lt;Rectangle x:Name="ColorRectangle" Fill="Red"
 	Height="30" RadiusX="4" RadiusY="4"
-	Grid.ColumnSpan="2"/&gt;
+	Grid.ColumnSpan="3"/&gt;
 
 &lt;Button Click="MakeRedButton_Click" Content="Red" Grid.Row="1"
 	AutomationProperties.AcceleratorKey="R"
@@ -286,18 +332,34 @@
 		&lt;KeyboardAccelerator Modifiers="Control" Key="B" /&gt;
 	&lt;/Button.KeyboardAccelerators&gt;
 &lt;/Button&gt;
+
+&lt;!-- Including the hotkey in a custom tooltip --&gt;
+&lt;Button Click="MakeChartreuseButton_Click" Content="Chartreuse"
+	Grid.Row="1" Grid.Column="1"
+	AutomationProperties.AcceleratorKey="G"
+	ToolTipService.ToolTip="A greenish yellow (Ctrl+G)"&gt;
+	&lt;Button.KeyboardAccelerators&gt;
+		&lt;KeyboardAccelerator Modifiers="Control" Key="G" /&gt;
+	&lt;/Button.KeyboardAccelerators&gt;
+&lt;/Button&gt;
 &lt;/Grid&gt;
                 </x:String>
             </core:ControlExample.Xaml>
             <core:ControlExample.CSharp>
-                private void MakeRedButton_Click(object sender, RoutedEventArgs e)
-                {
-                ColorRectangle.Fill = new SolidColorBrush(Colors.Red);
-                }
-                private void MakeBlueButton_Click(object sender, RoutedEventArgs e)
-                {
-                ColorRectangle.Fill = new SolidColorBrush(Colors.Blue);
-                }
+                <x:String xml:space="preserve">
+private void MakeRedButton_Click(object sender, RoutedEventArgs e)
+{
+    ColorRectangle.Fill = new SolidColorBrush(Colors.Red);
+}
+private void MakeBlueButton_Click(object sender, RoutedEventArgs e)
+{
+    ColorRectangle.Fill = new SolidColorBrush(Colors.Blue);
+}
+private void MakeChartreuseButton_Click(object sender, RoutedEventArgs e)
+{
+    ColorRectangle.Fill = new SolidColorBrush(Colors.Chartreuse);
+}
+                </x:String>
             </core:ControlExample.CSharp>
         </core:ControlExample>
 

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
@@ -96,7 +96,18 @@
             </core:ControlExample.Xaml>
         </core:ControlExample>
 
-        <core:ControlExample HeaderText="Manual tab order">
+        <TextBlock
+            Style="{ThemeResource BodyStrongTextBlockStyle}"
+            AutomationProperties.HeadingLevel="Level3"
+            Text="Manual tab order" />
+
+        <RichTextBlock>
+            <Paragraph>
+                When the XAML order doesn't match the "logical" tab order, though, you can specify tab order manually:
+            </Paragraph>
+        </RichTextBlock>
+
+        <core:ControlExample>
             <core:ControlExample.Example>
                 <Grid ColumnSpacing="8" RowSpacing="8">
                     <Grid.RowDefinitions>
@@ -107,50 +118,41 @@
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
 
                     <TextBlock
+                        Grid.Column="0"
+                        HorizontalAlignment="Center"
+                        Text="Front of check" />
+                    <TextBlock
                         Grid.Column="1"
                         HorizontalAlignment="Center"
-                        Text="Column 1" />
-                    <TextBlock
-                        Grid.Column="2"
-                        HorizontalAlignment="Center"
-                        Text="Column 2" />
+                        Text="Back of check" />
 
-                    <TextBlock
+                    <TextBox
                         Grid.Row="1"
-                        VerticalAlignment="Center"
-                        Text="Row 1" />
-                    <Button
-                        Grid.Row="1"
-                        Grid.Column="1"
-                        Width="100"
-                        Content="First stop"
+                        Grid.Column="0"
+                        Width="250"
+                        PlaceholderText="Pay to the order of..."
                         TabIndex="1" />
-                    <Button
+                    <TextBox
                         Grid.Row="1"
-                        Grid.Column="2"
+                        Grid.Column="1"
                         Width="100"
-                        Content="Second stop"
-                        TabIndex="2" />
+                        PlaceholderText="Signature"
+                        TabIndex="3" />
 
-                    <TextBlock
+                    <TextBox
                         Grid.Row="2"
-                        VerticalAlignment="Center"
-                        Text="Row 2" />
+                        Grid.Column="0"
+                        Width="250"
+                        PlaceholderText="Amount"
+                        TabIndex="2" />
                     <Button
                         Grid.Row="2"
                         Grid.Column="1"
                         Width="100"
-                        Content="Third stop"
-                        TabIndex="3" />
-                    <Button
-                        Grid.Row="2"
-                        Grid.Column="2"
-                        Width="100"
-                        Content="Not a stop"
+                        Content="(Not a stop)"
                         IsTabStop="False" />
                 </Grid>
             </core:ControlExample.Example>
@@ -165,19 +167,16 @@
     &lt;Grid.ColumnDefinitions&gt;
 	    &lt;ColumnDefinition Width="Auto"/&gt;
 	    &lt;ColumnDefinition Width="Auto"/&gt;
-	    &lt;ColumnDefinition Width="Auto"/&gt;
     &lt;/Grid.ColumnDefinitions&gt;
 
     &lt;TextBlock Grid.Column="1" HorizontalAlignment="Center" Text="Column 1"/&gt;
     &lt;TextBlock Grid.Column="2" HorizontalAlignment="Center" Text="Column 2"/&gt;
 
-    &lt;TextBlock Grid.Row="1" VerticalAlignment="Center" Text="Row 1"/&gt;
-    &lt;Button Grid.Column="1" Grid.Row="1" Content="First stop" TabIndex="1" Width="100"/&gt;
-    &lt;Button Grid.Column="2" Grid.Row="1" Content="Second stop" TabIndex="2" Width="100"/&gt;
+    &lt;TextBox Grid.Column="0" Grid.Row="1" PlaceholderText="Pay to the order of..." TabIndex="1" Width="250"/&gt;
+    &lt;TextBox Grid.Column="1" Grid.Row="1" PlaceholderText="Signature" TabIndex="3" Width="100"/&gt;
 
-    &lt;TextBlock Grid.Row="2" VerticalAlignment="Center" Text="Row 2"/&gt;
-    &lt;Button Grid.Column="1" Grid.Row="2" Content="Third stop" TabIndex="3" Width="100"/&gt;
-    &lt;Button Grid.Column="2" Grid.Row="2" Content="Not a stop" IsTabStop="False" Width="100"/&gt;
+    &lt;TextBox Grid.Column="0" Grid.Row="2" PlaceholderText="Amount" TabIndex="2" Width="250"/&gt;
+    &lt;Button Grid.Column="1" Grid.Row="2" Content="(Not a stop)" IsTabStop="False" Width="100"/&gt;
 &lt;/Grid&gt;
                     </x:String>
             </core:ControlExample.Xaml>

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
@@ -233,20 +233,20 @@
                 See
                 <Hyperlink
                     NavigateUri="https://learn.microsoft.com/windows/apps/design/input/keyboard-interactions#navigation">
-                    Keyboard navigation
+                    Keyboard interactions#Navigation
                 </Hyperlink>,
                 <Hyperlink
                     NavigateUri="https://learn.microsoft.com/windows/apps/design/input/keyboard-interactions#home-and-end-keys">
-                    Home and End keys
+                    Keyboard interactions#Home and End keys
                 </Hyperlink>,
                 <Hyperlink
                     NavigateUri="https://learn.microsoft.com/windows/apps/design/input/keyboard-interactions#page-up-and-page-down-keys">
-                    Page up and Page down keys
+                    Keyboard interactions#Page up and Page down keys
                 </Hyperlink>,
                 and
                 <Hyperlink
                     NavigateUri="https://learn.microsoft.com/windows/apps/design/input/keyboard-interactions#control-group">
-                    Control group
+                    Keyboard interactions#Control group
                 </Hyperlink>.
             </Paragraph>
         </RichTextBlock>

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
@@ -33,8 +33,10 @@
         <RichTextBlock>
             <Paragraph>
                 Accessibility is about building experiences that make your Windows application usable by people of
-                all abilities. For more information about designing accessible apps: <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/accessibility/accessibility-overview">Accessibility overview</Hyperlink>
-                .<LineBreak />
+                all abilities. For more information about designing accessible apps:
+                <Hyperlink
+                    NavigateUri="https://learn.microsoft.com/windows/apps/design/accessibility/accessibility-overview">Accessibility overview</Hyperlink>.
+                <LineBreak />
                 <LineBreak />
                 If your app does not provide good keyboard access, users who are blind or have mobility issues can have difficulty using your app or may not be able to use it at all.<LineBreak />
             </Paragraph>
@@ -51,7 +53,7 @@
                 <LineBreak />
             </Paragraph>
             <Paragraph>
-                All interactive controls, like buttons, should have tab stops (unless they are in a group), but non-interactive controls, like labels, should not.
+                All interactive controls, like buttons, should have tab stops (unless they are in a group that's accessible in some other way), but non-interactive controls, like labels, should not.
                 <LineBreak />
             </Paragraph>
             <Paragraph>
@@ -198,6 +200,160 @@
             Margin="0,20,0,0"
             Style="{ThemeResource SubtitleTextBlockStyle}"
             AutomationProperties.HeadingLevel="Level2"
+            Text="Arrow keys" />
+
+        <TextBlock
+            Margin="0,20,0,0"
+            Style="{ThemeResource BodyStrongTextBlockStyle}"
+            AutomationProperties.HeadingLevel="Level3"
+            Text="Automatically supporting arrow keys" />
+
+        <RichTextBlock>
+            <Paragraph>
+                Most controls that group elements support arrow keys by default:
+            </Paragraph>
+        </RichTextBlock>
+
+        <core:ControlExample>
+            <core:ControlExample.Example>
+                <StackPanel Orientation="Vertical">
+                    <!-- ListViews fully support arrow keys, for example -->
+                    <ListView
+                        Width="300"
+                        AutomationProperties.Name="Colors">
+                        <ListViewItem>Red</ListViewItem>
+                        <ListViewItem>Blue</ListViewItem>
+                        <ListViewItem>Green</ListViewItem>
+                        <ListViewItem>Yellow</ListViewItem>
+                    </ListView>
+                    <TextBlock
+                        Style="{ThemeResource CaptionTextBlockStyle}"
+                        Text="Tab navigates to the control, arrow keys navigate within the control" />
+                </StackPanel>
+            </core:ControlExample.Example>
+            <core:ControlExample.Xaml>
+                <x:String xml:space="preserve">
+&lt;!-- ListViews fully support arrow keys, for example --&gt;
+&lt;ListView
+    Width="300"
+    AutomationProperties.Name="Colors"&gt;
+    &lt;ListViewItem&gt;Red&lt;/ListViewItem&gt;
+    &lt;ListViewItem&gt;Blue&lt;/ListViewItem&gt;
+    &lt;ListViewItem&gt;Green&lt;/ListViewItem&gt;
+    &lt;ListViewItem&gt;Yellow&lt;/ListViewItem&gt;
+&lt;/ListView&gt;
+                </x:String>
+            </core:ControlExample.Xaml>
+        </core:ControlExample>
+        
+        <TextBlock
+            Margin="0,20,0,0"
+            Style="{ThemeResource BodyStrongTextBlockStyle}"
+            AutomationProperties.HeadingLevel="Level3"
+            Text="Manually supporting arrow keys with XYFocusKeyboardNavigation" />
+
+        <RichTextBlock>
+            <Paragraph>
+                You can enable arrow key navigation between items manually, too.
+                <LineBreak />
+            </Paragraph>
+            <Paragraph>
+                Note that for true lists of items, users may expect additional affordances like
+                support for Home/End, PgUp/PgDn, and additional accessibility properties like
+                PositionInSet and SizeOfSet. Keyboard navigation can get complicated, but getting
+                it right can make your app a lot easier to use - for everyone.
+                <LineBreak />
+            </Paragraph>
+            <Paragraph>
+                See
+                <Hyperlink
+                    NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/input/keyboard-interactions#navigation">
+                    Keyboard navigation
+                </Hyperlink>,
+                <Hyperlink
+                    NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/input/focus-navigation">
+                    Focus navigation for keyboard, gamepad, remote control, and accessibility tools
+                </Hyperlink>, and
+                <Hyperlink
+                    NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/accessibility/keyboard-accessibility">
+                    Keyboard accessibility
+                </Hyperlink>.
+            </Paragraph>
+        </RichTextBlock>
+
+        <core:ControlExample>
+            <core:ControlExample.Example>
+                <StackPanel
+                    Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
+                    BorderBrush="{ThemeResource SurfaceStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    Spacing="8"
+                    Padding="8"
+                    CornerRadius="4">
+                    <TextBlock
+                        Style="{ThemeResource BodyStrongTextBlockStyle}"
+                        Text="Potatoes?" />
+                    <!--
+                        XYFocusKeyboardNavigation enables arrow keys between the buttons.
+
+                        Note that:
+
+                            - The buttons are still tabbable by default
+                            - Home/End and PgUp/PgDn do not work
+                            - Screen readers do not read PositionInSet/SizeOfSet ("1 of 3")
+
+                        All of that would require custom work.
+                    -->
+                    <StackPanel
+                        Spacing="4"
+                        Orientation="Horizontal"
+                        XYFocusKeyboardNavigation="Enabled">
+                        <Button Content="Boil 'em"  />
+                        <Button Content="Mash 'em" />
+                        <Button Content="Stick 'em in a stew" />
+                    </StackPanel>
+                </StackPanel>
+            </core:ControlExample.Example>
+            <core:ControlExample.Xaml>
+                <x:String xml:space="preserve">
+&lt;StackPanel
+    Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
+    BorderBrush="{ThemeResource SurfaceStrokeColorDefaultBrush}"
+    BorderThickness="1"
+    Spacing="8"
+    Padding="8"
+    CornerRadius="4"&gt;
+    &lt;TextBlock
+        Style="{ThemeResource BodyStrongTextBlockStyle}"
+        Text="Potatoes?" /&gt;
+    &lt;!--
+        XYFocusKeyboardNavigation enables arrow keys between the buttons.
+
+        Note that:
+
+            - The buttons are still tabbable by default
+            - Home/End and PgUp/PgDn do not work
+            - Screen readers do not read PositionInSet/SizeOfSet ("1 of 3")
+
+        All of that would require custom work.
+    --&gt;
+    &lt;StackPanel
+        Spacing="4"
+        Orientation="Horizontal"
+        XYFocusKeyboardNavigation="Enabled"&gt;
+        &lt;Button Content="Boil 'em"  /&gt;
+        &lt;Button Content="Mash 'em" /&gt;
+        &lt;Button Content="Stick 'em in a stew" /&gt;
+    &lt;/StackPanel&gt;
+&lt;/StackPanel&gt;
+                </x:String>
+            </core:ControlExample.Xaml>
+        </core:ControlExample>
+        
+        <TextBlock
+            Margin="0,20,0,0"
+            Style="{ThemeResource SubtitleTextBlockStyle}"
+            AutomationProperties.HeadingLevel="Level2"
             Text="Keyboard shortcuts" />
 
         <RichTextBlock>
@@ -286,9 +442,9 @@
                         Grid.Column="2"
                         Click="MakeChartreuseButton_Click"
                         Content="Chartreuse"
-                        ToolTipService.ToolTip="A greenish-yellow (Ctrl+G)">
+                        ToolTipService.ToolTip="A greenish-yellow (Ctrl+C)">
                         <Button.KeyboardAccelerators>
-                            <KeyboardAccelerator Key="G" Modifiers="Control" />
+                            <KeyboardAccelerator Key="C" Modifiers="Control" />
                         </Button.KeyboardAccelerators>
                     </Button>
 
@@ -296,7 +452,7 @@
                         Grid.Row="2"
                         Grid.ColumnSpan="4"
                         Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="Using the KeyboardAccelarator property to create an accelerator" />
+                        Text="Ctrl+R, Ctrl+B, and Ctrl-C trigger Red, Blue, and Chartreuse respectively" />
                 </Grid>
             </core:ControlExample.Example>
 
@@ -374,6 +530,12 @@ private void MakeChartreuseButton_Click(object sender, RoutedEventArgs e)
                 <LineBreak />
             </Paragraph>
             <Paragraph>
+                When users press the Alt key, WinUI shows <Bold>Key Tips</Bold> next to each control with an access key,
+                so users can discover them. WinUI also populates AccessKey UIA property, so screen reader users can learn
+                access keys, too.
+                <LineBreak />
+            </Paragraph>
+            <Paragraph>
                 See
                 <Hyperlink
                     NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/input/access-keys">Access keys</Hyperlink>.
@@ -404,7 +566,7 @@ private void MakeChartreuseButton_Click(object sender, RoutedEventArgs e)
                     </MenuBar>
                     <TextBlock
                         Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="Using AccessKey to create access keys. Press and release Alt to display them." />
+                        Text="Press and release Alt to display Key Tips; use Alt+letter to move focus to items" />
                 </StackPanel>
             </core:ControlExample.Example>
             <core:ControlExample.Xaml>

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
@@ -409,7 +409,7 @@
         <RichTextBlock>
             <Paragraph>
                 Keyboard shortcuts are extremely helpful for Narrator users, keyboard users, and power users.
-                Since these groups often find it difficult to quickly jump between sections of UI like mouse users,
+                Since keyboard shortcuts generally lack the ability to quickly switch between sections of UI like a mouse can,
                 adding a few keyboard shortcuts for common actions can make your app much easier to use.
                 <LineBreak />
             </Paragraph>
@@ -441,8 +441,6 @@
             </Paragraph>
         </RichTextBlock>
 
-        <!-- BESTO: note to self. Why is WinUI not setting AutomationProperties.AcceleratorKey="Ctrl+G" properly? -->
-        
         <core:ControlExample>
             <core:ControlExample.Example>
                 <Grid ColumnSpacing="8" RowSpacing="8">

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
@@ -326,35 +326,41 @@
 
         <core:ControlExample>
             <core:ControlExample.Example>
-                <StackPanel
-                    Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
-                    BorderBrush="{ThemeResource SurfaceStrokeColorDefaultBrush}"
-                    BorderThickness="1"
-                    Spacing="8"
-                    Padding="8"
-                    CornerRadius="4">
-                    <TextBlock
-                        Style="{ThemeResource BodyStrongTextBlockStyle}"
-                        Text="Potatoes?" />
-                    <!--
-                        XYFocusKeyboardNavigation enables arrow keys between the buttons.
-
-                        Note that:
-
-                            - The buttons are still tabbable by default
-                            - Home/End and PgUp/PgDn do not work
-                            - Screen readers do not read PositionInSet/SizeOfSet ("1 of 3")
-
-                        All of that would require custom work.
-                    -->
+                <StackPanel Spacing="4">
                     <StackPanel
-                        Spacing="4"
-                        Orientation="Horizontal"
-                        XYFocusKeyboardNavigation="Enabled">
-                        <Button Content="Boil 'em"  />
-                        <Button Content="Mash 'em" />
-                        <Button Content="Stick 'em in a stew" />
+                        Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
+                        BorderBrush="{ThemeResource SurfaceStrokeColorDefaultBrush}"
+                        AutomationProperties.Name="Potatoes?"
+                        BorderThickness="1"
+                        Spacing="8"
+                        Padding="8"
+                        CornerRadius="4">
+                        <TextBlock
+                            Style="{ThemeResource BodyStrongTextBlockStyle}"
+                            Text="Potatoes?" />
+                        <!--
+                            XYFocusKeyboardNavigation enables arrow keys between the buttons.
+
+                            Note that:
+
+                                - The buttons are still tabbable by default
+                                - Home/End and PgUp/PgDn do not work
+                                - Screen readers do not read PositionInSet/SizeOfSet ("1 of 3")
+
+                            All of that would require custom work.
+                        -->
+                        <StackPanel
+                            Spacing="4"
+                            Orientation="Horizontal"
+                            XYFocusKeyboardNavigation="Enabled">
+                            <Button Content="Boil 'em"  />
+                            <Button Content="Mash 'em" />
+                            <Button Content="Stick 'em in a stew" />
+                        </StackPanel>
                     </StackPanel>
+                    <TextBlock
+                        Style="{ThemeResource CaptionTextBlockStyle}"
+                        Text="Arrow keys navigate between each button, but tab still navigates between each button, and other buttons like Home/End do not work." />
                 </StackPanel>
             </core:ControlExample.Example>
             <core:ControlExample.Xaml>
@@ -362,6 +368,7 @@
 &lt;StackPanel
     Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
     BorderBrush="{ThemeResource SurfaceStrokeColorDefaultBrush}"
+    AutomationProperties.Name="Potatoes?"
     BorderThickness="1"
     Spacing="8"
     Padding="8"

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
@@ -308,7 +308,7 @@
                 Note that for true lists of items, users may expect additional affordances like
                 support for Home/End, PgUp/PgDn, and additional accessibility properties like
                 PositionInSet and SizeOfSet. Keyboard navigation can get complicated, but getting
-                it right can make your app a lot easier to use—for everyone.
+                it right can make your app a lot easier to use — for everyone.
                 <LineBreak />
             </Paragraph>
             <Paragraph>

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
@@ -360,7 +360,7 @@
                     </StackPanel>
                     <TextBlock
                         Style="{ThemeResource CaptionTextBlockStyle}"
-                        Text="Arrow keys navigate between each button, but tab still navigates between each button, and other buttons like Home/End do not work." />
+                        Text="Arrow keys navigate between each button, but tab still navigates between each button, and other buttons like Home/End do not work" />
                 </StackPanel>
             </core:ControlExample.Example>
             <core:ControlExample.Xaml>

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
@@ -49,11 +49,12 @@
 
         <RichTextBlock>
             <Paragraph>
-                To use the keyboard with a control, the control must have focus, and to receive focus (without using a pointer) the control must be accessible in a Ul design via tab navigation.
+                To use the keyboard with a control, the control must have focus. The most common way to receive focus is via <Bold>Tab navigation</Bold> and the <Bold>Tab order</Bold>.
                 <LineBreak />
             </Paragraph>
             <Paragraph>
                 All interactive controls, like buttons, should have tab stops (unless they are in a group that's accessible in some other way), but non-interactive controls, like labels, should not.
+                Try to put initial focus on the most useful or logical element.
                 <LineBreak />
             </Paragraph>
             <Paragraph>
@@ -79,8 +80,10 @@
             <core:ControlExample.Example>
                 <StackPanel Spacing="4">
                     <Button Content="First" />
+                    <!-- Non-interactive controls should not be in the tab order -->
                     <TextBlock Text="(not present)" />
                     <Button Content="Second" />
+                    <!-- Disabled controls should not be in the tab order -->
                     <Button Content="(not present)" IsEnabled="False" />
                     <Button Content="Third" />
                 </StackPanel>
@@ -89,8 +92,10 @@
                 <x:String xml:space="preserve">
 &lt;StackPanel Spacing="4"&gt;
     &lt;Button Content="First" /&gt;
+    &lt;!-- Non-interactive controls should not be in the tab order --&gt;
     &lt;TextBlock Text="(not present)" /&gt;
     &lt;Button Content="Second" /&gt;
+    &lt;!-- Disabled controls should not be in the tab order --&gt;
     &lt;Button Content="(not present)" IsEnabled="False" /&gt;
     &lt;Button Content="Third" /&gt;
 &lt;/StackPanel&gt;
@@ -132,6 +137,11 @@
                         HorizontalAlignment="Center"
                         Text="Column 2" />
 
+                    <!--
+                        This example is a bit contrived, since you could fix the
+                        tab order by reordering the elements in the XAML, but
+                        sometimes that is not easy to do.
+                    -->
                     <TextBlock
                         Grid.Row="1"
                         VerticalAlignment="Center"
@@ -184,6 +194,11 @@
     &lt;TextBlock Grid.Column="1" HorizontalAlignment="Center" Text="Column 1"/&gt;
     &lt;TextBlock Grid.Column="2" HorizontalAlignment="Center" Text="Column 2"/&gt;
 
+    &lt;!--
+        This example is a bit contrived, since you could fix the
+        tab order by reordering the elements in the XAML, but
+        sometimes that is not easy to do.
+    --&gt;
     &lt;TextBlock Grid.Row="1" VerticalAlignment="Center" Text="Row 1"/&gt;
     &lt;Button Grid.Column="1" Grid.Row="1" Content="First stop" TabIndex="1" HorizontalAlignment="Stretch"/&gt;
     &lt;Button Grid.Column="2" Grid.Row="1" Content="Third stop" TabIndex="3" HorizontalAlignment="Stretch"/&gt;
@@ -201,6 +216,12 @@
             Style="{ThemeResource SubtitleTextBlockStyle}"
             AutomationProperties.HeadingLevel="Level2"
             Text="Arrow keys" />
+
+        <RichTextBlock>
+            <Paragraph>
+                
+            </Paragraph>
+        </RichTextBlock>
 
         <TextBlock
             Margin="0,20,0,0"

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
@@ -486,7 +486,11 @@
                         </Button.KeyboardAccelerators>
                     </Button>
 
-                    <!-- Including the hotkey in a custom tooltip -->
+                    <!--
+                        Chartreuse is an uncommon color, so we explain it in the tooltip.
+                        This replaces the auto-generated tooltip, so we manually mention
+                        the hotkey in the custom tooltip.
+                    -->
                     <Button
                         Grid.Row="1"
                         Grid.Column="2"
@@ -539,7 +543,11 @@
 	&lt;/Button.KeyboardAccelerators&gt;
 &lt;/Button&gt;
 
-&lt;!-- Including the hotkey in a custom tooltip --&gt;
+&lt;!--
+    Chartreuse is an uncommon color, so we explain it in the tooltip.
+    This replaces the auto-generated tooltip, so we manually mention
+    the hotkey in the custom tooltip.
+--&gt;
 &lt;Button Click="MakeChartreuseButton_Click" Content="Chartreuse"
 	Grid.Row="1" Grid.Column="1"
 	ToolTipService.ToolTip="A greenish yellow (Ctrl+G)"&gt;

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
@@ -305,7 +305,7 @@
                 <LineBreak />
             </Paragraph>
             <Paragraph>
-                Note that for true lists of items, users may expect additional affordances like
+                Note that if you're implementing a list of items, users may expect additional affordances like
                 support for Home/End, PgUp/PgDn, and additional accessibility properties like
                 PositionInSet and SizeOfSet. Keyboard navigation can get complicated, but getting
                 it right can make your app a lot easier to use — for everyone.

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
@@ -414,7 +414,7 @@
                 <LineBreak />
             </Paragraph>
             <Paragraph>
-                WinUI offers 2 types of keyboard shortcuts: <Bold>Accelerators</Bold> and <Bold>Access keys</Bold>.
+                WinUI 3 offers 2 types of keyboard shortcuts: <Bold>Accelerators</Bold> and <Bold>Access keys</Bold>.
                 Accelerators invoke specific app commands, while access keys set focus to specific parts of your UI.
             </Paragraph>
         </RichTextBlock>

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
@@ -37,11 +37,66 @@
                 .<LineBreak />
                 <LineBreak />
                 If your app does not provide good keyboard access, users who are blind or have mobility issues can have difficulty using your app or may not be able to use it at all.<LineBreak />
-                <LineBreak />
-                To use the keyboard with a control, the control must have focus, and to receive focus (without using a pointer) the control must be accessible in a Ul design via tab navigation. Here is how you can override the default tab order:</Paragraph>
+            </Paragraph>
         </RichTextBlock>
 
-        <core:ControlExample HeaderText="Controlling tab sequence">
+        <TextBlock
+            Style="{ThemeResource SubtitleTextBlockStyle}"
+            AutomationProperties.HeadingLevel="Level2"
+            Text="Tab order" />
+
+        <RichTextBlock>
+            <Paragraph>
+                To use the keyboard with a control, the control must have focus, and to receive focus (without using a pointer) the control must be accessible in a Ul design via tab navigation.
+                <LineBreak />
+            </Paragraph>
+            <Paragraph>
+                All interactive controls, like buttons, should have tab stops (unless they are in a group), but non-interactive controls, like labels, should not.
+                <LineBreak />
+            </Paragraph>
+            <Paragraph>
+                See
+                <Hyperlink NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/input/keyboard-interactions">Keyboard interactions</Hyperlink>
+                and
+                <Hyperlink NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/accessibility/keyboard-accessibility">Keyboard accessibility</Hyperlink>.
+            </Paragraph>
+        </RichTextBlock>
+
+        <TextBlock
+            Style="{ThemeResource BodyStrongTextBlockStyle}"
+            AutomationProperties.HeadingLevel="Level3"
+            Text="Automatic tab order" />
+
+        <RichTextBlock>
+            <Paragraph>
+                By default, tab order matches the order elements are defined in the XAML. This is usually the best order:
+            </Paragraph>
+        </RichTextBlock>
+
+        <core:ControlExample>
+            <core:ControlExample.Example>
+                <StackPanel Spacing="4">
+                    <Button Content="First" />
+                    <TextBlock Text="(not present)" />
+                    <Button Content="Second" />
+                    <Button Content="(not present)" IsEnabled="False" />
+                    <Button Content="Third" />
+                </StackPanel>
+            </core:ControlExample.Example>
+            <core:ControlExample.Xaml>
+                <x:String xml:space="preserve">
+&lt;StackPanel Spacing="4"&gt;
+    &lt;TextBlock Text="(not present)" /&gt;
+    &lt;Button Content="First" /&gt;
+    &lt;Button Content="Second" /&gt;
+    &lt;Button Content="(not present)" IsEnabled="False" /&gt;
+    &lt;Button Content="Third" /&gt;
+&lt;/StackPanel&gt;
+                </x:String>
+            </core:ControlExample.Xaml>
+        </core:ControlExample>
+
+        <core:ControlExample HeaderText="Manual tab order">
             <core:ControlExample.Example>
                 <Grid ColumnSpacing="8" RowSpacing="8">
                     <Grid.RowDefinitions>
@@ -102,27 +157,27 @@
             <core:ControlExample.Xaml>
                 <x:String xml:space="preserve">
 &lt;Grid RowSpacing="8" ColumnSpacing="8"&gt;
-&lt;Grid.RowDefinitions&gt;
-	&lt;RowDefinition Height="Auto"/&gt;
-	&lt;RowDefinition Height="Auto"/&gt;
-	&lt;RowDefinition Height="Auto"/&gt;
-&lt;/Grid.RowDefinitions&gt;
-&lt;Grid.ColumnDefinitions&gt;
-	&lt;ColumnDefinition Width="Auto"/&gt;
-	&lt;ColumnDefinition Width="Auto"/&gt;
-	&lt;ColumnDefinition Width="Auto"/&gt;
-&lt;/Grid.ColumnDefinitions&gt;
+    &lt;Grid.RowDefinitions&gt;
+	    &lt;RowDefinition Height="Auto"/&gt;
+	    &lt;RowDefinition Height="Auto"/&gt;
+	    &lt;RowDefinition Height="Auto"/&gt;
+    &lt;/Grid.RowDefinitions&gt;
+    &lt;Grid.ColumnDefinitions&gt;
+	    &lt;ColumnDefinition Width="Auto"/&gt;
+	    &lt;ColumnDefinition Width="Auto"/&gt;
+	    &lt;ColumnDefinition Width="Auto"/&gt;
+    &lt;/Grid.ColumnDefinitions&gt;
 
-&lt;TextBlock Grid.Column="1" HorizontalAlignment="Center" Text="Column 1"/&gt;
-&lt;TextBlock Grid.Column="2" HorizontalAlignment="Center" Text="Column 2"/&gt;
+    &lt;TextBlock Grid.Column="1" HorizontalAlignment="Center" Text="Column 1"/&gt;
+    &lt;TextBlock Grid.Column="2" HorizontalAlignment="Center" Text="Column 2"/&gt;
 
-&lt;TextBlock Grid.Row="1" VerticalAlignment="Center" Text="Row 1"/&gt;
-&lt;Button Grid.Column="1" Grid.Row="1" Content="First stop" TabIndex="1" Width="100"/&gt;
-&lt;Button Grid.Column="2" Grid.Row="1" Content="Second stop" TabIndex="2" Width="100"/&gt;
+    &lt;TextBlock Grid.Row="1" VerticalAlignment="Center" Text="Row 1"/&gt;
+    &lt;Button Grid.Column="1" Grid.Row="1" Content="First stop" TabIndex="1" Width="100"/&gt;
+    &lt;Button Grid.Column="2" Grid.Row="1" Content="Second stop" TabIndex="2" Width="100"/&gt;
 
-&lt;TextBlock Grid.Row="2" VerticalAlignment="Center" Text="Row 2"/&gt;
-&lt;Button Grid.Column="1" Grid.Row="2" Content="Third stop" TabIndex="3" Width="100"/&gt;
-&lt;Button Grid.Column="2" Grid.Row="2" Content="Not a stop" IsTabStop="False" Width="100"/&gt;
+    &lt;TextBlock Grid.Row="2" VerticalAlignment="Center" Text="Row 2"/&gt;
+    &lt;Button Grid.Column="1" Grid.Row="2" Content="Third stop" TabIndex="3" Width="100"/&gt;
+    &lt;Button Grid.Column="2" Grid.Row="2" Content="Not a stop" IsTabStop="False" Width="100"/&gt;
 &lt;/Grid&gt;
                     </x:String>
             </core:ControlExample.Xaml>

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
@@ -49,11 +49,13 @@
 
         <RichTextBlock>
             <Paragraph>
-                To use the keyboard with a control, the control must have focus. The most common way to receive focus is via <Bold>Tab navigation</Bold> and the <Bold>Tab order</Bold>.
+                To use the keyboard with a control, the control must have focus. The most common way to receive focus is via <Bold>Tab navigation</Bold>, which cycles through controls that are
+                <Bold>tab stops</Bold>.
+                The order of these tab stops is called the <Bold>tab order</Bold>.
                 <LineBreak />
             </Paragraph>
             <Paragraph>
-                All interactive controls, like buttons, should have tab stops (unless they are in a group that's accessible in some other way), but non-interactive controls, like labels, should not.
+                All interactive controls, like buttons, should be tab stops (unless they are in a group that's accessible in some other way), but non-interactive controls, like labels, should not.
                 Try to put initial focus on the most useful or logical element.
                 <LineBreak />
             </Paragraph>
@@ -72,7 +74,7 @@
 
         <RichTextBlock>
             <Paragraph>
-                By default, tab order matches the order elements are defined in the XAML. This is usually the best order:
+                By default, tab order matches the order elements are defined in XAML. This is usually the best order:
             </Paragraph>
         </RichTextBlock>
 

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
@@ -235,6 +235,8 @@
             </Paragraph>
         </RichTextBlock>
 
+        <!-- BESTO: note to self. Why is WinUI not setting AutomationProperties.AcceleratorKey="Ctrl+G" properly? -->
+        
         <core:ControlExample>
             <core:ControlExample.Example>
                 <Grid ColumnSpacing="8" RowSpacing="8">
@@ -294,7 +296,7 @@
                         Grid.Row="2"
                         Grid.ColumnSpan="4"
                         Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="Using KeyboardAccelarator and the AutomationProperties.AcceleratorKey property to create a shortcut" />
+                        Text="Using the KeyboardAccelarator property to create an accelerator" />
                 </Grid>
             </core:ControlExample.Example>
 
@@ -317,7 +319,6 @@
 	Grid.ColumnSpan="3"/&gt;
 
 &lt;Button Click="MakeRedButton_Click" Content="Red" Grid.Row="1"
-	AutomationProperties.AcceleratorKey="R"
 	ToolTipService.ToolTip="Shortcut: Ctrl+R"&gt;
 	&lt;Button.KeyboardAccelerators&gt;
 		&lt;KeyboardAccelerator Modifiers="Control" Key="R" /&gt;
@@ -326,7 +327,6 @@
 	
 &lt;Button Click="MakeBlueButton_Click" Content="Blue"
 	Grid.Row="1" Grid.Column="1"
-	AutomationProperties.AcceleratorKey="B"
 	ToolTipService.ToolTip="Shortcut: Ctrl+B"&gt;
 	&lt;Button.KeyboardAccelerators&gt;
 		&lt;KeyboardAccelerator Modifiers="Control" Key="B" /&gt;
@@ -336,7 +336,6 @@
 &lt;!-- Including the hotkey in a custom tooltip --&gt;
 &lt;Button Click="MakeChartreuseButton_Click" Content="Chartreuse"
 	Grid.Row="1" Grid.Column="1"
-	AutomationProperties.AcceleratorKey="G"
 	ToolTipService.ToolTip="A greenish yellow (Ctrl+G)"&gt;
 	&lt;Button.KeyboardAccelerators&gt;
 		&lt;KeyboardAccelerator Modifiers="Control" Key="G" /&gt;
@@ -361,6 +360,76 @@ private void MakeChartreuseButton_Click(object sender, RoutedEventArgs e)
 }
                 </x:String>
             </core:ControlExample.CSharp>
+        </core:ControlExample>
+
+        <TextBlock
+            Margin="0,20,0,0"
+            Style="{ThemeResource BodyStrongTextBlockStyle}"
+            AutomationProperties.HeadingLevel="Level3"
+            Text="Access keys" />
+
+        <RichTextBlock>
+            <Paragraph>
+                Access keys are keyboard shortcuts, starting with Alt, that move system focus around your UI.
+                <LineBreak />
+            </Paragraph>
+            <Paragraph>
+                See
+                <Hyperlink
+                    NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/input/access-keys">Access keys</Hyperlink>.
+            </Paragraph>
+        </RichTextBlock>
+
+        <core:ControlExample>
+            <core:ControlExample.Example>
+                <StackPanel Orientation="Vertical">
+                    <MenuBar>
+                        <MenuBarItem Title="File" AccessKey="F">
+                            <MenuFlyoutItem Text="New" AccessKey="N" />
+                            <MenuFlyoutItem Text="Open..." AccessKey="O" />
+                            <MenuFlyoutItem Text="Save" AccessKey="S" />
+                            <MenuFlyoutItem Text="Exit" AccessKey="E" />
+                        </MenuBarItem>
+
+                        <MenuBarItem Title="Edit" AccessKey="E">
+                            <MenuFlyoutItem Text="Undo" AccessKey="U" />
+                            <MenuFlyoutItem Text="Cut" AccessKey="X" />
+                            <MenuFlyoutItem Text="Copy" AccessKey="C" />
+                            <MenuFlyoutItem Text="Paste" AccessKey="V" />
+                        </MenuBarItem>
+
+                        <MenuBarItem Title="Help" AccessKey="H">
+                            <MenuFlyoutItem Text="About" AccessKey="A" />
+                        </MenuBarItem>
+                    </MenuBar>
+                    <TextBlock
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="Using AccessKey to create access keys. Press and release Alt to display them." />
+                </StackPanel>
+            </core:ControlExample.Example>
+            <core:ControlExample.Xaml>
+                <x:String xml:space="preserve">
+&lt;MenuBar&gt;
+    &lt;MenuBarItem Title="File" AccessKey="F"&gt;
+        &lt;MenuFlyoutItem Text="New" AccessKey="N" /&gt;
+        &lt;MenuFlyoutItem Text="Open..." AccessKey="O" /&gt;
+        &lt;MenuFlyoutItem Text="Save" AccessKey="S" /&gt;
+        &lt;MenuFlyoutItem Text="Exit" AccessKey="E" /&gt;
+    &lt;/MenuBarItem&gt;
+
+    &lt;MenuBarItem Title="Edit" AccessKey="E"&gt;
+        &lt;MenuFlyoutItem Text="Undo" AccessKey="U" /&gt;
+        &lt;MenuFlyoutItem Text="Cut" AccessKey="X" /&gt;
+        &lt;MenuFlyoutItem Text="Copy" AccessKey="C" /&gt;
+        &lt;MenuFlyoutItem Text="Paste" AccessKey="V" /&gt;
+    &lt;/MenuBarItem&gt;
+
+    &lt;MenuBarItem Title="Help" AccessKey="H"&gt;
+        &lt;MenuFlyoutItem Text="About" AccessKey="A" /&gt;
+    &lt;/MenuBarItem&gt;
+&lt;/MenuBar&gt;
+                </x:String>
+            </core:ControlExample.Xaml>
         </core:ControlExample>
 
         <TextBlock

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
@@ -59,9 +59,9 @@
             </Paragraph>
             <Paragraph>
                 See
-                <Hyperlink NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/input/keyboard-interactions">Keyboard interactions</Hyperlink>
+                <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/input/keyboard-interactions">Keyboard interactions</Hyperlink>
                 and
-                <Hyperlink NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/accessibility/keyboard-accessibility">Keyboard accessibility</Hyperlink>.
+                <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/accessibility/keyboard-accessibility">Keyboard accessibility</Hyperlink>.
             </Paragraph>
         </RichTextBlock>
 
@@ -230,20 +230,20 @@
             <Paragraph>
                 See
                 <Hyperlink
-                    NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/input/keyboard-interactions#navigation">
+                    NavigateUri="https://learn.microsoft.com/windows/apps/design/input/keyboard-interactions#navigation">
                     Keyboard navigation
                 </Hyperlink>,
                 <Hyperlink
-                    NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/input/keyboard-interactions#home-and-end-keys">
+                    NavigateUri="https://learn.microsoft.com/windows/apps/design/input/keyboard-interactions#home-and-end-keys">
                     Home and End keys
                 </Hyperlink>,
                 <Hyperlink
-                    NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/input/keyboard-interactions#page-up-and-page-down-keys">
+                    NavigateUri="https://learn.microsoft.com/windows/apps/design/input/keyboard-interactions#page-up-and-page-down-keys">
                     Page up and Page down keys
                 </Hyperlink>,
                 and
                 <Hyperlink
-                    NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/input/keyboard-interactions#control-group">
+                    NavigateUri="https://learn.microsoft.com/windows/apps/design/input/keyboard-interactions#control-group">
                     Control group
                 </Hyperlink>.
             </Paragraph>
@@ -314,11 +314,11 @@
             <Paragraph>
                 See
                 <Hyperlink
-                    NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/input/focus-navigation">
+                    NavigateUri="https://learn.microsoft.com/windows/apps/design/input/focus-navigation">
                     Focus navigation for keyboard, gamepad, remote control, and accessibility tools
                 </Hyperlink> and
                 <Hyperlink
-                    NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/accessibility/keyboard-accessibility">
+                    NavigateUri="https://learn.microsoft.com/windows/apps/design/accessibility/keyboard-accessibility">
                     Keyboard accessibility
                 </Hyperlink>.
             </Paragraph>
@@ -437,7 +437,7 @@
             </Paragraph>
             <Paragraph>
                 See
-                <Hyperlink NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/input/keyboard-accelerators">Keyboard accelerators</Hyperlink>.
+                <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/input/keyboard-accelerators">Keyboard accelerators</Hyperlink>.
             </Paragraph>
         </RichTextBlock>
 
@@ -588,7 +588,7 @@ private void MakeChartreuseButton_Click(object sender, RoutedEventArgs e)
             <Paragraph>
                 See
                 <Hyperlink
-                    NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/input/access-keys">Access keys</Hyperlink>.
+                    NavigateUri="https://learn.microsoft.com/windows/apps/design/input/access-keys">Access keys</Hyperlink>.
             </Paragraph>
         </RichTextBlock>
 

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
@@ -118,41 +118,50 @@
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
 
                     <TextBlock
-                        Grid.Column="0"
+                        Grid.Column="1"
                         HorizontalAlignment="Center"
-                        Text="Front of check" />
+                        Text="Column 1" />
                     <TextBlock
-                        Grid.Column="1"
+                        Grid.Column="2"
                         HorizontalAlignment="Center"
-                        Text="Back of check" />
+                        Text="Column 2" />
 
-                    <TextBox
+                    <TextBlock
                         Grid.Row="1"
-                        Grid.Column="0"
-                        Width="250"
-                        PlaceholderText="Pay to the order of..."
-                        TabIndex="1" />
-                    <TextBox
+                        VerticalAlignment="Center"
+                        Text="Row 1" />
+                    <Button
                         Grid.Row="1"
                         Grid.Column="1"
+                        HorizontalAlignment="Stretch"
+                        Content="First stop"
+                        TabIndex="1" />
+                    <Button
+                        Grid.Row="1"
+                        Grid.Column="2"
                         Width="100"
-                        PlaceholderText="Signature"
+                        Content="Third stop"
                         TabIndex="3" />
 
-                    <TextBox
+                    <TextBlock
                         Grid.Row="2"
-                        Grid.Column="0"
-                        Width="250"
-                        PlaceholderText="Amount"
-                        TabIndex="2" />
+                        VerticalAlignment="Center"
+                        Text="Row 2" />
                     <Button
                         Grid.Row="2"
                         Grid.Column="1"
-                        Width="100"
-                        Content="(Not a stop)"
+                        HorizontalAlignment="Stretch"
+                        Content="Second stop"
+                        TabIndex="2" />
+                    <Button
+                        Grid.Row="2"
+                        Grid.Column="2"
+                        HorizontalAlignment="Stretch"
+                        Content="Not a stop"
                         IsTabStop="False" />
                 </Grid>
             </core:ControlExample.Example>
@@ -167,16 +176,19 @@
     &lt;Grid.ColumnDefinitions&gt;
 	    &lt;ColumnDefinition Width="Auto"/&gt;
 	    &lt;ColumnDefinition Width="Auto"/&gt;
+	    &lt;ColumnDefinition Width="Auto"/&gt;
     &lt;/Grid.ColumnDefinitions&gt;
 
     &lt;TextBlock Grid.Column="1" HorizontalAlignment="Center" Text="Column 1"/&gt;
     &lt;TextBlock Grid.Column="2" HorizontalAlignment="Center" Text="Column 2"/&gt;
 
-    &lt;TextBox Grid.Column="0" Grid.Row="1" PlaceholderText="Pay to the order of..." TabIndex="1" Width="250"/&gt;
-    &lt;TextBox Grid.Column="1" Grid.Row="1" PlaceholderText="Signature" TabIndex="3" Width="100"/&gt;
+    &lt;TextBlock Grid.Row="1" VerticalAlignment="Center" Text="Row 1"/&gt;
+    &lt;Button Grid.Column="1" Grid.Row="1" Content="First stop" TabIndex="1" HorizontalAlignment="Stretch"/&gt;
+    &lt;Button Grid.Column="2" Grid.Row="1" Content="Third stop" TabIndex="3" HorizontalAlignment="Stretch"/&gt;
 
-    &lt;TextBox Grid.Column="0" Grid.Row="2" PlaceholderText="Amount" TabIndex="2" Width="250"/&gt;
-    &lt;Button Grid.Column="1" Grid.Row="2" Content="(Not a stop)" IsTabStop="False" Width="100"/&gt;
+    &lt;TextBlock Grid.Row="2" VerticalAlignment="Center" Text="Row 2"/&gt;
+    &lt;Button Grid.Column="1" Grid.Row="2" Content="Second stop" TabIndex="2" HorizontalAlignment="Stretch"/&gt;
+    &lt;Button Grid.Column="2" Grid.Row="2" Content="Not a stop" IsTabStop="False" HorizontalAlignment="Stretch"/&gt;
 &lt;/Grid&gt;
                     </x:String>
             </core:ControlExample.Xaml>

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
@@ -308,7 +308,7 @@
                 Note that for true lists of items, users may expect additional affordances like
                 support for Home/End, PgUp/PgDn, and additional accessibility properties like
                 PositionInSet and SizeOfSet. Keyboard navigation can get complicated, but getting
-                it right can make your app a lot easier to use - for everyone.
+                it right can make your app a lot easier to use—for everyone.
                 <LineBreak />
             </Paragraph>
             <Paragraph>

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml.cs
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml.cs
@@ -30,5 +30,9 @@ namespace AppUIBasics.ControlPages
         {
             ColorRectangle.Fill = new SolidColorBrush(Colors.Blue);
         }
+        private void MakeChartreuseButton_Click(object sender, RoutedEventArgs e)
+        {
+            ColorRectangle.Fill = new SolidColorBrush(Colors.Chartreuse);
+        }
     }
 }

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityScreenReaderPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityScreenReaderPage.xaml
@@ -627,6 +627,14 @@ AutomationProperties.Name="Contacts"&gt;
             AutomationProperties.HeadingLevel="3"
             Text="Headings" />
 
+        <RichTextBlock>
+            <Paragraph>
+                <Bold>Headings</Bold> typically identify smaller groups of content.
+                They usually correspond to the "visual" headings in your UI—the text
+                that labels sections in your UI visually.
+            </Paragraph>
+        </RichTextBlock>
+
         <core:ControlExample>
             <core:ControlExample.Example>
                 <StackPanel HorizontalAlignment="Left">

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityScreenReaderPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityScreenReaderPage.xaml
@@ -472,7 +472,9 @@ AutomationProperties.Name="Contacts"&gt;
             Text="Landmarks and headings" />
         <RichTextBlock>
             <Paragraph>
-                <Bold>Landmarks and headings</Bold> indicate, or label, different sections of a user interface, just like visible headings would.
+                <Bold>Landmarks and headings</Bold> indicate, or label, different
+                sections of a user interface for screen readers and other
+                Assistive Technologies (ATs), just like visible headings do for visual users.
                 Marking up your content with landmarks and headings lets
                 screen reader users skim content similarly to sighted users.
                 <LineBreak />

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityScreenReaderPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityScreenReaderPage.xaml
@@ -279,7 +279,7 @@ AutomationProperties.Name="Contacts"&gt;
                 <LineBreak />
                 - Position in set
                 <LineBreak />
-                - Headings and landmarks (see <Bold>Keyboard navigation</Bold> page)
+                - Headings and landmarks (see below)
                 <LineBreak />
             </Paragraph>
             <Paragraph>
@@ -630,7 +630,7 @@ AutomationProperties.Name="Contacts"&gt;
         <RichTextBlock>
             <Paragraph>
                 <Bold>Headings</Bold> typically identify smaller groups of content.
-                They usually correspond to the "visual" headings in your UI—the text
+                They usually correspond to the "visual" headings in your UI — the text
                 that labels sections in your UI visually.
                 <LineBreak />
             </Paragraph>

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityScreenReaderPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityScreenReaderPage.xaml
@@ -68,8 +68,8 @@
                 <LineBreak />
             </Paragraph>
             <Paragraph>
-                See <Hyperlink NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/accessibility/basic-accessibility-information#accessible-name">Accessible name</Hyperlink>
-                and <Hyperlink NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/accessibility/basic-accessibility-information#name-from-inner-text">Name from inner text</Hyperlink>.
+                See <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/accessibility/basic-accessibility-information#accessible-name">Accessible name</Hyperlink>
+                and <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/accessibility/basic-accessibility-information#name-from-inner-text">Name from inner text</Hyperlink>.
             </Paragraph>
         </RichTextBlock>
 
@@ -284,9 +284,9 @@ AutomationProperties.Name="Contacts"&gt;
             </Paragraph>
             <Paragraph>
                 See
-                <Hyperlink NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/accessibility/basic-accessibility-information">Basic Accessibility Information</Hyperlink>
+                <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/accessibility/basic-accessibility-information">Basic Accessibility Information</Hyperlink>
                 and
-                <Hyperlink NavigateUri="https://learn.microsoft.com/en-us/accessibility-tools-docs/items/uwpxaml/control_fulldescription_describedby_helptext">UWP XAML: Setting supplemental information on an control</Hyperlink>.
+                <Hyperlink NavigateUri="https://learn.microsoft.com/accessibility-tools-docs/items/uwpxaml/control_fulldescription_describedby_helptext">UWP XAML: Setting supplemental information on an control</Hyperlink>.
             </Paragraph>
         </RichTextBlock>
 
@@ -421,7 +421,7 @@ AutomationProperties.Name="Contacts"&gt;
             </Paragraph>
             <Paragraph>
                 See
-                <Hyperlink NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/accessibility/basic-accessibility-information#influencing-the-ui-automation-tree-views">Influencing the UI Automation tree views
+                <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/accessibility/basic-accessibility-information#influencing-the-ui-automation-tree-views">Influencing the UI Automation tree views
                 </Hyperlink>.
             </Paragraph>
         </RichTextBlock>
@@ -480,7 +480,7 @@ AutomationProperties.Name="Contacts"&gt;
             <Paragraph>
                 See
                 <Hyperlink
-                    NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/accessibility/landmarks-and-headings">
+                    NavigateUri="https://learn.microsoft.com/windows/apps/design/accessibility/landmarks-and-headings">
                     Landmarks and headings
                 </Hyperlink>.
             </Paragraph>

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityScreenReaderPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityScreenReaderPage.xaml
@@ -68,8 +68,9 @@
                 <LineBreak />
             </Paragraph>
             <Paragraph>
-                See <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/accessibility/basic-accessibility-information#accessible-name">Accessible name</Hyperlink>
-                and <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/accessibility/basic-accessibility-information#name-from-inner-text">Name from inner text</Hyperlink>.
+                See
+                <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/accessibility/basic-accessibility-information#accessible-name">Expose basic accessibility information#Accessible name</Hyperlink>
+                and <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/accessibility/basic-accessibility-information#name-from-inner-text">Expose basic accessibility information#Name from inner text</Hyperlink>.
             </Paragraph>
         </RichTextBlock>
 
@@ -284,7 +285,7 @@ AutomationProperties.Name="Contacts"&gt;
             </Paragraph>
             <Paragraph>
                 See
-                <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/accessibility/basic-accessibility-information">Basic Accessibility Information</Hyperlink>
+                <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/accessibility/basic-accessibility-information">Expose basic accessibility information</Hyperlink>
                 and
                 <Hyperlink NavigateUri="https://learn.microsoft.com/accessibility-tools-docs/items/uwpxaml/control_fulldescription_describedby_helptext">UWP XAML: Setting supplemental information on an control</Hyperlink>.
             </Paragraph>
@@ -421,7 +422,8 @@ AutomationProperties.Name="Contacts"&gt;
             </Paragraph>
             <Paragraph>
                 See
-                <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/accessibility/basic-accessibility-information#influencing-the-ui-automation-tree-views">Influencing the UI Automation tree views
+                <Hyperlink
+                    NavigateUri="https://learn.microsoft.com/windows/apps/design/accessibility/basic-accessibility-information#influencing-the-ui-automation-tree-views">Expose basic accessibility information#Influencing the UI Automation tree views
                 </Hyperlink>.
             </Paragraph>
         </RichTextBlock>
@@ -767,9 +769,9 @@ AutomationProperties.Name="Contacts"&gt;
                                 Text="Shared with me"
                                 Style="{ThemeResource BodyStrongTextBlockStyle}" />
                             <ListView>
+                                <x:String>Valeria's cat</x:String>
                                 <x:String>Paul's winter vacation</x:String>
                                 <x:String>Cool street photography</x:String>
-                                <x:String>Valeria's cat</x:String>
                             </ListView>
                         </StackPanel>
                     </StackPanel>

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityScreenReaderPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityScreenReaderPage.xaml
@@ -210,7 +210,7 @@ AutomationProperties.Name="Contacts"&gt;
                     <RichTextBlock Style="{StaticResource ScreenReaderOutputStyle}">
                         <Paragraph>
                             The image above will be read out as
-                            <Bold>Grapes</Bold>. To navigate through elements that aren't focusable, use Caps + Left/Right arrow.
+                            <Bold>Grapes</Bold>. To navigate in Narrator through elements that aren't focusable, use Caps + Left/Right arrow.
                         </Paragraph>
                     </RichTextBlock>
                 </StackPanel>
@@ -505,7 +505,7 @@ AutomationProperties.Name="Contacts"&gt;
                         Margin="0,0,0,10"
                         HorizontalAlignment="Left"
                         Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="The sample below showcases landmarks. To navigate landmarks, press D or Shift+D while in Scan mode."
+                        Text="The sample below showcases landmarks. To navigate landmarks in Narrator, press D or Shift+D while in Scan mode."
                         TextWrapping="Wrap" />
                     <Grid>
                         <Grid.ColumnDefinitions>
@@ -646,9 +646,11 @@ AutomationProperties.Name="Contacts"&gt;
                         Margin="0,0,0,10"
                         HorizontalAlignment="Left"
                         Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="The sample below showcases headings. To navigate headings, press H or Shift+H while in Scan mode."
+                        Text="The sample below showcases headings. To navigate headings in Narrator, press H or Shift+H while in Scan mode."
                         TextWrapping="Wrap" />
-                    <StackPanel MaxWidth="500">
+                    <StackPanel
+                        MaxWidth="500"
+                        HorizontalAlignment="Left">
                         <!--  Here is the main header for the whole text. It gets HeadingLevel 1  -->
                         <TextBlock AutomationProperties.HeadingLevel="Level1" FontSize="26">Lorem ipsums</TextBlock>
                         <!--  The following TextBlock is the header for the standard lorem ipsum text, thus it is only HeadingLevel 2  -->
@@ -714,6 +716,89 @@ AutomationProperties.Name="Contacts"&gt;
             AutomationProperties.HeadingLevel="3"
             Text="Associating smaller groups of controls" />
 
-        
+        <RichTextBlock>
+            <Paragraph>
+                You can also group controls together manually, even if the
+                controls don't have a visible heading or landmark, by adding
+                an accessible name to the parent container. When entering a
+                region with a name or a landmark, Narrator will read it out as
+                <Bold>Context</Bold>. Narrator users can control their
+                <Bold>Context level</Bold> in Settings.
+                <LineBreak />
+            </Paragraph>
+            <Paragraph>
+                This is helpful in complicated UI with many similar elements,
+                where the grouping might be obvious to visual users, but not
+                screen reader users.
+            </Paragraph>
+        </RichTextBlock>
+
+        <core:ControlExample>
+            <core:ControlExample.Example>
+                <StackPanel Spacing="8">
+                    <TextBlock
+                        Style="{ThemeResource CaptionTextBlockStyle}">
+                        The sample below groups items using accessible names.
+                        Screen readers will read this as users navigate between
+                        different groups. To force read the current context in
+                        Narrator, press Caps+/.
+                    </TextBlock>
+                    <TextBlock
+                        Style="{ThemeResource CaptionTextBlockStyle}">
+                        Note how Narrator reads 'My albums' or 'Shared with me' if you
+                        tab between the ListViews, and reads the additional context
+                        'Album browser' when Caps+/ is pressed.
+                    </TextBlock>
+                    <StackPanel AutomationProperties.Name="Album browser">
+                        <StackPanel AutomationProperties.Name="My albums">
+                            <!-- These TextBlocks could reasonably be headings, too. -->
+                            <TextBlock
+                                Text="My albums"
+                                Style="{ThemeResource BodyStrongTextBlockStyle}" />
+                            <ListView>
+                                <x:String>Trip to Redmond</x:String>
+                                <x:String>Visiting Ben</x:String>
+                            </ListView>
+                        </StackPanel>
+                        <StackPanel AutomationProperties.Name="Shared with me">
+                            <TextBlock
+                                Text="Shared with me"
+                                Style="{ThemeResource BodyStrongTextBlockStyle}" />
+                            <ListView>
+                                <x:String>Paul's winter vacation</x:String>
+                                <x:String>Cool street photography</x:String>
+                                <x:String>Valeria's cat</x:String>
+                            </ListView>
+                        </StackPanel>
+                    </StackPanel>
+                </StackPanel>
+            </core:ControlExample.Example>
+            <core:ControlExample.Xaml>
+                <x:String xml:space="preserve">
+&lt;StackPanel AutomationProperties.Name="Album browser"&gt;
+    &lt;StackPanel AutomationProperties.Name="My albums"&gt;
+        &lt;!-- These TextBlocks could reasonably be headings, too. --&gt;
+        &lt;TextBlock
+            Text="My albums"
+            Style="{ThemeResource BodyStrongTextBlockStyle}" /&gt;
+        &lt;ListView&gt;
+            &lt;x:String&gt;Trip to Redmond&lt;/x:String&gt;
+            &lt;x:String&gt;Visiting Ben&lt;/x:String&gt;
+        &lt;/ListView&gt;
+    &lt;/StackPanel&gt;
+    &lt;StackPanel AutomationProperties.Name="Shared with me"&gt;
+        &lt;TextBlock
+            Text="Shared with me"
+            Style="{ThemeResource BodyStrongTextBlockStyle}" /&gt;
+        &lt;ListView&gt;
+            &lt;x:String&gt;Paul's winter vacation&lt;/x:String&gt;
+            &lt;x:String&gt;Cool street photography&lt;/x:String&gt;
+            &lt;x:String&gt;Valeria's cat&lt;/x:String&gt;
+        &lt;/ListView&gt;
+    &lt;/StackPanel&gt;
+&lt;/StackPanel&gt;
+                </x:String>
+            </core:ControlExample.Xaml>
+        </core:ControlExample>
     </StackPanel>
 </Page>

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityScreenReaderPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityScreenReaderPage.xaml
@@ -464,5 +464,242 @@ AutomationProperties.Name="Contacts"&gt;
                 </x:String>
             </core:ControlExample.Xaml>
         </core:ControlExample>
+
+        <TextBlock
+            Margin="0,20,0,0"
+            Style="{ThemeResource SubtitleTextBlockStyle}"
+            AutomationProperties.HeadingLevel="2"
+            Text="Landmarks and headings" />
+        <RichTextBlock>
+            <Paragraph>
+                <Bold>Landmarks and headings</Bold> indicate, or label, different sections of a user interface, just like visible headings would.
+                Marking up your content with landmarks and headings lets
+                screen reader users skim content similarly to sighted users.
+                <LineBreak />
+            </Paragraph>
+            <Paragraph>
+                See
+                <Hyperlink
+                    NavigateUri="https://learn.microsoft.com/en-us/windows/apps/design/accessibility/landmarks-and-headings">
+                    Landmarks and headings
+                </Hyperlink>.
+            </Paragraph>
+        </RichTextBlock>
+
+        <TextBlock
+            Margin="0,20,0,0"
+            Style="{ThemeResource SubtitleTextBlockStyle}"
+            AutomationProperties.HeadingLevel="3"
+            Text="Landmarks" />
+
+        <RichTextBlock>
+            <Paragraph>
+                <Bold>Landmarks</Bold> typically identify big sections of your UI, like "search", "main content", or "navigation." You can also add landmarks with custom names.
+            </Paragraph>
+        </RichTextBlock>
+
+        <core:ControlExample>
+            <core:ControlExample.Example>
+                <StackPanel>
+                    <TextBlock
+                        Margin="0,0,0,10"
+                        HorizontalAlignment="Left"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="The sample below showcases landmarks."
+                        TextWrapping="Wrap" />
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="200" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="200" />
+                        </Grid.ColumnDefinitions>
+
+                        <!--  The navigation pane for our app  -->
+                        <StackPanel
+                            Grid.Column="0"
+                            Spacing="8"
+                            Padding="6"
+                            Background="{ThemeResource CardStrokeColorDefaultBrush}"
+                            CornerRadius="{StaticResource ControlCornerRadius}"
+                            AutomationProperties.LandmarkType="Navigation">
+                            <AutoSuggestBox
+                                PlaceholderText="Search"
+                                AutomationProperties.LandmarkType="Search"/>
+                            <Button Content="Open settings" />
+                        </StackPanel>
+
+                        <!--  The main content of our app  -->
+                        <StackPanel
+                            Grid.Column="1"
+                            Padding="6"
+                            AutomationProperties.LandmarkType="Main">
+                            <TextBlock TextWrapping="WrapWholeWords">
+                                Loren ipsum dolor sit anet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                                Ut enim ad minim venian, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea cannodo consequat.
+                                Duis aute irure dolor in reprehenderit in voluptate velit esse cilium dolore eu fugiat nulla pariatur.
+                                Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborun
+                            </TextBlock>
+                        </StackPanel>
+
+                        <!-- A custom sidebar with a custom landmark name -->
+                        <StackPanel
+                            Grid.Column="2"
+                            Padding="6"
+                            Background="{ThemeResource CardStrokeColorDefaultBrush}"
+                            CornerRadius="{StaticResource ControlCornerRadius}"
+                            Spacing="8"
+                            AutomationProperties.LandmarkType="Custom"
+                            AutomationProperties.LocalizedLandmarkType="Current viewers">
+                            <TextBlock
+                                Text="Current viewers"
+                                Style="{ThemeResource BodyStrongTextBlockStyle}"
+                                AutomationProperties.HeadingLevel="Level1" />
+                            <TextBlock
+                                Text="(No other users viewing)"
+                                Style="{ThemeResource BodyTextBlockStyle}"
+                                FontStyle="Italic" />
+                        </StackPanel>
+                    </Grid>
+                </StackPanel>
+            </core:ControlExample.Example>
+            <core:ControlExample.Xaml>
+                <x:String xml:space="preserve">
+&lt;Grid&gt;
+    &lt;Grid.ColumnDefinitions&gt;
+        &lt;ColumnDefinition Width="200" /&gt;
+        &lt;ColumnDefinition Width="*" /&gt;
+        &lt;ColumnDefinition Width="200" /&gt;
+    &lt;/Grid.ColumnDefinitions&gt;
+
+    &lt;!--  The navigation pane for our app  --&gt;
+    &lt;StackPanel
+        Grid.Column="0"
+        Spacing="8"
+        Padding="6"
+        Background="{ThemeResource CardStrokeColorDefaultBrush}"
+        CornerRadius="{StaticResource ControlCornerRadius}"
+        AutomationProperties.LandmarkType="Navigation"&gt;
+        &lt;AutoSuggestBox
+            PlaceholderText="Search"
+            AutomationProperties.LandmarkType="Search"/&gt;
+        &lt;Button Content="Open settings" /&gt;
+    &lt;/StackPanel&gt;
+
+    &lt;!--  The main content of our app  --&gt;
+    &lt;StackPanel
+        Grid.Column="1"
+        Padding="6"
+        AutomationProperties.LandmarkType="Main"&gt;
+        &lt;TextBlock TextWrapping="WrapWholeWords"&gt;
+            Loren ipsum dolor sit anet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            Ut enim ad minim venian, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea cannodo consequat.
+            Duis aute irure dolor in reprehenderit in voluptate velit esse cilium dolore eu fugiat nulla pariatur.
+            Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborun
+        &lt;/TextBlock&gt;
+    &lt;/StackPanel&gt;
+
+    &lt;!-- A custom sidebar with a custom landmark name --&gt;
+    &lt;StackPanel
+        Grid.Column="2"
+        Padding="6"
+        Background="{ThemeResource CardStrokeColorDefaultBrush}"
+        CornerRadius="{StaticResource ControlCornerRadius}"
+        Spacing="8"
+        AutomationProperties.LandmarkType="Custom"
+        AutomationProperties.LocalizedLandmarkType="Current viewers"&gt;
+        &lt;TextBlock
+            Text="Current viewers"
+            Style="{ThemeResource BodyStrongTextBlockStyle}"
+            AutomationProperties.HeadingLevel="Level1" /&gt;
+        &lt;TextBlock
+            Text="(No other users viewing)"
+            Style="{ThemeResource BodyTextBlockStyle}"
+            FontStyle="Italic" /&gt;
+    &lt;/StackPanel&gt;
+&lt;/Grid&gt;
+                    </x:String>
+            </core:ControlExample.Xaml>
+        </core:ControlExample>
+
+        <TextBlock
+            Margin="0,20,0,0"
+            Style="{ThemeResource SubtitleTextBlockStyle}"
+            AutomationProperties.HeadingLevel="3"
+            Text="Headings" />
+
+        <core:ControlExample>
+            <core:ControlExample.Example>
+                <StackPanel HorizontalAlignment="Left">
+                    <TextBlock
+                        Margin="0,0,0,10"
+                        HorizontalAlignment="Left"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="The sample below showcases headings."
+                        TextWrapping="Wrap" />
+                    <StackPanel MaxWidth="500">
+                        <!--  Here is the main header for the whole text. It gets HeadingLevel 1  -->
+                        <TextBlock AutomationProperties.HeadingLevel="Level1" FontSize="26">Lorem ipsums</TextBlock>
+                        <!--  The following TextBlock is the header for the standard lorem ipsum text, thus it is only HeadingLevel 2  -->
+                        <TextBlock AutomationProperties.HeadingLevel="Level2" FontSize="22">Lorem ipsum</TextBlock>
+                        <TextBlock TextWrapping="WrapWholeWords">
+                            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                            Pellentesque feugiat velit pulvinar, vehicula nisi at, molestie risus.
+                            Duis consequat auctor libero vitae consectetur. Nullam efficitur euismod lacinia.
+                        </TextBlock>
+
+                        <TextBlock AutomationProperties.HeadingLevel="Level2" FontSize="22">Cat ipsum</TextBlock>
+                        <!--  This is the header for the standard cat ipsum section, which is hierarchically below the cat ipsum header, resulting in HeadingLevel 3  -->
+                        <TextBlock AutomationProperties.HeadingLevel="3" FontSize="18">Standard</TextBlock>
+                        <TextBlock TextWrapping="WrapWholeWords">
+                            Mice litter kitter kitty litty little kitten big roar roar feed me
+                            but i will ruin the couch with my claws and hunt by meowing loudly at 5am next to human.
+                        </TextBlock>
+                        <TextBlock AutomationProperties.HeadingLevel="3" FontSize="18">Cat breeds</TextBlock>
+                        <TextBlock TextWrapping="WrapWholeWords">
+                            Tabby abyssinian for jaguar. Thai russian blue and ragdoll, ocicat.
+                            Mouser puma so american bobtail for donskoy balinese . Scottish fold manx so siamese.
+                        </TextBlock>
+
+                        <TextBlock AutomationProperties.HeadingLevel="2" FontSize="22">Bacon ipsum</TextBlock>
+                        <TextBlock TextWrapping="WrapWholeWords">
+                            Bacon ipsum dolor amet meatball nulla labore,
+                            tempor sirloin chicken frankfurter tail drumstick ex cupim ground round.
+                        </TextBlock>
+                    </StackPanel>
+                </StackPanel>
+            </core:ControlExample.Example>
+            <core:ControlExample.Xaml>
+                <x:String xml:space="preserve">
+&lt;StackPanel MaxWidth="500"&gt;
+&lt;!-- Here is the main header for the whole text. It gets HeadingLevel 1 --&gt;
+&lt;TextBlock AutomationProperties.HeadingLevel="Level1" FontSize="26"&gt;Lorem ipsums&lt;/TextBlock&gt;
+&lt;!-- The following TextBlock is the header for the standard lorem ipsum text, thus it is only HeadingLevel 2--&gt;
+&lt;TextBlock AutomationProperties.HeadingLevel="Level2" FontSize="22"&gt;Lorem ipsum&lt;/TextBlock&gt;
+&lt;TextBlock TextWrapping="WrapWholeWords"&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
+                Pellentesque feugiat velit pulvinar, vehicula nisi at, molestie risus. 
+                Duis consequat auctor libero vitae consectetur. Nullam efficitur euismod lacinia.&lt;/TextBlock&gt;
+    
+&lt;TextBlock AutomationProperties.HeadingLevel="Level2" FontSize="22"&gt;Cat ipsum&lt;/TextBlock&gt;
+&lt;!-- This is the header for the standard cat ipsum section, which is hierarchically below the cat ipsum header, resulting in HeadingLevel 3 --&gt;
+&lt;TextBlock AutomationProperties.HeadingLevel="3" FontSize="18"&gt;Standard&lt;/TextBlock&gt;
+&lt;TextBlock TextWrapping="WrapWholeWords">Mice litter kitter kitty litty little kitten big roar roar feed me 
+                but i will ruin the couch with my claws and hunt by meowing loudly at 5am next to human.&lt;/TextBlock&gt;
+&lt;TextBlock AutomationProperties.HeadingLevel="3" FontSize="18"&gt;Cat breeds&lt;/TextBlock&gt;
+&lt;TextBlock TextWrapping="WrapWholeWords">Tabby abyssinian for jaguar. Thai russian blue and ragdoll, ocicat. 
+                Mouser puma so american bobtail for donskoy balinese . Scottish fold manx so siamese.&lt;/TextBlock&gt;
+    
+&lt;TextBlock AutomationProperties.HeadingLevel="2" FontSize="22"&gt;Bacon ipsum&lt;/TextBlock&gt;
+&lt;TextBlock TextWrapping="WrapWholeWords">Bacon ipsum dolor amet meatball nulla labore, 
+                tempor sirloin chicken frankfurter tail drumstick ex cupim ground round.&lt;/TextBlock&gt;
+&lt;/StackPanel&gt;
+                </x:String>
+            </core:ControlExample.Xaml>
+        </core:ControlExample>
+
+        <TextBlock
+            Margin="0,20,0,0"
+            Style="{ThemeResource SubtitleTextBlockStyle}"
+            AutomationProperties.HeadingLevel="3"
+            Text="Associating smaller groups of controls" />
     </StackPanel>
 </Page>

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityScreenReaderPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityScreenReaderPage.xaml
@@ -505,7 +505,7 @@ AutomationProperties.Name="Contacts"&gt;
                         Margin="0,0,0,10"
                         HorizontalAlignment="Left"
                         Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="The sample below showcases landmarks."
+                        Text="The sample below showcases landmarks. To navigate landmarks, press D or Shift+D while in Scan mode."
                         TextWrapping="Wrap" />
                     <Grid>
                         <Grid.ColumnDefinitions>
@@ -632,6 +632,10 @@ AutomationProperties.Name="Contacts"&gt;
                 <Bold>Headings</Bold> typically identify smaller groups of content.
                 They usually correspond to the "visual" headings in your UI—the text
                 that labels sections in your UI visually.
+                <LineBreak />
+            </Paragraph>
+            <Paragraph>
+                For example, all of the section headings on this page are accessible headings.
             </Paragraph>
         </RichTextBlock>
 
@@ -642,7 +646,7 @@ AutomationProperties.Name="Contacts"&gt;
                         Margin="0,0,0,10"
                         HorizontalAlignment="Left"
                         Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="The sample below showcases headings."
+                        Text="The sample below showcases headings. To navigate headings, press H or Shift+H while in Scan mode."
                         TextWrapping="Wrap" />
                     <StackPanel MaxWidth="500">
                         <!--  Here is the main header for the whole text. It gets HeadingLevel 1  -->
@@ -709,5 +713,7 @@ AutomationProperties.Name="Contacts"&gt;
             Style="{ThemeResource SubtitleTextBlockStyle}"
             AutomationProperties.HeadingLevel="3"
             Text="Associating smaller groups of controls" />
+
+        
     </StackPanel>
 </Page>

--- a/WinUIGallery/DataModel/ControlInfoData.json
+++ b/WinUIGallery/DataModel/ControlInfoData.json
@@ -132,8 +132,28 @@
               "Uri": "https://learn.microsoft.com/windows/apps/design/accessibility/accessibility"
             },
             {
+              "Title": "Accessibility overview",
+              "Uri": "https://learn.microsoft.com/windows/apps/design/accessibility/accessibility-overview"
+            },
+            {
               "Title": "Keyboard accessibility",
               "Uri": "https://learn.microsoft.com/windows/apps/design/accessibility/keyboard-accessibility"
+            },
+            {
+              "Title": "Keyboard interactions",
+              "Uri": "https://learn.microsoft.com/windows/apps/design/input/keyboard-interactions"
+            },
+            {
+              "Title": "Access keys",
+              "Uri": "https://learn.microsoft.com/windows/apps/design/input/access-keys"
+            },
+            {
+              "Title": "Keyboard accelerators",
+              "Uri": "https://learn.microsoft.com/windows/apps/design/input/keyboard-accelerators"
+            },
+            {
+              "Title": "Focus navigation for keyboard, gamepad, remote control, and accessibility tools",
+              "Uri": "https://learn.microsoft.com/windows/apps/design/input/focus-navigation"
             },
             {
               "Title": "Automation Properties - API",
@@ -160,8 +180,24 @@
               "Uri": "https://learn.microsoft.com/windows/apps/design/accessibility/accessibility"
             },
             {
+              "Title": "Accessibility overview",
+              "Uri": "https://learn.microsoft.com/windows/apps/design/accessibility/accessibility-overview"
+            },
+            {
+              "Title": "Expose basic accessibility information",
+              "Uri": "https://learn.microsoft.com/windows/apps/design/accessibility/basic-accessibility-information"
+            },
+            {
+              "Title": "Landmarks and Headings",
+              "Uri": "https://learn.microsoft.com/windows/apps/design/accessibility/landmarks-and-headings"
+            },
+            {
               "Title": "Accessible text requirements",
               "Uri": "https://learn.microsoft.com/windows/apps/design/accessibility/accessible-text-requirements"
+            },
+            {
+              "Title": "Complete guide to Narrator",
+              "Uri": "https://support.microsoft.com/windows/complete-guide-to-narrator-e4397a0d-ef4f-b386-d8ae-c172f109bdb1"
             }
           ],
           "RelatedControls": []


### PR DESCRIPTION
Today, our **Keyboard support** section does not include information about access keys or arrow keys, and doesn't have much documentation about default behavior or reference documents. This change adds guidance for access keys, arrow keys, and more, and documents the expected and default behavior for many of them.

Fixes #1229
Fixes #1225 
Fixes #1226

## Description

* Tab order
    * Added example of default behavior.
    * Clarified guidance & added documentation links.
    * Updated manual tab order example to differ from default behavior.
* Arrow keys
    * Added arrow keys section, with default example and custom example using `XYFocusKeyboardNavigation`.
    * Documented common expectations for arrow keys, like Home/End, PgUp/PgDn, and PosInSet/SizeOfSet.
* Accelerators
    * Demonstrate the default tooltip for keyboard accelerators.
    * Add an example with a custom tooltip.
* Access keys
   * Added an example of access keys, plus documentation.
* Landmarks & headings
    * Moved to Screen reader section, since it has no effect on Keyboard.
    * Added references for understanding headings & landmarks.
    * Added example with custom landmarks.
    * Documented "Narrator contexts", or how Narrator will read controls within named accessible groups.

## Motivation and Context

This addresses documentation gaps in our keyboard examples. Hopefully it will lead folks to design more keyboard-accessible UI.

## How Has This Been Tested?

Deployed locally.

* [ ] Narrator correctly narrates new content.
* [ ] Keyboard examples work as described.
* [ ] Links work
* [ ] Why aren't accelerator keys correctly setting the UIA `AcceleratorKey` property?

## Screenshots (if appropriate):

### Keyboard page

<img width="962" alt="pg 1 of keyboard" src="https://user-images.githubusercontent.com/432939/232641928-bc67dd01-7ad6-4654-afce-214b518c572d.png">

![pg 2 of keyboard](https://user-images.githubusercontent.com/432939/232641976-490d446f-c8bb-45c6-879f-0494db9e2a8d.png)

![pg 3 of keyboard](https://user-images.githubusercontent.com/432939/232642042-5a6c9063-0c4f-4805-accd-849f95a0a981.png)

### Screen reader page

![pg 1 of screen reader ](https://user-images.githubusercontent.com/432939/232642084-d5c38d6e-3b0a-4872-a175-27451df45bd2.png)
<img width="964" alt="pg 2 of screen reader" src="https://user-images.githubusercontent.com/432939/232642115-a7c7280c-4d24-4ef0-9f47-ca47efc7fc05.png">


## Types of changes
- [X] New feature (non-breaking change which adds functionality)