### PR TITLE
Upgrading to Toolkit 8.x

### DIFF
--- a/WinUIGallery/ControlPages/DesignGuidance/IconsPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/IconsPage.xaml
@@ -134,7 +134,7 @@
                             <Paragraph>
                                 If you don't specify a FontFamily,
                                 or you specify a FontFamily that is not available on the system at runtime,
-                                the<Hyperlink NavigateUri="https://learn.microsoft.com/uwp/api/windows.ui.xaml.controls.fonticon">FontIcon</Hyperlink> falls back to the default font family defined by the SymbolThemeFontFamily resource.</Paragraph>
+                                the <Hyperlink NavigateUri="https://learn.microsoft.com/uwp/api/windows.ui.xaml.controls.fonticon">FontIcon</Hyperlink> falls back to the default font family defined by the SymbolThemeFontFamily resource.</Paragraph>
                             <Paragraph>
                                 An icon with a 16-epx font size is the equivalent of a 16x16-epx icon, to make sizing and positioning more predictable.
                                 For optimal appearance, use these specific sizes: 16, 20, 24, 32, 40, 48, and 64. Deviating from these font sizes could lead to less crisp or blurry outcomes.

--- a/WinUIGallery/ControlPages/DesignGuidance/IconsPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/IconsPage.xaml
@@ -122,8 +122,7 @@
                         </Paragraph>
                         <Paragraph>
                             On Windows 11: There's nothing you need to do, the font comes with Windows.<LineBreak />
-                            On Windows 10: Segoe Fluent Icons is not included by default on Windows 10. You can download it<Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/downloads/#fonts">here</Hyperlink>
-                            .</Paragraph>
+                            On Windows 10: Segoe Fluent Icons is not included by default on Windows 10. You can download it <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/downloads/#fonts">here</Hyperlink>                            .</Paragraph>
                     </RichTextBlock>
                 </toolkit:SettingsCard>
                 <toolkit:SettingsCard Padding="16,8" ContentAlignment="Left">
@@ -135,15 +134,13 @@
                             <Paragraph>
                                 If you don't specify a FontFamily,
                                 or you specify a FontFamily that is not available on the system at runtime,
-                                the<Hyperlink NavigateUri="https://learn.microsoft.com/uwp/api/windows.ui.xaml.controls.fonticon">FontIcon</Hyperlink>
-                                falls back to the default font family defined by the SymbolThemeFontFamily resource.</Paragraph>
+                                the<Hyperlink NavigateUri="https://learn.microsoft.com/uwp/api/windows.ui.xaml.controls.fonticon">FontIcon</Hyperlink> falls back to the default font family defined by the SymbolThemeFontFamily resource.</Paragraph>
                             <Paragraph>
                                 An icon with a 16-epx font size is the equivalent of a 16x16-epx icon, to make sizing and positioning more predictable.
                                 For optimal appearance, use these specific sizes: 16, 20, 24, 32, 40, 48, and 64. Deviating from these font sizes could lead to less crisp or blurry outcomes.
                             </Paragraph>
                             <Paragraph>
-                                All glyphs in Segoe Fluent Icons have the same fixed width with a consistent height and left origin point, so<Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/style/segoe-fluent-icons-font#layering-and-mirroring">layering</Hyperlink>
-                                and colorization effects can be achieved by drawing glyphs directly on top of each other.</Paragraph>
+                                All glyphs in Segoe Fluent Icons have the same fixed width with a consistent height and left origin point, so <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/style/segoe-fluent-icons-font#layering-and-mirroring">layering</Hyperlink> and colorization effects can be achieved by drawing glyphs directly on top of each other.</Paragraph>
                         </RichTextBlock>
                         <controls:SampleCodePresenter CodeSourceFile="Icons/FontIconSample2_xaml.txt" SampleType="XAML" />
                     </StackPanel>

--- a/WinUIGallery/ControlPages/DesignGuidance/IconsPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/IconsPage.xaml
@@ -19,7 +19,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:AppUIBasics"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:labs="using:CommunityToolkit.Labs.WinUI"
+    xmlns:toolkit="using:CommunityToolkit.WinUI.Controls"
     mc:Ignorable="d">
 
     <Page.Resources>
