### PR TITLE
Display Windows App SDK and Runtime version info

### DIFF
--- a/WinUIGallery/App.xaml
+++ b/WinUIGallery/App.xaml
@@ -69,7 +69,6 @@
 
             <x:String x:Key="ControlsName">All samples</x:String>
             <x:String x:Key="AppTitleName">WinUI 3 Gallery</x:String>
-            <x:String x:Key="WinUIVersion">WinAppSDK 1.3</x:String>
 
             <Style
                 x:Key="OutputTextBlockStyle"

--- a/WinUIGallery/App.xaml.cs
+++ b/WinUIGallery/App.xaml.cs
@@ -24,6 +24,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
 using WinUIGallery.DesktopWap.DataModel;
+using WASDK = Microsoft.WindowsAppSDK;
 
 namespace AppUIBasics
 {
@@ -32,8 +33,25 @@ namespace AppUIBasics
     /// </summary>
     sealed partial class App : Application
     {
-
         private static Window startupWindow;
+
+        public static string WinAppSdkDetails
+        {
+            get => string.Format("Windows App SDK {0}.{1}.{2}{3}",
+                WASDK.Release.Major, WASDK.Release.Minor, WASDK.Release.Patch, WASDK.Release.FormattedVersionTag);
+        }
+
+        public static string WinAppSdkRuntimeDetails
+        {
+            get
+            {
+                var details = WinAppSdkDetails;
+#if WindowsAppSdkRuntimeDependent
+                details += ", Windows App Runtime " + WASDK.Runtime.Version.DotQuadString;
+#endif
+                return details;
+            }
+        }
 
         // Get the initial window created for this app
         // On UWP, this is simply Window.Current

--- a/WinUIGallery/NewControlsPage.xaml
+++ b/WinUIGallery/NewControlsPage.xaml
@@ -78,7 +78,7 @@
                         <TextBlock
                             x:Name="smallHeaderSubtitleText"
                             FontSize="18"
-                            Text="{StaticResource WinUIVersion}" />
+                            Text="{x:Bind WinAppSdkDetails}" />
                         <TextBlock
                             x:Name="smallHeaderText"
                             Style="{StaticResource TitleLargeTextBlockStyle}"

--- a/WinUIGallery/NewControlsPage.xaml.cs
+++ b/WinUIGallery/NewControlsPage.xaml.cs
@@ -22,6 +22,8 @@ namespace AppUIBasics
             this.InitializeComponent();
         }
 
+        public string WinAppSdkDetails => App.WinAppSdkDetails;
+
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             NavigationRootPageArgs args = (NavigationRootPageArgs)e.Parameter;

--- a/WinUIGallery/SettingsPage.xaml
+++ b/WinUIGallery/SettingsPage.xaml
@@ -152,7 +152,6 @@
                                 <HyperlinkButton Content="Windows Community Toolkit" NavigateUri="https://github.com/CommunityToolkit/WindowsCommunityToolkit" />
                                 <HyperlinkButton Content="ColorCode-Universal" NavigateUri="https://github.com/WilliamABradley/ColorCode-Universal" />
                                 <HyperlinkButton Content="Win2D" NavigateUri="https://github.com/Microsoft/Win2D" />
-                                <HyperlinkButton Content="Xaml Behaviors" NavigateUri="https://github.com/Microsoft/XamlBehaviors" />
                             </StackPanel>
                         </labs:SettingsCard>
                         <labs:SettingsCard

--- a/WinUIGallery/SettingsPage.xaml
+++ b/WinUIGallery/SettingsPage.xaml
@@ -117,7 +117,7 @@
 
                 <!--  About  -->
                 <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="About" />
-                <labs:SettingsExpander Description="© 2023 Microsoft. All rights reserved." Header="WinUI Gallery">
+                <labs:SettingsExpander Description="© 2023 Microsoft. All rights reserved." Header="{StaticResource AppTitleName}">
                     <labs:SettingsExpander.HeaderIcon>
                         <BitmapIcon ShowAsMonochrome="False" UriSource="/Assets/Tiles/SmallTile-sdk.png" />
                     </labs:SettingsExpander.HeaderIcon>
@@ -147,6 +147,7 @@
                             ContentAlignment="Vertical"
                             Header="Dependencies &amp; references">
                             <StackPanel Margin="-12,0,0,0" Orientation="Vertical">
+                                <HyperlinkButton Content="{x:Bind WinAppSdkRuntimeDetails}" NavigateUri="https://aka.ms/windowsappsdk" />
                                 <HyperlinkButton Content="Windows UI Library" NavigateUri="https://aka.ms/winui" />
                                 <HyperlinkButton Content="Windows Community Toolkit" NavigateUri="https://github.com/CommunityToolkit/WindowsCommunityToolkit" />
                                 <HyperlinkButton Content="ColorCode-Universal" NavigateUri="https://github.com/WilliamABradley/ColorCode-Universal" />

--- a/WinUIGallery/SettingsPage.xaml.cs
+++ b/WinUIGallery/SettingsPage.xaml.cs
@@ -38,6 +38,8 @@ namespace AppUIBasics
             }
         }
 
+        public string WinAppSdkRuntimeDetails => App.WinAppSdkRuntimeDetails;
+
         public SettingsPage()
         {
             this.InitializeComponent();

--- a/WinUIGallery/WinUIGallery.DesktopWap.csproj
+++ b/WinUIGallery/WinUIGallery.DesktopWap.csproj
@@ -4,7 +4,8 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>$(SamplesTargetFrameworkMoniker)</TargetFramework>
-    <DefineConstants>MSIX</DefineConstants>
+    <DefineConstants>$(DefineConstants);MSIX</DefineConstants>
+    <DefineConstants Condition="'$(WindowsAppSdkSelfContained)'==''">$(DefineConstants);WindowsAppSdkRuntimeDependent</DefineConstants>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
     <NoWarn>8305</NoWarn>
@@ -68,6 +69,9 @@
 
   <ItemGroup>
     <PRIResource Include="Strings\en-US\Resources.resw" />
+
+    <!--Include package/runtime version numbers-->
+    <Compile Include="$(MicrosoftWindowsAppSDKPackageDir)include\WindowsAppSDK-VersionInfo.cs" />
 
     <Compile Remove="CollectionsInterop.cs" />
     <Compile Remove="Behaviors\ImageScrollBehavior.cs" />
@@ -193,4 +197,16 @@
     </Page>
   </ItemGroup>
   <Import Project="ContentIncludes.props" />
+
+  <!-- Work around: WindowsAppSDK 1.3 distributed Microsoft.WindowsAppRuntime.Release.Net.dll,
+    causing duplicate type errors. -->
+  <Target Name="RemoveWindowsAppRuntimeReleaseNet"
+        Returns="@(ReferencePath)"
+        AfterTargets="ResolveAssemblyReferences">
+    <ItemGroup>
+      <FileToRemove Include="@(ReferencePath)" Condition="'%(Filename)' == 'Microsoft.WindowsAppRuntime.Release.Net'" />
+      <ReferencePath Remove="@(FileToRemove)"/>
+    </ItemGroup>
+  </Target>
+  
 </Project>


### PR DESCRIPTION
Uses auto-init bootstrapper version info contained in WindowsAppSDK-VersionInfo.cs to generate version strings for Home and Settings pages.  This also demonstrates how app developers can use version info for other purposes.