### PR TITLE
[A11y] Increasing MinWidth of color textbox

### DIFF
--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityColorContrastPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityColorContrastPage.xaml
@@ -38,7 +38,7 @@
         <RichTextBlock>
             <Paragraph>
                 Accessibility is about building experiences that make your Windows application usable by people of
-                all abilities. For more information about designing accessible apps: <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/accessibility/accessibility-overview">Accessibility overview</Hyperlink>
+                all abilities. For more information about designing accessible apps:<Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/accessibility/accessibility-overview">Accessibility overview</Hyperlink>
                 .<LineBreak />
                 <LineBreak />
                 To ensure optimal accessibility and usability, apps should strive to use high-contrast and easy-to-
@@ -46,7 +46,7 @@
                 visual acuity, but this will also ensure visibility and legibility under a wide range of lighting
                 conditions, screens, and device settings.<LineBreak />
                 <LineBreak />
-                Check out the <Hyperlink NavigateUri="https://accessibilityinsights.io/">Accessibility Insights</Hyperlink>
+                Check out the<Hyperlink NavigateUri="https://accessibilityinsights.io/">Accessibility Insights</Hyperlink>
                 app to help you find and fix accessibility issues in your Windows apps.</Paragraph>
 
         </RichTextBlock>
@@ -64,7 +64,7 @@
             Padding="8"
             Background="{ThemeResource CardStrokeColorDefaultBrush}"
             ColumnSpacing="8"
-            CornerRadius="4"
+            CornerRadius="{StaticResource ControlCornerRadius}"
             RowSpacing="8">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
@@ -81,7 +81,8 @@
             <TextBlock
                 Grid.Row="0"
                 Grid.Column="0"
-                Margin="10,10,0,0"
+                Margin="12,0,0,0"
+                VerticalAlignment="Bottom"
                 Style="{ThemeResource BodyStrongTextBlockStyle}"
                 Text="Text color" />
 
@@ -89,35 +90,34 @@
                 x:Name="TextColorPicker"
                 Grid.Row="1"
                 Grid.Column="0"
-                Width="160"
-                Margin="10,0,0,10"
+                Margin="12,0,0,12"
                 ColorChanged="TextColorPicker_ColorChanged"
                 Color="Black" />
 
             <TextBlock
                 Grid.Row="0"
                 Grid.Column="1"
-                Margin="10,10,0,0"
+                Margin="12,10,0,0"
                 Style="{ThemeResource BodyStrongTextBlockStyle}"
                 Text="Background color" />
             <controls1:InlineColorPicker
                 x:Name="BackgroundColorPicker"
                 Grid.Row="1"
                 Grid.Column="1"
-                Width="160"
-                Margin="10,0,0,10"
+                Margin="12,0,0,12"
                 ColorChanged="BackgroundColorPicker_ColorChanged" />
 
             <TextBlock
                 Grid.Column="3"
-                Margin="10,10,0,0"
+                Margin="12,0,0,0"
+                VerticalAlignment="Bottom"
                 Style="{ThemeResource BodyStrongTextBlockStyle}"
                 Text="Contrast Ratio" />
             <TextBlock
                 x:Name="ContrastRatioPresenter"
                 Grid.Row="1"
                 Grid.Column="3"
-                Margin="10,0,0,10"
+                Margin="12,0,0,0"
                 Style="{ThemeResource SubtitleTextBlockStyle}"
                 Text="21:1" />
 
@@ -125,8 +125,8 @@
                 Grid.Row="2"
                 Grid.ColumnSpan="4"
                 MinHeight="300"
-                Margin="10,0,10,10"
-                CornerRadius="4">
+                Margin="12,0,12,12"
+                CornerRadius="{StaticResource ControlCornerRadius}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="*" />
@@ -150,7 +150,7 @@
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
 
-                    <Grid Margin="10,0,0,0">
+                    <Grid Margin="12,0,0,0">
                         <Ellipse
                             x:Name="NormalTextCheckEllipse"
                             Width="30"
@@ -170,13 +170,13 @@
                         Text="Pass" />
                     <StackPanel
                         Grid.Column="2"
-                        Padding="0,0,10,0"
+                        Padding="0,0,12,0"
                         VerticalAlignment="Center">
                         <TextBlock FontWeight="Bold" Text="Regular text" />
                         <TextBlock Text="Requires at least 4.5:1" />
                     </StackPanel>
 
-                    <Grid Grid.Row="1" Margin="10,0,0,0">
+                    <Grid Grid.Row="1" Margin="12,0,0,0">
                         <Ellipse
                             x:Name="LargeTextCheckEllipse"
                             Width="30"
