### PR TITLE
Miscellaneous Acessibility Fixes

### DIFF
--- a/WinUIGallery/App.xaml
+++ b/WinUIGallery/App.xaml
@@ -141,6 +141,7 @@
 
             <Style x:Key="ColorTilesPanelStyle" TargetType="Grid">
                 <Style.Setters>
+                    <Setter Property="Background" Value="{ThemeResource ControlExampleDisplayBrush}" />
                     <Setter Property="BorderThickness" Value="1" />
                     <Setter Property="BorderBrush" Value="{ThemeResource CardStrokeColorDefaultBrush}" />
                     <Setter Property="CornerRadius" Value="{StaticResource OverlayCornerRadius}" />

--- a/WinUIGallery/ControlPages/AppBarButtonPage.xaml.cs
+++ b/WinUIGallery/ControlPages/AppBarButtonPage.xaml.cs
@@ -7,6 +7,7 @@
 // PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
 //
 //*********************************************************
+using AppUIBasics.Helper;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
@@ -31,18 +32,23 @@ namespace AppUIBasics.ControlPages
                 {
                     case "Button1":
                         Control1Output.Text = "You clicked: " + name;
+                        UIHelper.AnnounceActionForAccessibility(Button1, Control1Output.Text, "AppBarButtonSuccessNotificationId");
                         break;
                     case "Button2":
                         Control2Output.Text = "You clicked: " + name;
+                        UIHelper.AnnounceActionForAccessibility(Button2, Control2Output.Text, "AppBarButtonSuccessNotificationId");
                         break;
                     case "Button3":
                         Control3Output.Text = "You clicked: " + name;
+                        UIHelper.AnnounceActionForAccessibility(Button3, Control3Output.Text, "AppBarButtonSuccessNotificationId");
                         break;
                     case "Button4":
                         Control4Output.Text = "You clicked: " + name;
+                        UIHelper.AnnounceActionForAccessibility(Button4, Control4Output.Text, "AppBarButtonSuccessNotificationId");
                         break;
                     case "Button5":
                         Control5Output.Text = "You clicked: " + name;
+                        UIHelper.AnnounceActionForAccessibility(Button5, Control5Output.Text, "AppBarButtonSuccessNotificationId");
                         break;
                 }
             }

--- a/WinUIGallery/ControlPages/BreadcrumbBarPage.xaml
+++ b/WinUIGallery/ControlPages/BreadcrumbBarPage.xaml
@@ -51,7 +51,10 @@ BreadcrumbBar1.ItemsSource = new string[] { "Home", "Documents", "Design", "Nort
             </local:ControlExample.Example>
 
             <local:ControlExample.Options>
-                <Button Content="Reset sample" Click="ResetSampleButton_Click"/>
+                <StackPanel>
+                    <Button Content="Reset sample" Click="ResetSampleButton_Click"/>
+                    <TextBlock x:Name="ResetSampleSucessTextBlock" Foreground="{ThemeResource SystemFillColorSuccessBrush}" AutomationProperties.LiveSetting="Assertive" Margin="4" Opacity="0" />
+                </StackPanel>
             </local:ControlExample.Options>
 
             <local:ControlExample.Xaml>

--- a/WinUIGallery/ControlPages/BreadcrumbBarPage.xaml
+++ b/WinUIGallery/ControlPages/BreadcrumbBarPage.xaml
@@ -51,7 +51,7 @@ BreadcrumbBar1.ItemsSource = new string[] { "Home", "Documents", "Design", "Nort
             </local:ControlExample.Example>
 
             <local:ControlExample.Options>
-                <Button x:Name="ResetSampleBtn" Content="Reset sample"  Click="ResetSampleButton_Click"/>
+                <Button x:Name="ResetSampleBtn" Content="Reset sample" Click="ResetSampleButton_Click"/>
             </local:ControlExample.Options>
 
             <local:ControlExample.Xaml>

--- a/WinUIGallery/ControlPages/BreadcrumbBarPage.xaml
+++ b/WinUIGallery/ControlPages/BreadcrumbBarPage.xaml
@@ -51,9 +51,7 @@ BreadcrumbBar1.ItemsSource = new string[] { "Home", "Documents", "Design", "Nort
             </local:ControlExample.Example>
 
             <local:ControlExample.Options>
-                <StackPanel>
-                    <Button x:Name="ResetSampleBtn" Content="Reset sample"  Click="ResetSampleButton_Click"/>
-                </StackPanel>
+                <Button x:Name="ResetSampleBtn" Content="Reset sample"  Click="ResetSampleButton_Click"/>
             </local:ControlExample.Options>
 
             <local:ControlExample.Xaml>

--- a/WinUIGallery/ControlPages/BreadcrumbBarPage.xaml
+++ b/WinUIGallery/ControlPages/BreadcrumbBarPage.xaml
@@ -52,8 +52,7 @@ BreadcrumbBar1.ItemsSource = new string[] { "Home", "Documents", "Design", "Nort
 
             <local:ControlExample.Options>
                 <StackPanel>
-                    <Button Content="Reset sample" Click="ResetSampleButton_Click"/>
-                    <TextBlock x:Name="ResetSampleSucessTextBlock" Foreground="{ThemeResource SystemFillColorSuccessBrush}" AutomationProperties.LiveSetting="Assertive" Margin="4" Opacity="0" />
+                    <Button x:Name="ResetSampleBtn" Content="Reset sample"  Click="ResetSampleButton_Click"/>
                 </StackPanel>
             </local:ControlExample.Options>
 

--- a/WinUIGallery/ControlPages/BreadcrumbBarPage.xaml.cs
+++ b/WinUIGallery/ControlPages/BreadcrumbBarPage.xaml.cs
@@ -43,7 +43,7 @@ namespace AppUIBasics.ControlPages
                 items.Add(folders[i]);
             }
 
-            // Announce reset successful notifiication.
+            // Announce reset success notifiication.
             UIHelper.AnnounceActionForAccessibility(ResetSampleBtn, "BreadcrumbBar sample reset successful.", "BreadCrumbBarSampleResetNotificationId");
         }
     }

--- a/WinUIGallery/ControlPages/BreadcrumbBarPage.xaml.cs
+++ b/WinUIGallery/ControlPages/BreadcrumbBarPage.xaml.cs
@@ -1,10 +1,9 @@
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
+using AppUIBasics.Helper;
 
 
 namespace AppUIBasics.ControlPages
@@ -18,8 +17,6 @@ namespace AppUIBasics.ControlPages
                 new Folder { Name = "Folder3" },
         };
 
-        private DispatcherTimer resetTimer = new DispatcherTimer();
-
         public BreadcrumbBarPage()
         {
             this.InitializeComponent();
@@ -27,9 +24,6 @@ namespace AppUIBasics.ControlPages
 
             BreadcrumbBar2.ItemsSource = new ObservableCollection<Folder>(folders);
             BreadcrumbBar2.ItemClicked += BreadcrumbBar2_ItemClicked;
-
-            resetTimer.Interval = TimeSpan.FromSeconds(5);
-            resetTimer.Tick += ResetTimer_Tick;
         }
 
         private void BreadcrumbBar2_ItemClicked(BreadcrumbBar sender, BreadcrumbBarItemClickedEventArgs args)
@@ -49,27 +43,8 @@ namespace AppUIBasics.ControlPages
                 items.Add(folders[i]);
             }
 
-            // Toggle success message for accessibility.
-            ResetSampleSucessTextBlock.Text = "Reset successful";
-            ResetSampleSucessTextBlock.Opacity = 1;
-
-            var peer = FrameworkElementAutomationPeer.FromElement(ResetSampleSucessTextBlock);
-
-            if (peer != null)
-            {
-                peer.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
-            }
-
-            // Start the timer to hide the success message after 5 seconds.
-            resetTimer.Start();
-        }
-
-        private void ResetTimer_Tick(object sender, object e)
-        {
-            // Reset the message and stop the timer
-            ResetSampleSucessTextBlock.Text = string.Empty;
-            ResetSampleSucessTextBlock.Opacity = 0;
-            resetTimer.Stop();
+            // Announce reset successful notifiication.
+            UIHelper.AnnounceActionForAccessibility(ResetSampleBtn, "BreadcrumbBar sample reset successful.", "BreadCrumbBarSampleResetNotificationId");
         }
     }
 

--- a/WinUIGallery/ControlPages/BreadcrumbBarPage.xaml.cs
+++ b/WinUIGallery/ControlPages/BreadcrumbBarPage.xaml.cs
@@ -1,8 +1,5 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
-using Microsoft.UI.Xaml.Automation.Peers;
-using Microsoft.UI.Xaml.Controls;
 using AppUIBasics.Helper;
 
 

