### PR TITLE
Build Errors and Warning Fixes

### DIFF
--- a/WinUIGallery/ControlPages/BreadcrumbBarPage.xaml.cs
+++ b/WinUIGallery/ControlPages/BreadcrumbBarPage.xaml.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using Microsoft.UI.Xaml.Controls;
 using AppUIBasics.Helper;
-
 
 namespace AppUIBasics.ControlPages
 {

--- a/WinUIGallery/DataModel/ControlInfoDataSource.cs
+++ b/WinUIGallery/DataModel/ControlInfoDataSource.cs
@@ -218,6 +218,7 @@ namespace AppUIBasics.Data
 
                 controlInfoDataGroup.Groups.SelectMany(g => g.Items).ToList().ForEach(item =>
                 {
+#nullable enable
                     string? badgeString = item switch
                     {
                         { IsNew: true } => "New",
@@ -230,6 +231,7 @@ namespace AppUIBasics.Data
 
                     item.BadgeString = badgeString;
                     item.IncludedInBuild = pageType is not null;
+#nullable disable
                 });
 
                 foreach (var group in controlInfoDataGroup.Groups)

--- a/WinUIGallery/WinUIGallery.csproj
+++ b/WinUIGallery/WinUIGallery.csproj
@@ -89,6 +89,8 @@
           CVE-2019-0657, CVE-2019-0980, and CVE-2019-0981. Since no meta-package depends on version 4.3.2, which
           addresses those vulnerabilites, we need to pull it in ourselves. -->
           <PackageReference Include="System.Private.Uri" />
+          <!-- Include package/runtime version numbers -->
+          <Compile Include="$(MicrosoftWindowsAppSDKPackageDir)include\WindowsAppSDK-VersionInfo.cs" />
       </ItemGroup>
 
       <ItemGroup Condition="'$(IsInWinUIRepo)' != 'true'">
@@ -115,8 +117,6 @@
       </ItemGroup>
 
       <ItemGroup>
-          <!-- Include package/runtime version numbers -->
-          <Compile Include="$(MicrosoftWindowsAppSDKPackageDir)include\WindowsAppSDK-VersionInfo.cs" />
           <Compile Remove="CollectionsInterop.cs" />
           <Compile Remove="Behaviors\ImageScrollBehavior.cs" />
           <Compile Remove="ControlPages\ScrollViewer2Page.xaml.cs" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Add missing namespace in BreadCrumBar.xaml.cs
- Add `#Nullable enable` to disable build warning
- Move compile include line to more appropriate location.