@@ -198,7 +198,7 @@
                     <StackPanel
                         Grid.Row="1"
                         Grid.Column="2"
-                        Padding="0,0,10,0"
+                        Padding="0,0,12,0"
                         VerticalAlignment="Center">
                         <TextBlock FontWeight="Bold" Text="Large text (14 pt. bold or 18pt. regular)" />
                         <TextBlock Text="Requires at least 3:1" />
@@ -246,14 +246,14 @@
                     </Grid.RowDefinitions>
 
                     <TextBlock
-                        Padding="10,0,10,0"
+                        Padding="12,0,12,0"
                         VerticalAlignment="Center"
                         Foreground="{x:Bind TextColorPicker.ColorBrush, Mode=OneWay}"
                         Text="The quick brown fox jumped over the lazy fox." />
 
                     <StackPanel
                         Grid.Row="1"
-                        Padding="10,0,10,0"
+                        Padding="12,0,12,0"
                         VerticalAlignment="Center">
                         <TextBlock
                             FontSize="14"
@@ -268,7 +268,7 @@
 
                     <StackPanel
                         Grid.Row="2"
-                        Padding="10,0,10,0"
+                        Padding="12,0,12,0"
                         VerticalAlignment="Center"
                         Orientation="Horizontal"
                         Spacing="8">

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityColorContrastPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityColorContrastPage.xaml
@@ -38,7 +38,7 @@
         <RichTextBlock>
             <Paragraph>
                 Accessibility is about building experiences that make your Windows application usable by people of
-                all abilities. For more information about designing accessible apps:<Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/accessibility/accessibility-overview">Accessibility overview</Hyperlink>
+                all abilities. For more information about designing accessible apps: <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/accessibility/accessibility-overview">Accessibility overview</Hyperlink>
                 .<LineBreak />
                 <LineBreak />
                 To ensure optimal accessibility and usability, apps should strive to use high-contrast and easy-to-
@@ -46,7 +46,7 @@
                 visual acuity, but this will also ensure visibility and legibility under a wide range of lighting
                 conditions, screens, and device settings.<LineBreak />
                 <LineBreak />
-                Check out the<Hyperlink NavigateUri="https://accessibilityinsights.io/">Accessibility Insights</Hyperlink>
+                Check out the <Hyperlink NavigateUri="https://accessibilityinsights.io/">Accessibility Insights</Hyperlink>
                 app to help you find and fix accessibility issues in your Windows apps.</Paragraph>
 
         </RichTextBlock>

--- a/WinUIGallery/Controls/InlineColorPicker.xaml
+++ b/WinUIGallery/Controls/InlineColorPicker.xaml
@@ -2,7 +2,6 @@
     x:Class="WinUIGallery.DesktopWap.Controls.InlineColorPicker"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WinUIGallery.DesktopWap.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
@@ -24,6 +23,6 @@
                 </Flyout>
             </SplitButton.Flyout>
         </SplitButton>
-        <TextBox x:Name="ColorHex" TextChanged="ColorHex_TextChanged" MinWidth="120" HorizontalAlignment="Stretch" Margin="5, 0, 0, 0" Grid.Column="1"/>
+        <TextBox x:Name="ColorHex" TextChanged="ColorHex_TextChanged" MinWidth="120" HorizontalAlignment="Stretch" Margin="4, 0, 0, 0" Grid.Column="1"/>
     </Grid>
 </UserControl>

--- a/WinUIGallery/Controls/InlineColorPicker.xaml
+++ b/WinUIGallery/Controls/InlineColorPicker.xaml
@@ -24,6 +24,6 @@
                 </Flyout>
             </SplitButton.Flyout>
         </SplitButton>
-        <TextBox x:Name="ColorHex" TextChanged="ColorHex_TextChanged" HorizontalAlignment="Stretch" Margin="5, 0, 0, 0" Grid.Column="1"/>
+        <TextBox x:Name="ColorHex" TextChanged="ColorHex_TextChanged" MinWidth="120" HorizontalAlignment="Stretch" Margin="5, 0, 0, 0" Grid.Column="1"/>
     </Grid>
 </UserControl>


### PR DESCRIPTION
This PR increases the MinWidth of the color textbox so that when selected the user can read the entire HEX value without the clear button getting in the way. Addressing: https://github.com/microsoft/WinUI-Gallery/issues/1265

Before:
![image](https://github.com/microsoft/WinUI-Gallery/assets/9866362/0e34955e-56b6-4b07-a3a3-eaaa0cdca8ff)

After:
<img width="449" alt="image" src="https://github.com/microsoft/WinUI-Gallery/assets/9866362/0e9e2176-6e03-4ce8-81e2-5a6bf37def89">