--- a/WinUIGallery/ControlPages/BreadcrumbBarPage.xaml.cs
+++ b/WinUIGallery/ControlPages/BreadcrumbBarPage.xaml.cs
@@ -1,6 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 
 
@@ -15,6 +18,8 @@ namespace AppUIBasics.ControlPages
                 new Folder { Name = "Folder3" },
         };
 
+        private DispatcherTimer resetTimer = new DispatcherTimer();
+
         public BreadcrumbBarPage()
         {
             this.InitializeComponent();
@@ -22,6 +27,9 @@ namespace AppUIBasics.ControlPages
 
             BreadcrumbBar2.ItemsSource = new ObservableCollection<Folder>(folders);
             BreadcrumbBar2.ItemClicked += BreadcrumbBar2_ItemClicked;
+
+            resetTimer.Interval = TimeSpan.FromSeconds(5);
+            resetTimer.Tick += ResetTimer_Tick;
         }
 
         private void BreadcrumbBar2_ItemClicked(BreadcrumbBar sender, BreadcrumbBarItemClickedEventArgs args)
@@ -40,6 +48,28 @@ namespace AppUIBasics.ControlPages
             {
                 items.Add(folders[i]);
             }
+
+            // Toggle success message for accessibility.
+            ResetSampleSucessTextBlock.Text = "Reset successful";
+            ResetSampleSucessTextBlock.Opacity = 1;
+
+            var peer = FrameworkElementAutomationPeer.FromElement(ResetSampleSucessTextBlock);
+
+            if (peer != null)
+            {
+                peer.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
+            }
+
+            // Start the timer to hide the success message after 5 seconds.
+            resetTimer.Start();
+        }
+
+        private void ResetTimer_Tick(object sender, object e)
+        {
+            // Reset the message and stop the timer
+            ResetSampleSucessTextBlock.Text = string.Empty;
+            ResetSampleSucessTextBlock.Opacity = 0;
+            resetTimer.Stop();
         }
     }
 

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityColorContrastPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityColorContrastPage.xaml
@@ -78,46 +78,33 @@
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
 
-            <TextBlock
-                Grid.Row="0"
-                Grid.Column="0"
-                Margin="12,0,0,0"
-                VerticalAlignment="Bottom"
-                Style="{ThemeResource BodyStrongTextBlockStyle}"
-                Text="Text color" />
-
             <controls1:InlineColorPicker
                 x:Name="TextColorPicker"
-                Grid.Row="1"
-                Grid.Column="0"
-                Margin="12,0,0,12"
+                AutomationProperties.Name="TextColorPicker"
+                Grid.RowSpan="2"
+                Header="Text Color"
                 ColorChanged="TextColorPicker_ColorChanged"
                 Color="Black" />
 
-            <TextBlock
-                Grid.Row="0"
-                Grid.Column="1"
-                Margin="12,10,0,0"
-                Style="{ThemeResource BodyStrongTextBlockStyle}"
-                Text="Background color" />
             <controls1:InlineColorPicker
                 x:Name="BackgroundColorPicker"
-                Grid.Row="1"
+                AutomationProperties.Name="BackgroundColorPicker"
                 Grid.Column="1"
-                Margin="12,0,0,12"
+                Grid.RowSpan="2"
+                Header="Background Color"
                 ColorChanged="BackgroundColorPicker_ColorChanged" />
 
             <TextBlock
                 Grid.Column="3"
                 Margin="12,0,0,0"
-                VerticalAlignment="Bottom"
+                VerticalAlignment="Center"
                 Style="{ThemeResource BodyStrongTextBlockStyle}"
                 Text="Contrast Ratio" />
             <TextBlock
                 x:Name="ContrastRatioPresenter"
                 Grid.Row="1"
                 Grid.Column="3"
-                Margin="12,0,0,0"
+                Margin="12,-4,0,0"
                 Style="{ThemeResource SubtitleTextBlockStyle}"
                 Text="21:1" />
 

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityColorContrastPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityColorContrastPage.xaml
@@ -85,41 +85,41 @@
                 </Grid.ColumnDefinitions>
 
                 <controls1:InlineColorPicker
-                x:Name="TextColorPicker"
-                AutomationProperties.Name="TextColorPicker"
-                Grid.RowSpan="2"
-                Header="Text Color"
-                ColorChanged="TextColorPicker_ColorChanged"
-                Color="Black" />
+                    x:Name="TextColorPicker"
+                    AutomationProperties.Name="TextColorPicker"
+                    Grid.RowSpan="2"
+                    Header="Text Color"
+                    ColorChanged="TextColorPicker_ColorChanged"
+                    Color="Black" />
 
                 <controls1:InlineColorPicker
-                x:Name="BackgroundColorPicker"
-                AutomationProperties.Name="BackgroundColorPicker"
-                Grid.Column="1"
-                Grid.RowSpan="2"
-                Header="Background Color"
-                ColorChanged="BackgroundColorPicker_ColorChanged" />
+                    x:Name="BackgroundColorPicker"
+                    AutomationProperties.Name="BackgroundColorPicker"
+                    Grid.Column="1"
+                    Grid.RowSpan="2"
+                    Header="Background Color"
+                    ColorChanged="BackgroundColorPicker_ColorChanged" />
 
                 <TextBlock
-                Grid.Column="3"
-                Margin="12,0,0,0"
-                VerticalAlignment="Center"
-                Style="{ThemeResource BodyStrongTextBlockStyle}"
-                Text="Contrast Ratio" />
+                    Grid.Column="3"
+                    Margin="12,0,0,0"
+                    VerticalAlignment="Center"
+                    Style="{ThemeResource BodyStrongTextBlockStyle}"
+                    Text="Contrast Ratio" />
                 <TextBlock
-                x:Name="ContrastRatioPresenter"
-                Grid.Row="1"
-                Grid.Column="3"
-                Margin="12,-4,0,0"
-                Style="{ThemeResource SubtitleTextBlockStyle}"
-                Text="21:1" />
+                    x:Name="ContrastRatioPresenter"
+                    Grid.Row="1"
+                    Grid.Column="3"
+                    Margin="12,-4,0,0"
+                    Style="{ThemeResource SubtitleTextBlockStyle}"
+                    Text="21:1" />
 
                 <Grid
-                Grid.Row="2"
-                Grid.ColumnSpan="4"
-                MinHeight="300"
-                Margin="12,0,12,12"
-                CornerRadius="{StaticResource ControlCornerRadius}">
+                    Grid.Row="2"
+                    Grid.ColumnSpan="4"
+                    MinHeight="300"
+                    Margin="12,0,12,12"
+                    CornerRadius="{StaticResource ControlCornerRadius}">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="*" />
@@ -127,10 +127,10 @@
 
                     <!--  Status Checks  -->
                     <Grid
-                    Padding="8"
-                    Background="{ThemeResource ControlFillColorDefaultBrush}"
-                    ColumnSpacing="8"
-                    RowSpacing="16">
+                        Padding="8"
+                        Background="{ThemeResource ControlFillColorDefaultBrush}"
+                        ColumnSpacing="8"
+                        RowSpacing="16">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="*" />
                             <RowDefinition Height="*" />
@@ -155,16 +155,16 @@
                             Glyph="&#xE73E;" />
                         </Grid>
                         <TextBlock
-                        x:Name="NormalTextCheckResult"
-                        Grid.Column="1"
-                        Width="40"
-                        VerticalAlignment="Center"
-                        Style="{ThemeResource BodyStrongTextBlockStyle}"
-                        Text="Pass" />
+                            x:Name="NormalTextCheckResult"
+                            Grid.Column="1"
+                            Width="40"
+                            VerticalAlignment="Center"
+                            Style="{ThemeResource BodyStrongTextBlockStyle}"
+                            Text="Pass" />
                         <StackPanel
-                        Grid.Column="2"
-                        Padding="0,0,12,0"
-                        VerticalAlignment="Center">
+                            Grid.Column="2"
+                            Padding="0,0,12,0"
+                            VerticalAlignment="Center">
                             <TextBlock FontWeight="Bold" Text="Regular text" />
                             <TextBlock Text="Requires at least 4.5:1" />
                         </StackPanel>
@@ -181,18 +181,18 @@
                             Glyph="&#xE73E;" />
                         </Grid>
                         <TextBlock
-                        x:Name="LargeTextCheckResult"
-                        Grid.Row="1"
-                        Grid.Column="1"
-                        Width="40"
-                        VerticalAlignment="Center"
-                        Style="{ThemeResource BodyStrongTextBlockStyle}"
-                        Text="Pass" />
+                            x:Name="LargeTextCheckResult"
+                            Grid.Row="1"
+                            Grid.Column="1"
+                            Width="40"
+                            VerticalAlignment="Center"
+                            Style="{ThemeResource BodyStrongTextBlockStyle}"
+                            Text="Pass" />
                         <StackPanel