@@ -109,24 +109,24 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <TextBlock Text="With the release of Windows 11, Segoe Fluent Icons is the recommended icon font."/>
-        <labs:SettingsExpander Grid.Row="1"
-                  IsExpanded="False"
-                  Header="Instructions on how to use Segoe Fluent Icons">
-            <labs:SettingsExpander.Items>
-                <labs:SettingsCard ContentAlignment="Left" Padding="16,8">
+        <TextBlock Text="With the release of Windows 11, Segoe Fluent Icons is the recommended icon font." />
+        <toolkit:SettingsExpander
+            Grid.Row="1"
+            Header="Instructions on how to use Segoe Fluent Icons"
+            IsExpanded="False">
+            <toolkit:SettingsExpander.Items>
+                <toolkit:SettingsCard Padding="16,8" ContentAlignment="Left">
                     <RichTextBlock TextWrapping="Wrap">
                         <Paragraph FontWeight="SemiBold">
                             How to get the font
                         </Paragraph>
                         <Paragraph>
                             On Windows 11: There's nothing you need to do, the font comes with Windows.<LineBreak />
-                            On Windows 10: Segoe Fluent Icons is not included by default on Windows 10. You can download it
-                            <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/downloads/#fonts">here</Hyperlink>.
-                        </Paragraph>
+                            On Windows 10: Segoe Fluent Icons is not included by default on Windows 10. You can download it<Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/downloads/#fonts">here</Hyperlink>
+                            .</Paragraph>
                     </RichTextBlock>
-                </labs:SettingsCard>
-                <labs:SettingsCard ContentAlignment="Left" Padding="16,8">
+                </toolkit:SettingsCard>
+                <toolkit:SettingsCard Padding="16,8" ContentAlignment="Left">
                     <StackPanel Orientation="Vertical" Spacing="8">
                         <RichTextBlock TextWrapping="Wrap">
                             <Paragraph FontWeight="SemiBold">
@@ -135,43 +135,40 @@
                             <Paragraph>
                                 If you don't specify a FontFamily,
                                 or you specify a FontFamily that is not available on the system at runtime,
-                                the <Hyperlink NavigateUri="https://learn.microsoft.com/uwp/api/windows.ui.xaml.controls.fonticon">FontIcon</Hyperlink> falls back to the default font family defined by the SymbolThemeFontFamily resource.
-                            </Paragraph>
+                                the<Hyperlink NavigateUri="https://learn.microsoft.com/uwp/api/windows.ui.xaml.controls.fonticon">FontIcon</Hyperlink>
+                                falls back to the default font family defined by the SymbolThemeFontFamily resource.</Paragraph>
                             <Paragraph>
                                 An icon with a 16-epx font size is the equivalent of a 16x16-epx icon, to make sizing and positioning more predictable.
                                 For optimal appearance, use these specific sizes: 16, 20, 24, 32, 40, 48, and 64. Deviating from these font sizes could lead to less crisp or blurry outcomes.
                             </Paragraph>
                             <Paragraph>
-                                All glyphs in Segoe Fluent Icons have the same fixed width with a consistent height and left origin point, so
-                                <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/style/segoe-fluent-icons-font#layering-and-mirroring">layering</Hyperlink> and colorization effects can be achieved by drawing glyphs directly on top of each other.
-                            </Paragraph>
+                                All glyphs in Segoe Fluent Icons have the same fixed width with a consistent height and left origin point, so<Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/style/segoe-fluent-icons-font#layering-and-mirroring">layering</Hyperlink>
+                                and colorization effects can be achieved by drawing glyphs directly on top of each other.</Paragraph>
                         </RichTextBlock>
-                        <controls:SampleCodePresenter
-                            SampleType="XAML"
-                            CodeSourceFile="Icons/FontIconSample2_xaml.txt">
-                        </controls:SampleCodePresenter>
+                        <controls:SampleCodePresenter CodeSourceFile="Icons/FontIconSample2_xaml.txt" SampleType="XAML" />
                     </StackPanel>
-                </labs:SettingsCard>
-            </labs:SettingsExpander.Items>
-        </labs:SettingsExpander>
+                </toolkit:SettingsCard>
+            </toolkit:SettingsExpander.Items>
+        </toolkit:SettingsExpander>
 
-        <StackPanel Grid.Row="2" Spacing="8" Margin="0,24,0,0">
-            <TextBlock
-            Style="{ThemeResource BodyStrongTextBlockStyle}"
-            Text="Fluent Icons Library" />
+        <StackPanel
+            Grid.Row="2"
+            Margin="0,24,0,0"
+            Spacing="8">
+            <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}" Text="Fluent Icons Library" />
             <AutoSuggestBox
