### PR TITLE
[Design guidance] Add design guidance to the homepage

### DIFF
--- a/WinUIGallery/DataModel/ControlInfoData.json
+++ b/WinUIGallery/DataModel/ControlInfoData.json
@@ -11,6 +11,7 @@
         {
           "UniqueId": "Typography",
           "Title": "Typography",
+          "Subtitle": "The type ramp used in WinUI",
           "ImagePath": "ms-appx:///Assets/ControlImages/AppBarSeparator.png",
           "ImageIconPath": "ms-appx:///Assets/ControlIcons/AppBarSeparatorIcon.png",
           "HideSourceCodeAndRelatedControls": true,
@@ -32,6 +33,7 @@
         {
           "UniqueId": "Icons",
           "Title": "Icons",
+          "Subtitle": "A complete list of icons in the Segoe Fluent Icons font",
           "ImagePath": "ms-appx:///Assets/ControlImages/AppBarSeparator.png",
           "ImageIconPath": "ms-appx:///Assets/ControlIcons/AppBarSeparatorIcon.png",
           "HideSourceCodeAndRelatedControls": true,
@@ -49,6 +51,7 @@
         {
           "UniqueId": "Colors",
           "Title": "Colors",
+          "Subtitle": "Theme colors and their usage",
           "ImagePath": "ms-appx:///Assets/ControlImages/AppBarSeparator.png",
           "ImageIconPath": "ms-appx:///Assets/ControlIcons/AppBarSeparatorIcon.png",
           "HideSourceCodeAndRelatedControls": true,
@@ -69,6 +72,7 @@
         {
           "UniqueId": "AccessibilityColorContrast",
           "Title": "Color contrast",
+          "Subtitle": "Tool for checking color contrast",
           "ImagePath": "ms-appx:///Assets/ControlImages/AppBarSeparator.png",
           "ImageIconPath": "ms-appx:///Assets/ControlIcons/AppBarSeparatorIcon.png",
           "HideSourceCodeAndRelatedControls": true,
@@ -86,6 +90,7 @@
         {
           "UniqueId": "AccessibilityKeyboard",
           "Title": "Keyboard support",
+          "Subtitle": "How to write keyboard-accessible apps",
           "ImagePath": "ms-appx:///Assets/ControlImages/AppBarSeparator.png",
           "ImageIconPath": "ms-appx:///Assets/ControlIcons/AppBarSeparatorIcon.png",
           "HideSourceCodeAndRelatedControls": true,
@@ -127,6 +132,7 @@
         {
           "UniqueId": "AccessibilityScreenReader",
           "Title": "Screen reader support",
+          "Subtitle": "How to write screen reader-accessible apps for blind and visually-impaired people",
           "ImagePath": "ms-appx:///Assets/ControlImages/AppBarSeparator.png",
           "ImageIconPath": "ms-appx:///Assets/ControlIcons/AppBarSeparatorIcon.png",
           "HideSourceCodeAndRelatedControls": true,

--- a/WinUIGallery/NewControlsPage.xaml
+++ b/WinUIGallery/NewControlsPage.xaml
@@ -63,6 +63,7 @@
                 <Grid x:Name="HeaderGrid" Margin="-24,0,-24,0">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="204" />
+                        <RowDefinition Height="Auto" />
                         <RowDefinition Height="*" />
                     </Grid.RowDefinitions>
                     <controls:HomePageHeaderImage

--- a/WinUIGallery/NewControlsPage.xaml.cs
+++ b/WinUIGallery/NewControlsPage.xaml.cs
@@ -30,7 +30,9 @@ namespace AppUIBasics
             var menuItem = (Microsoft.UI.Xaml.Controls.NavigationViewItem)args.NavigationRootPage.NavigationView.MenuItems.First();
             menuItem.IsSelected = true;
 
-            Items = ControlInfoDataSource.Instance.Groups.SelectMany(g => g.Items.Where(i => i.BadgeString != null)).OrderBy(i => i.Title).ToList();
+            Items = ControlInfoDataSource.Instance.Groups
+                .SelectMany(g => g.Items.Where(i => i.BadgeString != null || g.IsSpecialSection))
+                .OrderBy(i => i.Title).ToList();
             itemsCVS.Source = FormatData();
         }
 
@@ -39,7 +41,7 @@ namespace AppUIBasics
             var query = from item in this.Items
                         group item by item.BadgeString into g
                         orderby g.Key
-                        select new GroupInfoList(g) { Key = g.Key };
+                        select new GroupInfoList(g) { Key = g.Key ?? "SpecialSection" };
 
             ObservableCollection<GroupInfoList> groupList = new ObservableCollection<GroupInfoList>(query);
 
@@ -63,6 +65,9 @@ namespace AppUIBasics
                         break;
                     case "Preview":
                         item.Title = "Preview samples";
+                        break;
+                    case "SpecialSection":
+                        item.Title = "Design guidance";
                         break;
                 }
             }


### PR DESCRIPTION
Today, the **Design guidance** section is not obvious if you don't already know about it. This change adds Design Guidance items to the homepage.

## Description

* Add Design guidance section on home page by extending the LINQ query.
* Add subtitles to Design guidance pages.

## Motivation and Context

We've done a fair amount of work to write great design guidance, including accessibility & colors & type ramp guidance, but it is hard to discover. This change makes it much more prominent.

## How Has This Been Tested?

Deployed locally.

* [X] Design guidance section appears
* [ ] Design guidance items have icons
* [X] Design guidance items have descriptions
* [ ] Clicking the items navigates in both the main view and the nav view.

## Screenshots (if appropriate)

![Design guidance section on homepage](https://github.com/microsoft/WinUI-Gallery/assets/432939/5b7af4e1-3265-42df-8e23-be4c231dd713)


## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