-                        Grid.Row="1"
-                        Grid.Column="2"
-                        Padding="0,0,12,0"
-                        VerticalAlignment="Center">
+                            Grid.Row="1"
+                            Grid.Column="2"
+                            Padding="0,0,12,0"
+                            VerticalAlignment="Center">
                             <TextBlock FontWeight="Bold" Text="Large text (14 pt. bold or 18pt. regular)" />
                             <TextBlock Text="Requires at least 3:1" />
                         </StackPanel>
@@ -210,18 +210,18 @@
                             Glyph="&#xE73E;" />
                         </Grid>
                         <TextBlock
-                        x:Name="ComponentsCheckResult"
-                        Grid.Row="2"
-                        Grid.Column="1"
-                        Width="40"
-                        VerticalAlignment="Center"
-                        Style="{ThemeResource BodyStrongTextBlockStyle}"
-                        Text="Pass" />
+                            x:Name="ComponentsCheckResult"
+                            Grid.Row="2"
+                            Grid.Column="1"
+                            Width="40"
+                            VerticalAlignment="Center"
+                            Style="{ThemeResource BodyStrongTextBlockStyle}"
+                            Text="Pass" />
                         <StackPanel
-                        Grid.Row="2"
-                        Grid.Column="2"
-                        Padding="0,0,10,0"
-                        VerticalAlignment="Center">
+                            Grid.Row="2"
+                            Grid.Column="2"
+                            Padding="0,0,10,0"
+                            VerticalAlignment="Center">
                             <TextBlock FontWeight="Bold" Text="Graphical objects and UI components" />
                             <TextBlock Text="Requires at least 3:1" />
                         </StackPanel>
@@ -229,9 +229,9 @@
 
                     <!--  Preview  -->
                     <Grid
-                    Grid.Column="1"
-                    Padding="8"
-                    Background="{x:Bind BackgroundColorPicker.ColorBrush, Mode=OneWay}">
+                        Grid.Column="1"
+                        Padding="8"
+                        Background="{x:Bind BackgroundColorPicker.ColorBrush, Mode=OneWay}">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="*" />
                             <RowDefinition Height="*" />
@@ -239,61 +239,61 @@
                         </Grid.RowDefinitions>
 
                         <TextBlock
-                        Padding="12,0,12,0"
-                        VerticalAlignment="Center"
-                        Foreground="{x:Bind TextColorPicker.ColorBrush, Mode=OneWay}"
-                        Text="The quick brown fox jumped over the lazy fox." />
+                            Padding="12,0,12,0"
+                            VerticalAlignment="Center"
+                            Foreground="{x:Bind TextColorPicker.ColorBrush, Mode=OneWay}"
+                            Text="The quick brown fox jumped over the lazy fox." />
 
                         <StackPanel
-                        Grid.Row="1"
-                        Padding="12,0,12,0"
-                        VerticalAlignment="Center">
+                            Grid.Row="1"
+                            Padding="12,0,12,0"
+                            VerticalAlignment="Center">
                             <TextBlock
-                            FontSize="14"
-                            FontWeight="Bold"
-                            Foreground="{x:Bind TextColorPicker.ColorBrush, Mode=OneWay}"
-                            Text="The quick brown fox jumped over the lazy fox." />
+                                FontSize="14"
+                                FontWeight="Bold"
+                                Foreground="{x:Bind TextColorPicker.ColorBrush, Mode=OneWay}"
+                                Text="The quick brown fox jumped over the lazy fox." />
                             <TextBlock
-                            FontSize="18"
-                            Foreground="{x:Bind TextColorPicker.ColorBrush, Mode=OneWay}"
-                            Text="The quick brown fox jumped over the lazy fox." />
+                                FontSize="18"
+                                Foreground="{x:Bind TextColorPicker.ColorBrush, Mode=OneWay}"
+                                Text="The quick brown fox jumped over the lazy fox." />
                         </StackPanel>
 
                         <StackPanel
-                        Grid.Row="2"
-                        Padding="12,0,12,0"
-                        VerticalAlignment="Center"
-                        Orientation="Horizontal"
-                        Spacing="8">
+                            Grid.Row="2"
+                            Padding="12,0,12,0"
+                            VerticalAlignment="Center"
+                            Orientation="Horizontal"
+                            Spacing="8">
                             <Grid>
                                 <Rectangle
-                                Width="30"
-                                Height="30"
-                                Fill="{x:Bind TextColorPicker.ColorBrush, Mode=OneWay}"
-                                RadiusX="4"
-                                RadiusY="4" />
+                                    Width="30"
+                                    Height="30"
+                                    Fill="{x:Bind TextColorPicker.ColorBrush, Mode=OneWay}"
+                                    RadiusX="4"
+                                    RadiusY="4" />
                                 <FontIcon Foreground="White" Glyph="&#xE73E;" />
                             </Grid>
 
                             <Grid>
                                 <Rectangle
-                                Width="50"
-                                Height="30"
-                                Fill="{x:Bind TextColorPicker.ColorBrush, Mode=OneWay}"
-                                RadiusX="15"
-                                RadiusY="50" />
+                                    Width="50"
+                                    Height="30"
+                                    Fill="{x:Bind TextColorPicker.ColorBrush, Mode=OneWay}"
+                                    RadiusX="15"
+                                    RadiusY="50" />
                                 <Ellipse
-                                Width="15"
-                                Height="15"
-                                Margin="0,0,5,0"
-                                HorizontalAlignment="Right"
-                                VerticalAlignment="Center"
-                                Fill="White" />
+                                    Width="15"
+                                    Height="15"
+                                    Margin="0,0,5,0"
+                                    HorizontalAlignment="Right"
+                                    VerticalAlignment="Center"
+                                    Fill="White" />
                             </Grid>
                             <FontIcon
-                            FontSize="20"
-                            Foreground="{x:Bind TextColorPicker.ColorBrush, Mode=OneWay}"
-                            Glyph="&#xE735;" />
+                                FontSize="20"
+                                Foreground="{x:Bind TextColorPicker.ColorBrush, Mode=OneWay}"
+                                Glyph="&#xE735;" />
                         </StackPanel>
                     </Grid>
                 </Grid>

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityColorContrastPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityColorContrastPage.xaml
@@ -62,7 +62,7 @@
             TextWrapping="Wrap" />
         <Grid
             Padding="8"
-            Background="{ThemeResource CardStrokeColorDefaultBrush}"
+            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
             ColumnSpacing="8"
             CornerRadius="{StaticResource ControlCornerRadius}"
             RowSpacing="8">

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityColorContrastPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityColorContrastPage.xaml
@@ -9,7 +9,6 @@
     //
     //*********************************************************
 -->
-
 <Page
     x:Class="AppUIBasics.ControlPages.AccessibilityColorContrastPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -38,17 +37,21 @@
         <RichTextBlock>
             <Paragraph>
                 Accessibility is about building experiences that make your Windows application usable by people of
-                all abilities. For more information about designing accessible apps: <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/accessibility/accessibility-overview">Accessibility overview</Hyperlink>
-                .<LineBreak />
+                all abilities. For more information about designing accessible apps:
+                <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/accessibility/accessibility-overview">Accessibility overview</Hyperlink>
+                .
+                <LineBreak />
                 <LineBreak />
                 To ensure optimal accessibility and usability, apps should strive to use high-contrast and easy-to-
                 read color combinationto for text and its background. Not only will this benefit users with lower
                 visual acuity, but this will also ensure visibility and legibility under a wide range of lighting
-                conditions, screens, and device settings.<LineBreak />
+                conditions, screens, and device settings.
                 <LineBreak />
-                Check out the <Hyperlink NavigateUri="https://accessibilityinsights.io/">Accessibility Insights</Hyperlink>
-                app to help you find and fix accessibility issues in your Windows apps.</Paragraph>
-
+                <LineBreak />
+                Check out the
+                <Hyperlink NavigateUri="https://accessibilityinsights.io/">Accessibility Insights</Hyperlink>
+                app to help you find and fix accessibility issues in your Windows apps.
+            </Paragraph>
         </RichTextBlock>
 
         <TextBlock
@@ -60,25 +63,28 @@
             Style="{ThemeResource BodyTextBlockStyle}"
             Text="Use this tool to calculate the contrast ratio of two colors and measure them against the Web Content Accessibility Guidelines (WCAG)."
             TextWrapping="Wrap" />