-            MinWidth="304"
-            MaxWidth="320"
-            HorizontalAlignment="Left"
-            PlaceholderText="Search icons"
-            QueryIcon="Find"
-            TextChanged="SearchTextBox_TextChanged" />
+                MinWidth="304"
+                MaxWidth="320"
+                HorizontalAlignment="Left"
+                PlaceholderText="Search icons"
+                QueryIcon="Find"
+                TextChanged="SearchTextBox_TextChanged" />
         </StackPanel>
 
         <controls1:SampleThemeListener
-                Grid.Row="3"
-                MaxHeight="600"
-                VerticalAlignment="Top">
+            Grid.Row="3"
+            MaxHeight="600"
+            VerticalAlignment="Top">
             <Grid
                 Background="{ThemeResource ControlExampleDisplayBrush}"
                 BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"

--- a/WinUIGallery/Controls/HomePageHeaderImage.xaml
+++ b/WinUIGallery/Controls/HomePageHeaderImage.xaml
@@ -7,7 +7,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:toolkit="using:CommunityToolkit.WinUI.UI"
+    xmlns:toolkit="using:CommunityToolkit.WinUI"
     Loaded="OnLoaded"
     Loading="OnLoading"
     Unloaded="OnUnloaded"

--- a/WinUIGallery/Controls/HomePageHeaderImage.xaml.cs
+++ b/WinUIGallery/Controls/HomePageHeaderImage.xaml.cs
@@ -9,10 +9,10 @@ using Microsoft.UI.Xaml.Hosting;
 using Microsoft.UI.Xaml.Media.Animation;
 using Microsoft.UI.Composition;
 using Microsoft.UI;
-using CommunityToolkit.WinUI.UI.Animations;
+using CommunityToolkit.WinUI.Animations;
 using Windows.UI;
 using System;
-using CommunityToolkit.WinUI.UI;
+using CommunityToolkit.WinUI;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.

--- a/WinUIGallery/Controls/PageHeader.xaml
+++ b/WinUIGallery/Controls/PageHeader.xaml
@@ -6,7 +6,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:WinUIGallery.DesktopWap.Controls.CopyButton"
-    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:data="using:AppUIBasics.Data"
     xmlns:local="using:WinUIGallery.DesktopWap.Controls"
@@ -31,7 +31,6 @@
             Style="{StaticResource TitleTextBlockStyle}"
             Text="{x:Bind Item.Title}"
             AutomationProperties.AutomationId="PageHeader"
-            AutomationProperties.HeadingLevel="Level1"
             TextTrimming="CharacterEllipsis"
             TextWrapping="NoWrap" />
         <TextBlock

--- a/WinUIGallery/ItemPage.xaml
+++ b/WinUIGallery/ItemPage.xaml
@@ -14,7 +14,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:WinUIGallery.DesktopWap.Controls"
-    xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     x:Name="pageRoot"

--- a/WinUIGallery/SettingsPage.xaml
+++ b/WinUIGallery/SettingsPage.xaml
@@ -2,7 +2,7 @@
     x:Class="AppUIBasics.SettingsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:labs="using:CommunityToolkit.Labs.WinUI">
+    xmlns:toolkit="using:CommunityToolkit.WinUI.Controls">
     <Page.Resources>
         <!--  These styles can be referenced to create a consistent SettingsPage layout  -->
 
@@ -61,99 +61,99 @@
                     <RepositionThemeTransition IsStaggeringEnabled="False" />
                 </StackPanel.ChildrenTransitions>
                 <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="Appearance &amp; behavior" />
-                <labs:SettingsCard Description="Select which app theme to display" Header="App theme">
-                    <labs:SettingsCard.HeaderIcon>
+                <toolkit:SettingsCard Description="Select which app theme to display" Header="App theme">
+                    <toolkit:SettingsCard.HeaderIcon>
                         <FontIcon Glyph="&#xE790;" />
-                    </labs:SettingsCard.HeaderIcon>
+                    </toolkit:SettingsCard.HeaderIcon>
                     <ComboBox x:Name="themeMode" AutomationProperties.AutomationId="themeModeComboBox" SelectionChanged="themeMode_SelectionChanged">
                         <ComboBoxItem Content="Light" Tag="Light" />
                         <ComboBoxItem Content="Dark" Tag="Dark" />
                         <ComboBoxItem Content="Use system setting" Tag="Default" />
                     </ComboBox>
