### PR TITLE
Fix sample presenter not properly determing if its empty

### DIFF
--- a/WinUIGallery/Controls/SampleCodePresenter.xaml.cs
+++ b/WinUIGallery/Controls/SampleCodePresenter.xaml.cs
@@ -66,7 +66,7 @@ namespace AppUIBasics.Controls
             set { SetValue(SubstitutionsProperty, value); }
         }
 
-        public bool IsEmpty => Code.Length == 0 && CodeSourceFile == null;
+        public bool IsEmpty => string.IsNullOrEmpty(Code) && string.IsNullOrEmpty(CodeSourceFile);
 
         private string actualCode = "";
         private static Regex SubstitutionPattern = new Regex(@"\$\(([^\)]+)\)");
@@ -87,7 +87,7 @@ namespace AppUIBasics.Controls
 
         private void ReevaluateVisibility()
         {
-            if (Code.Length == 0 && CodeSourceFile == null)
+            if (IsEmpty)
             {
                 Visibility = Visibility.Collapsed;
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The sample presenter did not properly determine if it was empty resulting in it not hiding despite it being empty.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1373
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