-        <Grid
-            Padding="8"
-            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-            ColumnSpacing="8"
-            CornerRadius="{StaticResource ControlCornerRadius}"
-            RowSpacing="8">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
+        <controls1:SampleThemeListener>
+            <Grid
+                Padding="8"
+                Background="{ThemeResource ControlExampleDisplayBrush}"
+                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                BorderThickness="1"
+                CornerRadius="{StaticResource ControlCornerRadius}"
+                ColumnSpacing="8"
+                RowSpacing="8">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
 
-            <controls1:InlineColorPicker
+                <controls1:InlineColorPicker
                 x:Name="TextColorPicker"
                 AutomationProperties.Name="TextColorPicker"
                 Grid.RowSpan="2"
@@ -86,7 +92,7 @@
                 ColorChanged="TextColorPicker_ColorChanged"
                 Color="Black" />
 
-            <controls1:InlineColorPicker
+                <controls1:InlineColorPicker
                 x:Name="BackgroundColorPicker"
                 AutomationProperties.Name="BackgroundColorPicker"
                 Grid.Column="1"
@@ -94,13 +100,13 @@
                 Header="Background Color"
                 ColorChanged="BackgroundColorPicker_ColorChanged" />
 
-            <TextBlock
+                <TextBlock
                 Grid.Column="3"
                 Margin="12,0,0,0"
                 VerticalAlignment="Center"
                 Style="{ThemeResource BodyStrongTextBlockStyle}"
                 Text="Contrast Ratio" />
-            <TextBlock
+                <TextBlock
                 x:Name="ContrastRatioPresenter"
                 Grid.Row="1"
                 Grid.Column="3"
@@ -108,73 +114,73 @@
                 Style="{ThemeResource SubtitleTextBlockStyle}"
                 Text="21:1" />
 
-            <Grid
+                <Grid
                 Grid.Row="2"
                 Grid.ColumnSpan="4"
                 MinHeight="300"
                 Margin="12,0,12,12"
                 CornerRadius="{StaticResource ControlCornerRadius}">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
 
-                <!--  Status Checks  -->
-                <Grid
+                    <!--  Status Checks  -->
+                    <Grid
                     Padding="8"
                     Background="{ThemeResource ControlFillColorDefaultBrush}"
                     ColumnSpacing="8"
                     RowSpacing="16">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="*" />
-                    </Grid.RowDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
 
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="*" />
-                    </Grid.ColumnDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
 
-                    <Grid Margin="12,0,0,0">
-                        <Ellipse
+                        <Grid Margin="12,0,0,0">
+                            <Ellipse
                             x:Name="NormalTextCheckEllipse"
                             Width="30"
                             Height="30"
                             Fill="{ThemeResource SystemFillColorSuccess}" />
-                        <FontIcon
+                            <FontIcon
                             x:Name="NormalTextCheckIcon"
                             Foreground="White"
                             Glyph="&#xE73E;" />
-                    </Grid>
-                    <TextBlock
+                        </Grid>
+                        <TextBlock
                         x:Name="NormalTextCheckResult"
                         Grid.Column="1"
                         Width="40"
                         VerticalAlignment="Center"
                         Style="{ThemeResource BodyStrongTextBlockStyle}"
                         Text="Pass" />
-                    <StackPanel
+                        <StackPanel
                         Grid.Column="2"
                         Padding="0,0,12,0"
                         VerticalAlignment="Center">
-                        <TextBlock FontWeight="Bold" Text="Regular text" />
-                        <TextBlock Text="Requires at least 4.5:1" />
-                    </StackPanel>
+                            <TextBlock FontWeight="Bold" Text="Regular text" />
+                            <TextBlock Text="Requires at least 4.5:1" />
+                        </StackPanel>
 
-                    <Grid Grid.Row="1" Margin="12,0,0,0">
-                        <Ellipse
+                        <Grid Grid.Row="1" Margin="12,0,0,0">
+                            <Ellipse
                             x:Name="LargeTextCheckEllipse"
                             Width="30"
                             Height="30"
                             Fill="{ThemeResource SystemFillColorSuccess}" />
-                        <FontIcon
+                            <FontIcon
                             x:Name="LargeTextCheckIcon"
                             Foreground="White"
                             Glyph="&#xE73E;" />
-                    </Grid>
-                    <TextBlock
+                        </Grid>
+                        <TextBlock
                         x:Name="LargeTextCheckResult"
                         Grid.Row="1"
                         Grid.Column="1"
@@ -182,28 +188,28 @@
                         VerticalAlignment="Center"
                         Style="{ThemeResource BodyStrongTextBlockStyle}"
                         Text="Pass" />
-                    <StackPanel
+                        <StackPanel
                         Grid.Row="1"
                         Grid.Column="2"
                         Padding="0,0,12,0"
                         VerticalAlignment="Center">
-                        <TextBlock FontWeight="Bold" Text="Large text (14 pt. bold or 18pt. regular)" />
-                        <TextBlock Text="Requires at least 3:1" />
-                    </StackPanel>
+                            <TextBlock FontWeight="Bold" Text="Large text (14 pt. bold or 18pt. regular)" />
+                            <TextBlock Text="Requires at least 3:1" />
+                        </StackPanel>
 
-                    <Grid Grid.Row="2" Margin="10,0,0,0">
-                        <Ellipse
+                        <Grid Grid.Row="2" Margin="10,0,0,0">
+                            <Ellipse
                             x:Name="ComponentsCheckEllipse"
                             Width="30"
                             Height="30"
                             VerticalAlignment="Center"
                             Fill="{ThemeResource SystemFillColorSuccess}" />
-                        <FontIcon
+                            <FontIcon
                             x:Name="ComponentsCheckIcon"
                             Foreground="White"
                             Glyph="&#xE73E;" />
-                    </Grid>
-                    <TextBlock
+                        </Grid>
+                        <TextBlock
                         x:Name="ComponentsCheckResult"
                         Grid.Row="2"
                         Grid.Column="1"
@@ -211,86 +217,87 @@
                         VerticalAlignment="Center"
                         Style="{ThemeResource BodyStrongTextBlockStyle}"
                         Text="Pass" />
-                    <StackPanel
+                        <StackPanel
                         Grid.Row="2"
                         Grid.Column="2"
                         Padding="0,0,10,0"
                         VerticalAlignment="Center">
-                        <TextBlock FontWeight="Bold" Text="Graphical objects and UI components" />
-                        <TextBlock Text="Requires at least 3:1" />
-                    </StackPanel>
-                </Grid>
+                            <TextBlock FontWeight="Bold" Text="Graphical objects and UI components" />
+                            <TextBlock Text="Requires at least 3:1" />
+                        </StackPanel>
+                    </Grid>
 
-                <!--  Preview  -->
-                <Grid
+                    <!--  Preview  -->
+                    <Grid
                     Grid.Column="1"
                     Padding="8"
                     Background="{x:Bind BackgroundColorPicker.ColorBrush, Mode=OneWay}">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="*" />
-                    </Grid.RowDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
 
-                    <TextBlock
+                        <TextBlock
                         Padding="12,0,12,0"
                         VerticalAlignment="Center"
                         Foreground="{x:Bind TextColorPicker.ColorBrush, Mode=OneWay}"
                         Text="The quick brown fox jumped over the lazy fox." />
 
-                    <StackPanel
+                        <StackPanel
                         Grid.Row="1"
                         Padding="12,0,12,0"
                         VerticalAlignment="Center">
-                        <TextBlock
+                            <TextBlock
                             FontSize="14"
                             FontWeight="Bold"
                             Foreground="{x:Bind TextColorPicker.ColorBrush, Mode=OneWay}"
                             Text="The quick brown fox jumped over the lazy fox." />
-                        <TextBlock
+                            <TextBlock
                             FontSize="18"
                             Foreground="{x:Bind TextColorPicker.ColorBrush, Mode=OneWay}"
                             Text="The quick brown fox jumped over the lazy fox." />
-                    </StackPanel>
+                        </StackPanel>
 
-                    <StackPanel
+                        <StackPanel
                         Grid.Row="2"
                         Padding="12,0,12,0"
                         VerticalAlignment="Center"
                         Orientation="Horizontal"
                         Spacing="8">
-                        <Grid>
-                            <Rectangle
+                            <Grid>
+                                <Rectangle
                                 Width="30"
                                 Height="30"
                                 Fill="{x:Bind TextColorPicker.ColorBrush, Mode=OneWay}"
                                 RadiusX="4"
                                 RadiusY="4" />
-                            <FontIcon Foreground="White" Glyph="&#xE73E;" />
-                        </Grid>
+                                <FontIcon Foreground="White" Glyph="&#xE73E;" />
+                            </Grid>
 
