### PR TITLE
ContentDialog backdrop fix

### DIFF
--- a/WinUIGallery/ControlPages/ContentDialogPage.xaml.cs
+++ b/WinUIGallery/ControlPages/ContentDialogPage.xaml.cs
@@ -37,6 +37,22 @@ namespace AppUIBasics.ControlPages
             dialog.Content = new ContentDialogContent();
             dialog.RequestedTheme = (VisualTreeHelper.GetParent(sender as Button) as StackPanel).ActualTheme;
 
+            dialog.Loaded += (s, args) =>
+            {
+                // Apply a dark overlay to the title bar of the window while the dialog is open
+                var parent = VisualTreeHelper.GetParent((DependencyObject)dialog);
+                var child = VisualTreeHelper.GetChild(parent, 0);
+                var frame = (Microsoft.UI.Xaml.Shapes.Rectangle)child;
+                frame.Margin = new Thickness(0);
+                frame.RegisterPropertyChangedCallback(
+                    FrameworkElement.MarginProperty,
+                    (DependencyObject sender, DependencyProperty dp) =>
+                    {
+                        if (dp == FrameworkElement.MarginProperty)
+                            sender.ClearValue(dp);
+                    });
+            };
+
             var result = await dialog.ShowAsync();
 
             if (result == ContentDialogResult.Primary)

--- a/WinUIGallery/ControlPagesSampleCode/ContentDialog/ContentDialogSample1_cs.txt
+++ b/WinUIGallery/ControlPagesSampleCode/ContentDialog/ContentDialogSample1_cs.txt
@@ -12,5 +12,21 @@
     dialog.DefaultButton = ContentDialogButton.Primary;
     dialog.Content = new ContentDialogContent();
 
+    dialog.Loaded += (s, args) =>
+    {
+        // Apply a dark overlay to the title bar of the window while the dialog is open
+        var parent = VisualTreeHelper.GetParent((DependencyObject)dialog);
+        var child = VisualTreeHelper.GetChild(parent, 0);
+        var frame = (Microsoft.UI.Xaml.Shapes.Rectangle)child;
+        frame.Margin = new Thickness(0);
+        frame.RegisterPropertyChangedCallback(
+            FrameworkElement.MarginProperty,
+            (DependencyObject sender, DependencyProperty dp) =>
+            {
+                if (dp == FrameworkElement.MarginProperty)
+                    sender.ClearValue(dp);
+            });
+    };
+
     var result = await dialog.ShowAsync();
 }


### PR DESCRIPTION
This code applies overlay to the title bar of a ContentDialogExample instance.

## Description
Using VisualTreeHelper, which allows for navigation of the visual tree in Windows UI XAML, the parent and child instances of the dialog object are accessed. The first child is a rectangle that represents the title bar of the window frame. The rectangle margin is set to zero, which is used to make the overlay fill the title bar. A callback is also registered to handle a change of margin property in the rectangle. When the margin property changes to its original value, the overlay is removed by the sender.ClearValue(dp) method. 

## Motivation and Context
Extending the backdrop into the titlebar can provide a more seamless visual experience and better integration with the overall theme of the application, not resulting in inconsistant results provided to user.  https://github.com/microsoft/WinUI-Gallery/issues/1315

## How Has This Been Tested?
The Code was thoroughly user tested in both dark and light mode. In addition, it was executed successfully with changes to titlebar settings. It should not result in any additional changes or conflicts in other existing parts of the project.

## Screenshots (if appropriate):
Original ContentDialog
![Dialog Box Bug](https://github.com/microsoft/WinUI-Gallery/assets/98485942/d8e48fe6-9388-4573-842d-581b9747bd32)
Fixed ContentDialog
![Dialog Box Bug Fixed](https://github.com/microsoft/WinUI-Gallery/assets/98485942/1111407a-84c9-4d14-9ca8-bee5bc685944)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