-                </labs:SettingsCard>
+                </toolkit:SettingsCard>
 
-                <labs:SettingsCard Header="Navigation style">
-                    <labs:SettingsCard.HeaderIcon>
+                <toolkit:SettingsCard Header="Navigation style">
+                    <toolkit:SettingsCard.HeaderIcon>
                         <FontIcon Glyph="&#xF594;" />
-                    </labs:SettingsCard.HeaderIcon>
+                    </toolkit:SettingsCard.HeaderIcon>
                     <ComboBox x:Name="navigationLocation" SelectionChanged="navigationLocation_SelectionChanged">
                         <ComboBoxItem Content="Left" />
                         <ComboBoxItem Content="Top" />
                     </ComboBox>
-                </labs:SettingsCard>
+                </toolkit:SettingsCard>
 
-                <labs:SettingsExpander Description="Controls provide audible feedback" Header="Sound">
-                    <labs:SettingsExpander.HeaderIcon>
+                <toolkit:SettingsExpander Description="Controls provide audible feedback" Header="Sound">
+                    <toolkit:SettingsExpander.HeaderIcon>
                         <FontIcon Glyph="&#xEC4F;" />
-                    </labs:SettingsExpander.HeaderIcon>
+                    </toolkit:SettingsExpander.HeaderIcon>
                     <ToggleSwitch x:Name="soundToggle" Toggled="soundToggle_Toggled" />
-                    <labs:SettingsExpander.Items>
-                        <labs:SettingsCard
+                    <toolkit:SettingsExpander.Items>
+                        <toolkit:SettingsCard
                             x:Name="SpatialAudioCard"
                             Header="Enable Spatial Audio"
                             IsEnabled="False">
-                            <labs:SettingsCard.Description>
+                            <toolkit:SettingsCard.Description>
                                 <HyperlinkButton Click="soundPageHyperlink_Click" Content="Learn more about enabling sounds in your app" />
-                            </labs:SettingsCard.Description>
+                            </toolkit:SettingsCard.Description>
                             <ToggleSwitch x:Name="spatialSoundBox" Toggled="spatialSoundBox_Toggled" />
-                        </labs:SettingsCard>
-                    </labs:SettingsExpander.Items>
-                </labs:SettingsExpander>
+                        </toolkit:SettingsCard>
+                    </toolkit:SettingsExpander.Items>
+                </toolkit:SettingsExpander>
 
-                <labs:SettingsExpander x:Name="ScreenshotCard" Header="Screenshot mode">
-                    <labs:SettingsExpander.HeaderIcon>
+                <toolkit:SettingsExpander x:Name="ScreenshotCard" Header="Screenshot mode">
+                    <toolkit:SettingsExpander.HeaderIcon>
                         <FontIcon Glyph="&#xEC4F;" />
-                    </labs:SettingsExpander.HeaderIcon>
+                    </toolkit:SettingsExpander.HeaderIcon>
                     <ToggleSwitch x:Name="screenshotModeToggle" Toggled="screenshotModeToggle_Toggled" />
-                    <labs:SettingsExpander.Items>
-                        <labs:SettingsCard x:Name="ScreenshotFolderCard" Header="Screenshot folder">
-                            <labs:SettingsCard.Description>
+                    <toolkit:SettingsExpander.Items>
+                        <toolkit:SettingsCard x:Name="ScreenshotFolderCard" Header="Screenshot folder">
+                            <toolkit:SettingsCard.Description>
                                 <HyperlinkButton x:Name="screenshotFolderLink" Click="screenshotFolderLink_Click" />
-                            </labs:SettingsCard.Description>
+                            </toolkit:SettingsCard.Description>
                             <Button Click="FolderButton_Click" Content="Browse" />
-                        </labs:SettingsCard>
-                    </labs:SettingsExpander.Items>
-                </labs:SettingsExpander>
+                        </toolkit:SettingsCard>
+                    </toolkit:SettingsExpander.Items>
+                </toolkit:SettingsExpander>
 
                 <!--  About  -->
                 <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="About" />