-                        <Grid>
-                            <Rectangle
+                            <Grid>
+                                <Rectangle
                                 Width="50"
                                 Height="30"
                                 Fill="{x:Bind TextColorPicker.ColorBrush, Mode=OneWay}"
                                 RadiusX="15"
                                 RadiusY="50" />
-                            <Ellipse
+                                <Ellipse
                                 Width="15"
                                 Height="15"
                                 Margin="0,0,5,0"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="Center"
                                 Fill="White" />
-                        </Grid>
-                        <FontIcon
+                            </Grid>
+                            <FontIcon
                             FontSize="20"
                             Foreground="{x:Bind TextColorPicker.ColorBrush, Mode=OneWay}"
                             Glyph="&#xE735;" />
-                    </StackPanel>
+                        </StackPanel>
+                    </Grid>
                 </Grid>
             </Grid>
-        </Grid>
+        </controls1:SampleThemeListener>
     </StackPanel>
 </Page>

--- a/WinUIGallery/ControlPages/DesignGuidance/ColorsPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/ColorsPage.xaml
@@ -7,7 +7,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:labs="using:CommunityToolkit.Labs.WinUI"
+    xmlns:controls1="using:WinUIGallery.DesktopWap.Controls"
     mc:Ignorable="d">
 
     <Page.Resources>
@@ -36,7 +36,7 @@
             </RichTextBlock>
         </StackPanel>
 
-        <ComboBox x:Name="PageSelector" SelectionChanged="OnSelectionChanged" Loaded="OnLoaded" Width="200" Margin="0,18,0,-18" Grid.Row="1" >
+        <ComboBox x:Name="PageSelector" AutomationProperties.Name="PageSelector" SelectionChanged="OnSelectionChanged" Loaded="OnLoaded" Width="200" Margin="0,18,0,-18" Grid.Row="1" >
             <x:String>Text</x:String>
             <x:String>Fill</x:String>
             <x:String>Stroke</x:String>
@@ -44,6 +44,8 @@
             <x:String>Signal</x:String>
         </ComboBox>
 
-        <Frame x:Name="NavigationFrame" Grid.Row="2" />
+        <controls1:SampleThemeListener Grid.Row="2">
+            <Frame x:Name="NavigationFrame" />
+        </controls1:SampleThemeListener>
     </Grid>
 </Page>

--- a/WinUIGallery/ControlPages/DesignGuidance/ColorsPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/ColorsPage.xaml
@@ -34,16 +34,16 @@
             <RichTextBlock Margin="0,0,0,24">
                 <Paragraph>The colors below are provided as part of WinUI 3. You can reference them in your app using ThemeResource bindings. For example: Color="{ThemeResource CardBackgroundFillColorDefault}"</Paragraph>
             </RichTextBlock>
-        
         </StackPanel>
-        <labs:Segmented x:Name="PageSelector" SelectionChanged="OnSelectionChanged" Loaded="OnLoaded" HorizontalAlignment="Stretch" Grid.Row="1">
-            <labs:SegmentedItem Content="Text"/>
-            <labs:SegmentedItem Content="Fill"/>
-            <labs:SegmentedItem Content="Stroke"/>
-            <labs:SegmentedItem Content="Background"/>
-            <labs:SegmentedItem Content="Signal"/>
-        </labs:Segmented>
 
-        <Frame x:Name="NavigationFrame"   Grid.Row="2" />
+        <ComboBox x:Name="PageSelector" SelectionChanged="OnSelectionChanged" Loaded="OnLoaded" Width="200" Margin="0,18,0,-18" Grid.Row="1" >
+            <x:String>Text</x:String>
+            <x:String>Fill</x:String>
+            <x:String>Stroke</x:String>
+            <x:String>Background</x:String>
+            <x:String>Signal</x:String>
+        </ComboBox>
+
+        <Frame x:Name="NavigationFrame" Grid.Row="2" />
     </Grid>
 </Page>

--- a/WinUIGallery/ControlPages/IconElementPage.xaml
+++ b/WinUIGallery/ControlPages/IconElementPage.xaml
@@ -8,11 +8,11 @@
     xmlns:local="using:AppUIBasics"
     mc:Ignorable="d">
     <StackPanel>
-        <local:ControlExample Name="Example1" HeaderText="A BitmapIcon with a multicolor bitmap image">
+        <local:ControlExample x:Name="Example1" HeaderText="A BitmapIcon with a multicolor bitmap image">
             <local:ControlExample.Example>
                 <StackPanel>
                     <TextBlock Text="The ShowAsMonochrome property (true by default) will result in a solid block of the foreground color if the property is set to true and the icon is more than one color. This behavior can be ignored by setting the ShowAsMonochrome property to false." Style="{ThemeResource BodyTextBlockStyle}" Margin="0,0,0,12"  />
-                    <BitmapIcon Name="SlicesIcon" UriSource="ms-appx:///Assets/slices.png" Width="50" HorizontalAlignment="Left" ShowAsMonochrome="False"/>
+                    <BitmapIcon x:Name="SlicesIcon" UriSource="ms-appx:///Assets/slices.png" Width="50" HorizontalAlignment="Left" ShowAsMonochrome="False"/>
                 </StackPanel>
             </local:ControlExample.Example>
             <local:ControlExample.Options>
@@ -20,55 +20,55 @@
             </local:ControlExample.Options>
             <local:ControlExample.Xaml>
                 <x:String>
-                    &lt;BitmapIcon Name="SlicesIcon" UriSource="ms-appx:///Assets/slices.png" Width="50" ShowAsMonochrome="$(ShowAsMonochrome)"/&gt;
+                    &lt;BitmapIcon x:Name="SlicesIcon" UriSource="ms-appx:///Assets/slices.png" Width="50" ShowAsMonochrome="$(ShowAsMonochrome)"/&gt;
                 </x:String>
             </local:ControlExample.Xaml>
             <local:ControlExample.Substitutions>
                 <local:ControlExampleSubstitution Key="ShowAsMonochrome" Value="{ x:Bind MonochromeButton.IsChecked.Value, Mode=OneWay}"/>
             </local:ControlExample.Substitutions>
         </local:ControlExample>
-        <local:ControlExample Name="Example2" HeaderText="A FontIcon using a glyph from a specific font family in a button" XamlSource="Icons/FontIconSample1_xaml.txt">
+        <local:ControlExample x:Name="Example2" HeaderText="A FontIcon using a glyph from a specific font family in a button" XamlSource="Icons/FontIconSample1_xaml.txt">
             <local:ControlExample.Example>
                 <StackPanel>
                     <TextBlock Text="Use FontIcon as the icon for a control if you want to specify a Glyph value from a FontFamily. Windows 10 uses the Segoe MDL2 Assets FontFamily and that is what this example is showing." Style="{ThemeResource BodyTextBlockStyle}" Margin="0,0,0,12"  />
-                    <Button Name="ExampleButton1">
+                    <Button x:Name="ExampleButton1" AutomationProperties.Name="ExampleButton1">
                         <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE790;"/>
                     </Button>
                 </StackPanel>
             </local:ControlExample.Example>
         </local:ControlExample>
-        <local:ControlExample Name="Example3" HeaderText="A ImageIcon using a bitmap image in a button" XamlSource="Icons/ImageIconSample1_xaml.txt">
+        <local:ControlExample x:Name="Example3" HeaderText="A ImageIcon using a bitmap image in a button" XamlSource="Icons/ImageIconSample1_xaml.txt">
             <local:ControlExample.Example>
                 <StackPanel>
                     <TextBlock Text="To use an ImageIcon as the icon for a control, you can set image that has a file format supported by the Image class. The two examples here show a PNG and SVG image as the icon." Style="{ThemeResource BodyTextBlockStyle}" Margin="0,0,0,12"  />
-                    <Button Name="ImageExample1" Width="100">
+                    <Button x:Name="ImageExample1" AutomationProperties.Name="ImageExample1" Width="100">
                         <ImageIcon Source="/Assets/slices.png"/>
                     </Button>
                 </StackPanel>
             </local:ControlExample.Example>
         </local:ControlExample>
-        <local:ControlExample Name="Example4" HeaderText="A ImageIcon using a SVG image in a button" XamlSource="Icons/ImageIconSample2_xaml.txt">
+        <local:ControlExample x:Name="Example4" HeaderText="A ImageIcon using a SVG image in a button" XamlSource="Icons/ImageIconSample2_xaml.txt">
             <local:ControlExample.Example>
-                <Button Name="ImageExample2">
+                <Button x:Name="ImageExample2" AutomationProperties.Name="ImageExample2">
                     <ImageIcon Source="https://raw.githubusercontent.com/DiemenDesign/LibreICONS/master/svg-color/libre-camera-panorama.svg" Width="50"/>
                 </Button>
             </local:ControlExample.Example>
         </local:ControlExample>
