### PR TITLE
Make the version info show MSIX package version

### DIFF
--- a/WinUIGallery/SettingsPage.xaml.cs
+++ b/WinUIGallery/SettingsPage.xaml.cs
@@ -33,7 +33,7 @@ namespace AppUIBasics
         {
             get
             {
-                var version = System.Reflection.Assembly.GetEntryAssembly().GetName().Version;
+                var version = Windows.ApplicationModel.Package.Current.Id.Version;
                 return string.Format("{0}.{1}.{2}.{3}", version.Major, version.Minor, version.Build, version.Revision);
             }
         }

--- a/WinUIGallery/WinUIGallery.DesktopWap.csproj
+++ b/WinUIGallery/WinUIGallery.DesktopWap.csproj
@@ -29,8 +29,8 @@
        in the WinUI repo, or the next ItemGroup below when standalone. -->
   <ItemGroup>
     <PackageReference Include="ColorCode.Core" />
-    <PackageReference Include="CommunityToolkit.Labs.WinUI.SegmentedControl" Version="0.0.2" />
-    <PackageReference Include="CommunityToolkit.Labs.WinUI.SettingsControls" Version="0.0.16" />
+    <PackageReference Include="CommunityToolkit.Labs.WinUI.SegmentedControl" Version="0.0.3" />
+    <PackageReference Include="CommunityToolkit.Labs.WinUI.SettingsControls" Version="0.0.18" />
     <PackageReference Include="CommunityToolkit.WinUI.UI" Version="7.1.2" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Animations" Version="7.1.2" />
     <PackageReference Include="Microsoft.Graphics.Win2D" />
@@ -48,7 +48,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(IsInWinUIRepo)' != 'true'">
     <PackageReference Remove="ColorCode.Core" />
-    <PackageReference Include="ColorCode.WinUI" Version="$(ColorCodeVersion)" />
+    <PackageReference Include="ColorCode.WinUI" Version="2.0.14" />
     <PackageReference Update="Microsoft.Graphics.Win2D" Version="$(GraphicsWin2DVersion)" />
     <PackageReference Update="Microsoft.VCRTForwarders.140" Version="1.0.6" />
     <PackageReference Update="Microsoft.WinUI" Version="$(WinUIPackageVersion)" Condition="'$(WinUIPackageVersion)' != ''" />
@@ -200,12 +200,10 @@
 
   <!-- Work around: WindowsAppSDK 1.3 distributed Microsoft.WindowsAppRuntime.Release.Net.dll,
     causing duplicate type errors. -->
-  <Target Name="RemoveWindowsAppRuntimeReleaseNet"
-        Returns="@(ReferencePath)"
-        AfterTargets="ResolveAssemblyReferences">
+  <Target Name="RemoveWindowsAppRuntimeReleaseNet" Returns="@(ReferencePath)" AfterTargets="ResolveAssemblyReferences">
     <ItemGroup>
       <FileToRemove Include="@(ReferencePath)" Condition="'%(Filename)' == 'Microsoft.WindowsAppRuntime.Release.Net'" />
-      <ReferencePath Remove="@(FileToRemove)"/>
+      <ReferencePath Remove="@(FileToRemove)" />
     </ItemGroup>
   </Target>
   


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Make the app's version info show the MSIX package version instead of assembly version.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I hope the app show the MSIX package version to reflect the version info in Microsoft Store.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with VS2022 on Windows 11 build 25357.
## Screenshots (if appropriate):
none
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