-                <labs:SettingsExpander Description="© 2023 Microsoft. All rights reserved." Header="{StaticResource AppTitleName}">
-                    <labs:SettingsExpander.HeaderIcon>
+                <toolkit:SettingsExpander Description="© 2023 Microsoft. All rights reserved." Header="{StaticResource AppTitleName}">
+                    <toolkit:SettingsExpander.HeaderIcon>
                         <BitmapIcon ShowAsMonochrome="False" UriSource="/Assets/Tiles/SmallTile-sdk.png" />
-                    </labs:SettingsExpander.HeaderIcon>
+                    </toolkit:SettingsExpander.HeaderIcon>
                     <TextBlock
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                         IsTextSelectionEnabled="True"
                         Text="{x:Bind Version}" />
-                    <labs:SettingsExpander.Items>
-                        <labs:SettingsCard Header="To clone this repository">
+                    <toolkit:SettingsExpander.Items>
+                        <toolkit:SettingsCard Header="To clone this repository">
                             <TextBlock
                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                 IsTextSelectionEnabled="True"
                                 Text="git clone https://github.com/microsoft/WinUI-Gallery" />
-                        </labs:SettingsCard>
-                        <labs:SettingsCard
+                        </toolkit:SettingsCard>
+                        <toolkit:SettingsCard
                             x:Name="bugRequestCard"
                             Click="bugRequestCard_Click"
                             Header="File a bug or request new sample"
                             IsClickEnabled="True">
-                            <labs:SettingsCard.ActionIcon>
+                            <toolkit:SettingsCard.ActionIcon>
                                 <FontIcon Glyph="&#xE8A7;" />
-                            </labs:SettingsCard.ActionIcon>
-                        </labs:SettingsCard>
-                        <labs:SettingsCard
+                            </toolkit:SettingsCard.ActionIcon>
+                        </toolkit:SettingsCard>
+                        <toolkit:SettingsCard
                             HorizontalContentAlignment="Left"
                             ContentAlignment="Vertical"
                             Header="Dependencies &amp; references">
                             <StackPanel Margin="-12,0,0,0" Orientation="Vertical">
                                 <HyperlinkButton Content="{x:Bind WinAppSdkRuntimeDetails}" NavigateUri="https://aka.ms/windowsappsdk" />
                                 <HyperlinkButton Content="Windows UI Library" NavigateUri="https://aka.ms/winui" />
-                                <HyperlinkButton Content="Windows Community Toolkit" NavigateUri="https://github.com/CommunityToolkit/WindowsCommunityToolkit" />
+                                <HyperlinkButton Content="Windows Community Toolkit" NavigateUri="https://aka.ms/toolkit/windows" />
                                 <HyperlinkButton Content="ColorCode-Universal" NavigateUri="https://github.com/WilliamABradley/ColorCode-Universal" />
                                 <HyperlinkButton Content="Win2D" NavigateUri="https://github.com/Microsoft/Win2D" />
                             </StackPanel>
-                        </labs:SettingsCard>
-                        <labs:SettingsCard
+                        </toolkit:SettingsCard>
+                        <toolkit:SettingsCard
                             HorizontalContentAlignment="Left"
                             ContentAlignment="Vertical"
                             Header="THIS CODE AND INFORMATION IS PROVIDED ‘AS IS’ WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.">
@@ -161,9 +161,9 @@
                                 <HyperlinkButton Content="Microsoft Services Agreement" NavigateUri="https://go.microsoft.com/fwlink/?LinkId=822631" />
                                 <HyperlinkButton Content="Microsoft Privacy Statement" NavigateUri="https://go.microsoft.com/fwlink/?LinkId=521839" />
                             </StackPanel>
-                        </labs:SettingsCard>
-                    </labs:SettingsExpander.Items>
-                </labs:SettingsExpander>
+                        </toolkit:SettingsCard>
+                    </toolkit:SettingsExpander.Items>
+                </toolkit:SettingsExpander>
             </StackPanel>
         </ScrollViewer>
     </Grid>

--- a/WinUIGallery/WinUIGallery.csproj
+++ b/WinUIGallery/WinUIGallery.csproj
@@ -80,10 +80,10 @@
           <PackageReference Include="ColorCode.Core" />
           <PackageReference Include="Microsoft.Graphics.Win2D" />
           <PackageReference Include="Microsoft.Windows.CsWinRT" />