-        <local:ControlExample Name="Example5" HeaderText="A PathIcon in a button" XamlSource="Icons/PathIconSample1_xaml.txt">
+        <local:ControlExample x:Name="Example5" HeaderText="A PathIcon in a button" XamlSource="Icons/PathIconSample1_xaml.txt">
             <local:ControlExample.Example>
                 <StackPanel>
                     <TextBlock Text="To use a PathIcon as the icon for a control, you specify the path data of the image you are trying to display. The path data draws a series of connected lines and curves." Style="{ThemeResource BodyTextBlockStyle}" Margin="0,0,0,12"  />
-                    <Button Name="Example1Button">
+                    <Button x:Name="Example1Button" AutomationProperties.Name="Example1Button">
                         <PathIcon Data="F1 M 16,12 20,2L 20,16 1,16" HorizontalAlignment="Center"/>
                     </Button>
                 </StackPanel>
             </local:ControlExample.Example>
         </local:ControlExample>
-        <local:ControlExample Name="Example6" HeaderText="A SymbolIcon in a button" XamlSource="Icons/SymbolIconSample_1_xaml.txt">
+        <local:ControlExample x:Name="Example6" HeaderText="A SymbolIcon in a button" XamlSource="Icons/SymbolIconSample_1_xaml.txt">
             <local:ControlExample.Example>
                 <StackPanel>
                     <TextBlock Text="To use a SymbolIcon as the icon for a control, you specify the enum value for the glyph you would like to display. SymbolIcon's enum is based off of icons from the Segoe MDL2 font used by Windows 10." Style="{ThemeResource BodyTextBlockStyle}" Margin="0,0,0,12"  />
-                    <Button Name="AcceptButton">
+                    <Button x:Name="AcceptButton" AutomationProperties.Name="AcceptButton">
                         <StackPanel>
                             <SymbolIcon Symbol="Accept"/>
                             <TextBlock Text="Accept"/>

--- a/WinUIGallery/ControlPages/SplitButtonPage.xaml
+++ b/WinUIGallery/ControlPages/SplitButtonPage.xaml
@@ -35,14 +35,14 @@
                                     </Style>
                                 </GridView.Resources>
                                 <GridView.Items>
-                                    <Rectangle Fill="Red"/>
-                                    <Rectangle Fill="Orange"/>
-                                    <Rectangle Fill="Yellow"/>
-                                    <Rectangle Fill="Green"/>
-                                    <Rectangle Fill="Blue"/>
-                                    <Rectangle Fill="Indigo"/>
-                                    <Rectangle Fill="Violet"/>
-                                    <Rectangle Fill="Gray"/>
+                                    <Rectangle Fill="Red" AutomationProperties.Name="Red" />
+                                    <Rectangle Fill="Orange" AutomationProperties.Name="Orange" />
+                                    <Rectangle Fill="Yellow" AutomationProperties.Name="Yellow" />
+                                    <Rectangle Fill="Green" AutomationProperties.Name="Green" />
+                                    <Rectangle Fill="Blue" AutomationProperties.Name="Blue" />
+                                    <Rectangle Fill="Indigo" AutomationProperties.Name="Indigo" />
+                                    <Rectangle Fill="Violet" AutomationProperties.Name="Violet" />
+                                    <Rectangle Fill="Gray" AutomationProperties.Name="Gray" />
                                 </GridView.Items>
                             </GridView>
 

--- a/WinUIGallery/Controls/DesignGuidance/ColorPageExample.xaml
+++ b/WinUIGallery/Controls/DesignGuidance/ColorPageExample.xaml
@@ -18,7 +18,7 @@
         
         <Grid
             Grid.Row="1"
-            Margin="0,36,0,12"
+            Margin="0,36,0,0"
             Padding="12"
             Background="{x:Bind Background, Mode=OneWay}"
             BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
@@ -39,7 +39,7 @@
             <TextBlock Style="{ThemeResource CaptionTextBlockStyle}" Text="{x:Bind Description, Mode=OneWay}" Grid.Row="1"/>
             <ContentPresenter
                 Grid.Row="2"
-                Margin="0,16,0,16"
+                Margin="0,12,0,12"
                 HorizontalAlignment="Center"
                 Content="{x:Bind ExampleContent, Mode=OneWay}" />
         </Grid>

--- a/WinUIGallery/Controls/DesignGuidance/ColorPageExample.xaml
+++ b/WinUIGallery/Controls/DesignGuidance/ColorPageExample.xaml
@@ -7,7 +7,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+    Background="{ThemeResource ControlExampleDisplayBrush}"
     mc:Ignorable="d">
 
     <Grid>
@@ -15,25 +15,30 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <TextBlock
-            Margin="0,36,0,12"
-            Foreground="{ThemeResource TextFillColorPrimaryBrush}"
-            Style="{ThemeResource SubtitleTextBlockStyle}"
-            Text="{x:Bind Title, Mode=OneWay}" />
+        
         <Grid
             Grid.Row="1"
-            Padding="16"
+            Margin="0,36,0,12"
+            Padding="12"
             Background="{x:Bind Background, Mode=OneWay}"
             BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
             BorderThickness="1"
             CornerRadius="{StaticResource OverlayCornerRadius}">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
-            <TextBlock Style="{ThemeResource CaptionTextBlockStyle}" Text="{x:Bind Description, Mode=OneWay}" />
+
+            <TextBlock
+                Margin="0,0,0,12"
+                Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+                Style="{ThemeResource SubtitleTextBlockStyle}"
+                Text="{x:Bind Title, Mode=OneWay}" />
+
+            <TextBlock Style="{ThemeResource CaptionTextBlockStyle}" Text="{x:Bind Description, Mode=OneWay}" Grid.Row="1"/>
             <ContentPresenter
-                Grid.Row="1"
+                Grid.Row="2"
                 Margin="0,16,0,16"
                 HorizontalAlignment="Center"
                 Content="{x:Bind ExampleContent, Mode=OneWay}" />

--- a/WinUIGallery/Controls/DesignGuidance/ColorSections/TextSection.xaml
+++ b/WinUIGallery/Controls/DesignGuidance/ColorSections/TextSection.xaml
@@ -27,7 +27,7 @@
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
             <designguidance:ColorTile
-                Background="{ThemeResource TextFillColorPrimary}"
+                Background="{ThemeResource TextFillColorPrimaryBrush}"
                 ColorBrushName="TextFillColorPrimaryBrush"
                 ColorExplanation="Rest or Hover"
                 ColorName="Text / Primary"
@@ -142,7 +142,7 @@
                 ColorExplanation="Rest or Hover"
                 ColorName="Text on Accent / Primary"
                 ColorValue="#FFFFFF (FF, 100%)"
-                Foreground="{ThemeResource TextFillColorPrimary}" />
+                Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
 
             <designguidance:ColorTile
                 Grid.Column="2"
@@ -151,7 +151,7 @@
                 ColorExplanation="Pressed only (not accessible)"
                 ColorName="Text on Accent / Secondary"
                 ColorValue="#FFFFFF (B3, 70%)"
-                Foreground="{ThemeResource TextFillColorPrimary}"
+                Foreground="{ThemeResource TextFillColorPrimaryBrush}"
                 ShowSeparator="False" />
         </Grid>
 
@@ -167,7 +167,7 @@
                 ColorExplanation="Disabled only (not accessible)"
                 ColorName="Text on Accent / Disabled"
                 ColorValue="#FFFFFF (FF, 100%)"
-                Foreground="{ThemeResource TextFillColorPrimary}" />
+                Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
             <designguidance:ColorTile
                 Grid.Column="2"
                 Background="{ThemeResource TextOnAccentFillColorSelectedTextBrush}"

--- a/WinUIGallery/Controls/DesignGuidance/ColorTile.xaml
+++ b/WinUIGallery/Controls/DesignGuidance/ColorTile.xaml
@@ -8,8 +8,6 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:WinUIGallery.DesktopWap.Controls.DesignGuidance"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    PointerEntered="UserControl_PointerEntered"
-    PointerExited="UserControl_PointerExited"
     mc:Ignorable="d">
 
     <Grid>
@@ -43,19 +41,18 @@
 
             <Button
                 x:Name="CopyBrushNameButton"
+                AutomationProperties.Name="Copy brush name"
                 Grid.RowSpan="4"
                 Grid.Column="1"
                 Grid.ColumnSpan="2"
                 Padding="4"
                 HorizontalAlignment="Right"
                 VerticalAlignment="Top"
-                AutomationProperties.Name="Copy brush name"
                 Background="Transparent"
                 BorderBrush="Transparent"
                 Click="CopyBrushNameButton_Click"
                 Foreground="{x:Bind Foreground, Mode=OneWay}"
-                ToolTipService.ToolTip="Copy brush name"
-                Visibility="Collapsed">
+                ToolTipService.ToolTip="Copy brush name">
                 <FontIcon FontSize="16" Glyph="&#xE8C8;" />
             </Button>
 

--- a/WinUIGallery/Controls/DesignGuidance/ColorTile.xaml.cs
+++ b/WinUIGallery/Controls/DesignGuidance/ColorTile.xaml.cs
@@ -76,15 +76,5 @@ namespace WinUIGallery.DesktopWap.Controls.DesignGuidance
             Clipboard.SetContent(package);
 
         }
-
-        private void UserControl_PointerEntered(object sender, PointerRoutedEventArgs e)
-        {
-            CopyBrushNameButton.Visibility = Visibility.Visible;
-        }
-
-        private void UserControl_PointerExited(object sender, PointerRoutedEventArgs e)
-        {
-            CopyBrushNameButton.Visibility = Visibility.Collapsed;
-        }
     }
 }

--- a/WinUIGallery/Controls/InlineColorPicker.xaml
+++ b/WinUIGallery/Controls/InlineColorPicker.xaml
@@ -6,13 +6,36 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Grid ColumnSpacing="2">
+    <Grid ColumnSpacing="2" Margin="12,12,0,12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
-        <SplitButton Padding="0" VerticalAlignment="Stretch">
-            <Rectangle x:Name="ColorPreview" Fill="{x:Bind ColorBrush, Mode=OneWay}" VerticalAlignment="Stretch" MinHeight="30" Width="40"/>
+        
+        <TextBlock
+            x:Name="HeaderText"
+            Grid.Row="0"
+            Grid.Column="0"
+            Grid.ColumnSpan="2"
+            Margin="0,0,0,12"
+            VerticalAlignment="Bottom"
+            Style="{ThemeResource BodyStrongTextBlockStyle}"
+            Text="{x:Bind Header, Mode=OneWay}" />
+
+        <SplitButton
+            AutomationProperties.LabeledBy="{Binding ElementName=HeaderText}"
+            Padding="0" VerticalAlignment="Stretch"
+            Grid.Row="1">
+            <Rectangle
+                x:Name="ColorPreview"
+                Fill="{x:Bind ColorBrush, Mode=OneWay}"
+                VerticalAlignment="Stretch"
+                MinHeight="30"
+                Width="40"/>
             <SplitButton.Flyout>
                 <Flyout Opened="PickerFlyout_Opened">
                     <ColorPicker x:Name="Picker"
@@ -23,6 +46,14 @@
                 </Flyout>
             </SplitButton.Flyout>
         </SplitButton>
-        <TextBox x:Name="ColorHex" TextChanged="ColorHex_TextChanged" MinWidth="120" HorizontalAlignment="Stretch" Margin="4, 0, 0, 0" Grid.Column="1"/>
+        <TextBox
+            x:Name="ColorHex"
+            AutomationProperties.LabeledBy="{Binding ElementName=HeaderText}"
+            TextChanged="ColorHex_TextChanged"
+            MinWidth="120"
+            HorizontalAlignment="Stretch"
+            Margin="4,0,0,0"
+            Grid.Column="1"
+            Grid.Row="1" />
     </Grid>
 </UserControl>