-          <PackageReference Include="CommunityToolkit.Labs.WinUI.SegmentedControl" />
-          <PackageReference Include="CommunityToolkit.Labs.WinUI.SettingsControls" />
-          <PackageReference Include="CommunityToolkit.WinUI.UI" />
-          <PackageReference Include="CommunityToolkit.WinUI.UI.Animations" />
+          <PackageReference Include="CommunityToolkit.WinUI.Controls.Segmented" />
+          <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" />
+          <PackageReference Include="CommunityToolkit.WinUI.Converters" />
+          <PackageReference Include="CommunityToolkit.WinUI.Animations" />
           <Manifest Include="$(ApplicationManifest)" />
           <!-- System.Private.Uri is pulled in transitively through ColorCode.Core and contains vulnerabilities
           CVE-2019-0657, CVE-2019-0980, and CVE-2019-0981. Since no meta-package depends on version 4.3.2, which
@@ -99,13 +99,13 @@
           <PackageReference Remove="ColorCode.Core" />
           <PackageReference Include="ColorCode.WinUI"
                             Version="$(ColorCodeVersion)" />
-          <PackageReference Update="CommunityToolkit.Labs.WinUI.SegmentedControl"
-                            Version="$(CommunityToolkitSegmentedControlVersion)" />
-          <PackageReference Update="CommunityToolkit.Labs.WinUI.SettingsControls"
-                            Version="$(CommunityToolkitSettingsControlsVersion)" />
-          <PackageReference Update="CommunityToolkit.WinUI.UI"
+          <PackageReference Update="CommunityToolkit.WinUI.Controls.Segmented"
                             Version="$(CommunityToolkitWinUIVersion)" />
-          <PackageReference Update="CommunityToolkit.WinUI.UI.Animations"
+          <PackageReference Update="CommunityToolkit.WinUI.Controls.SettingsControls"
+                            Version="$(CommunityToolkitWinUIVersion)" />
+          <PackageReference Update="CommunityToolkit.WinUI.Converters"
+                            Version="$(CommunityToolkitWinUIVersion)" />
+          <PackageReference Update="CommunityToolkit.WinUI.Animations"
                             Version="$(CommunityToolkitWinUIVersion)" />
           <PackageReference Update="Microsoft.Graphics.Win2D"
                             Version="$(GraphicsWin2DVersion)" />

--- a/WinUIGallery/standalone.props
+++ b/WinUIGallery/standalone.props
@@ -6,9 +6,7 @@
     <MicrosoftNETCoreUniversalWindowsPlatformVersion>6.2.11</MicrosoftNETCoreUniversalWindowsPlatformVersion>
     <GraphicsWin2DVersion>1.0.4</GraphicsWin2DVersion>
     <ColorCodeVersion>2.0.13</ColorCodeVersion>
-    <CommunityToolkitSegmentedControlVersion>0.0.2</CommunityToolkitSegmentedControlVersion>
-    <CommunityToolkitSettingsControlsVersion>0.0.16</CommunityToolkitSettingsControlsVersion>
-    <CommunityToolkitWinUIVersion>7.1.2</CommunityToolkitWinUIVersion>
+    <CommunityToolkitWinUIVersion>8.0.230823-rc</CommunityToolkitWinUIVersion>
     <MicrosoftWindowsSDKBuildToolsNugetPackageVersion>10.0.22621.756</MicrosoftWindowsSDKBuildToolsNugetPackageVersion>
     <MicrosoftCsWinRTPackageVersion>2.0.3</MicrosoftCsWinRTPackageVersion>
     <!-- We have multiple projects in the same directory, which means we need to separate their output paths-->

--- a/nuget.config
+++ b/nuget.config
@@ -10,9 +10,6 @@
     <!-- For more info, see https://docs.nuget.org/consume/nuget-config-file -->
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
 
-    <!-- Windows Community Toolkit Labs preview feed -->
-    <add key="Toolkit Labs" value="https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-Labs/nuget/v3/index.json" />
-
     <!-- a local directory to allow testing nupkg files without pushing to a remote feed -->
     <add key="packagestore" value="packagestore" />
   </packageSources>


### PR DESCRIPTION
Upgrading to our new Toolkit 8.x packages.

This PR:

- Moves Toolkit packages to 8.0
- Removes the Labs preview feed, as packages are now available on the public nuget feed.
- Updating a bunch of Toolkit related namespaces
- XAML styling kicked in when editing a few .XAML packages