--- a/WinUIGallery/Controls/InlineColorPicker.xaml.cs
+++ b/WinUIGallery/Controls/InlineColorPicker.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
+using AppUIBasics.Controls;
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -22,6 +23,15 @@ namespace WinUIGallery.DesktopWap.Controls
 {
     public sealed partial class InlineColorPicker : UserControl
     {
+        public string Header
+        {
+            get { return (string)GetValue(HeaderProperty); }
+            set { SetValue(HeaderProperty, value); }
+        }
+
+        public static readonly DependencyProperty HeaderProperty =
+            DependencyProperty.Register("Header", typeof(string), typeof(InlineColorPicker), new PropertyMetadata(null));
+
         public Color Color
         {
             get { return (Color)GetValue(ColorProperty); }

--- a/WinUIGallery/Controls/PageHeader.xaml.cs
+++ b/WinUIGallery/Controls/PageHeader.xaml.cs
@@ -64,7 +64,7 @@ namespace WinUIGallery.DesktopWap.Controls
         public void OnThemeButtonClick(object sender, RoutedEventArgs e)
         {
             ToggleThemeAction?.Invoke();
-            UIHelper.AnnounceActionForAccessibility(ThemeButton, "Theme Changed.", "ThemeChangedSuccessNotificationId");
+            UIHelper.AnnounceActionForAccessibility(ThemeButton, "Theme changed.", "ThemeChangedSuccessNotificationId");
         }
 
         private void OnCopyDontShowAgainButtonClick(TeachingTip sender, object args)

--- a/WinUIGallery/Controls/PageHeader.xaml.cs
+++ b/WinUIGallery/Controls/PageHeader.xaml.cs
@@ -64,6 +64,7 @@ namespace WinUIGallery.DesktopWap.Controls
         public void OnThemeButtonClick(object sender, RoutedEventArgs e)
         {
             ToggleThemeAction?.Invoke();
+            UIHelper.AnnounceActionForAccessibility(ThemeButton, "Theme Changed.", "ThemeChangedSuccessNotificationId");
         }
 
         private void OnCopyDontShowAgainButtonClick(TeachingTip sender, object args)

--- a/WinUIGallery/Controls/TileGallery.xaml.cs
+++ b/WinUIGallery/Controls/TileGallery.xaml.cs
@@ -49,11 +49,16 @@ namespace AppUIBasics.Controls
         private void ScrollBackBtn_Click(object sender, RoutedEventArgs e)
         {
             scroller.ChangeView(scroller.HorizontalOffset - scroller.ViewportWidth, null, null);
+            // Manually focus to ScrollForwardBtn since this button disappears after scrolling to the end.          
+            ScrollForwardBtn.Focus(FocusState.Programmatic);
         }
 
         private void ScrollForwardBtn_Click(object sender, RoutedEventArgs e)
         {
             scroller.ChangeView(scroller.HorizontalOffset + scroller.ViewportWidth, null, null);
+
+            // Manually focus to ScrollBackBtn since this button disappears after scrolling to the end.    
+            ScrollBackBtn.Focus(FocusState.Programmatic);
         }
 
         private void scroller_SizeChanged(object sender, SizeChangedEventArgs e)

--- a/WinUIGallery/ItemPage.xaml.cs
+++ b/WinUIGallery/ItemPage.xaml.cs
@@ -104,22 +104,6 @@ namespace AppUIBasics
             base.OnNavigatedTo(e);
         }
 
-        protected override void OnKeyDown(KeyRoutedEventArgs e)
-        {
-            if (e.Key == Windows.System.VirtualKey.Escape)
-            {
-                this.Item = null;
-                if (this.contentFrame.CanGoBack)
-                {
-                    this.contentFrame.GoBack();
-                }
-                else
-                {
-                    NavigationRootPage.GetForElement(this).Navigate(typeof(AllControlsPage));
-                }
-            }
-        }
-
         protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
         {
             SetControlExamplesTheme(ThemeHelper.ActualTheme);

--- a/WinUIGallery/WinUIGallery.csproj
+++ b/WinUIGallery/WinUIGallery.csproj
@@ -55,10 +55,10 @@
     <PackageReference Include="ColorCode.Core" />
     <PackageReference Include="Microsoft.Graphics.Win2D" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" />
-    <PackageReference Include="CommunityToolkit.Labs.WinUI.SegmentedControl"/>
-    <PackageReference Include="CommunityToolkit.Labs.WinUI.SettingsControls"/>
-    <PackageReference Include="CommunityToolkit.WinUI.UI"/>
-    <PackageReference Include="CommunityToolkit.WinUI.UI.Animations"/>
+    <PackageReference Include="CommunityToolkit.Labs.WinUI.SegmentedControl" />
+    <PackageReference Include="CommunityToolkit.Labs.WinUI.SettingsControls" />
+    <PackageReference Include="CommunityToolkit.WinUI.UI" />
+    <PackageReference Include="CommunityToolkit.WinUI.UI.Animations" />
     <PackageReference Include="Microsoft.VCRTForwarders.140" />
     <Manifest Include="$(ApplicationManifest)" />
 
@@ -70,22 +70,15 @@
     <PackageReference Include="System.Private.Uri" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsInWinUIRepo)' != 'true'">
-    <PackageReference Update="Microsoft.WindowsAppSDK" Version="$(WindowsAppSdkPackageVersion)" />
+    <PackageReference Update="Microsoft.WindowsAppSDK" Version="1.4.230628000-preview1" />
     <PackageReference Remove="ColorCode.Core" />
-    <PackageReference Include="ColorCode.WinUI"
-                      Version="$(ColorCodeVersion)" />
-    <PackageReference Update="CommunityToolkit.Labs.WinUI.SegmentedControl"
-                      Version="$(CommunityToolkitSegmentedControlVersion)" />                      
-    <PackageReference Update="CommunityToolkit.Labs.WinUI.SettingsControls"
-                      Version="$(CommunityToolkitSettingsControlsVersion)" />
-    <PackageReference Update="CommunityToolkit.WinUI.UI"
-                      Version="$(CommunityToolkitWinUIVersion)" />
-    <PackageReference Update="CommunityToolkit.WinUI.UI.Animations"
-                      Version="$(CommunityToolkitWinUIVersion)" />                                                
-    <PackageReference Update="Microsoft.Graphics.Win2D"
-                      Version="$(GraphicsWin2DVersion)" />
-    <PackageReference Update="Microsoft.VCRTForwarders.140"
-                      Version="1.0.6" />
+    <PackageReference Include="ColorCode.WinUI" Version="$(ColorCodeVersion)" />
+    <PackageReference Update="CommunityToolkit.Labs.WinUI.SegmentedControl" Version="$(CommunityToolkitSegmentedControlVersion)" />                      
+    <PackageReference Update="CommunityToolkit.Labs.WinUI.SettingsControls" Version="$(CommunityToolkitSettingsControlsVersion)" />
+    <PackageReference Update="CommunityToolkit.WinUI.UI" Version="$(CommunityToolkitWinUIVersion)" />
+    <PackageReference Update="CommunityToolkit.WinUI.UI.Animations" Version="$(CommunityToolkitWinUIVersion)" />                                                
+    <PackageReference Update="Microsoft.Graphics.Win2D" Version="$(GraphicsWin2DVersion)" />
+    <PackageReference Update="Microsoft.VCRTForwarders.140" Version="1.0.6" />
     <!-- Get latest WinRT.Runtime.dll from C#/WinRT -->
     <PackageReference Update="Microsoft.Windows.CsWinRT" Version="2.0.3" />
     <PackageReference Update="System.Private.Uri" Version="4.3.2" />

--- a/WinUIGallery/WinUIGallery.csproj
+++ b/WinUIGallery/WinUIGallery.csproj
@@ -55,10 +55,10 @@
     <PackageReference Include="ColorCode.Core" />
     <PackageReference Include="Microsoft.Graphics.Win2D" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" />
-    <PackageReference Include="CommunityToolkit.Labs.WinUI.SegmentedControl" />
-    <PackageReference Include="CommunityToolkit.Labs.WinUI.SettingsControls" />
-    <PackageReference Include="CommunityToolkit.WinUI.UI" />
-    <PackageReference Include="CommunityToolkit.WinUI.UI.Animations" />
+    <PackageReference Include="CommunityToolkit.Labs.WinUI.SegmentedControl"/>
+    <PackageReference Include="CommunityToolkit.Labs.WinUI.SettingsControls"/>
+    <PackageReference Include="CommunityToolkit.WinUI.UI"/>
+    <PackageReference Include="CommunityToolkit.WinUI.UI.Animations"/>
     <PackageReference Include="Microsoft.VCRTForwarders.140" />
     <Manifest Include="$(ApplicationManifest)" />
 
@@ -70,15 +70,22 @@
     <PackageReference Include="System.Private.Uri" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsInWinUIRepo)' != 'true'">
-    <PackageReference Update="Microsoft.WindowsAppSDK" Version="1.4.230628000-preview1" />
+    <PackageReference Update="Microsoft.WindowsAppSDK" Version="$(WindowsAppSdkPackageVersion)" />
     <PackageReference Remove="ColorCode.Core" />
-    <PackageReference Include="ColorCode.WinUI" Version="$(ColorCodeVersion)" />
-    <PackageReference Update="CommunityToolkit.Labs.WinUI.SegmentedControl" Version="$(CommunityToolkitSegmentedControlVersion)" />                      
-    <PackageReference Update="CommunityToolkit.Labs.WinUI.SettingsControls" Version="$(CommunityToolkitSettingsControlsVersion)" />
-    <PackageReference Update="CommunityToolkit.WinUI.UI" Version="$(CommunityToolkitWinUIVersion)" />
-    <PackageReference Update="CommunityToolkit.WinUI.UI.Animations" Version="$(CommunityToolkitWinUIVersion)" />                                                
-    <PackageReference Update="Microsoft.Graphics.Win2D" Version="$(GraphicsWin2DVersion)" />
-    <PackageReference Update="Microsoft.VCRTForwarders.140" Version="1.0.6" />
+    <PackageReference Include="ColorCode.WinUI"
+                      Version="$(ColorCodeVersion)" />
+    <PackageReference Update="CommunityToolkit.Labs.WinUI.SegmentedControl"
+                      Version="$(CommunityToolkitSegmentedControlVersion)" />                      
+    <PackageReference Update="CommunityToolkit.Labs.WinUI.SettingsControls"
+                      Version="$(CommunityToolkitSettingsControlsVersion)" />
+    <PackageReference Update="CommunityToolkit.WinUI.UI"
+                      Version="$(CommunityToolkitWinUIVersion)" />
+    <PackageReference Update="CommunityToolkit.WinUI.UI.Animations"
+                      Version="$(CommunityToolkitWinUIVersion)" />                                                
+    <PackageReference Update="Microsoft.Graphics.Win2D"
+                      Version="$(GraphicsWin2DVersion)" />
+    <PackageReference Update="Microsoft.VCRTForwarders.140"
+                      Version="1.0.6" />
     <!-- Get latest WinRT.Runtime.dll from C#/WinRT -->
     <PackageReference Update="Microsoft.Windows.CsWinRT" Version="2.0.3" />
     <PackageReference Update="System.Private.Uri" Version="4.3.2" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR includes a handful of accessibility bug fixes. 

- [Bug 44665966](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/44665966): [WinUI Accessibility: Design guidance -> Accessibility -> Color contrast ]: No proper label name is defined to the split buttons present under Color Contrast Checker group.
      - `InlineColorPicker` UserControl is updated to be compliant
     
- [Bug 44672713](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/44672713): [WinUI Accessibility: Design guidance -> Accessibility -> Color contrast ]: Text color, Background color and Contrast ratio text present under Color Contrast Checker group is not visible in high contrast Aquatic and Desert themes.
      - Background is updated to the correct brush
      
- [Bug 44661719](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/44661719): [WinUI Accessibility: Design guidance -> Colors]: No success information upon invoking any of the banner items. [Bug 44661675](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/44661675): [WinUI Accessibility: Design guidance -> Colors]: Control type is not defined to the Top banner items i.e., Text, Fill, Stroke, Background and Signal.
       - Segmented from community toolkit lacks AP 
       - implementation, and is replaced with ComboBox. As Segmented is still an "experimental" control, I would like to go through the design team to make sure it is used correctly.
- [Bug 44661749](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/44661749): [WinUI Accessibility: Design guidance -> Colors]: Unable to navigate and access 'Copy brush name' button using keyboard.
      -  Copy button is made consistently visible.
      
- [Bug 44661258](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/44661258): [WinUI Accessibility: Home]: Keyboard focus is getting reset on invoking ‘Scroll right’ button.
      -  Manual focus is added in codebehind after invocation.
     
- [Bug 44964995](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/44964995): [WinUI Accessibility]: Screen reader is not announcing the success message after invoking 'Reset sample' button present in 'Breadcrumbbar' card.
       - `AnnounceActionForAccessibility` is added to manually announce success notification.
       
- [Bug 43942055](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/43942055): [WinUI Gallery] WinUI Accessibility: AppBarButton: Screen reader stays mute after activating the 'Symbol Icon/Bitmap Icon/Font Icon/Path Icon/Save' buttons.
       - `AnnounceActionForAccessibility` is added to manually announce success notification.

- [Bug 43944726](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/43944726): [WinUI Gallery] WinUI Accessibility: IconElement: Name property is not defined for the buttons present in 'Icon Element' page.
      - `x:` namespace is added to `Name` property.

- [Bug 43944253](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/43944253): [WinUI Gallery] WinUI Accessibility: SplitButton: Name property is not defined for the list items present in 'Font Colour' Split button.
      - Add `AutomationProperties.Name` 

- [Bug 44964941](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/44964941): [WinUI Gallery] WinUI Accessibility: When user invokes 'toggle theme' button, screen reader stays mute and fails announcing about the action performed.
       - `AnnounceActionForAccessibility` is added to manually announce success notification. 

- [Bug 44572299](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/44572299): ESC key should not navigate pages back
      - Remove `OnKeyDown` method related to esc key. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
