### PR TITLE
Fix damping sample misbehaving when using wrong locale

### DIFF
--- a/WinUIGallery/ControlPages/XamlCompInteropPage.xaml.cs
+++ b/WinUIGallery/ControlPages/XamlCompInteropPage.xaml.cs
@@ -7,6 +7,7 @@ using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
+using System.Globalization;
 
 namespace AppUIBasics.ControlPages
 {
@@ -42,7 +43,9 @@ namespace AppUIBasics.ControlPages
         {
             if(DampingStackPanel.SelectedItem != null)
             {
-                return (float)Convert.ToDouble((DampingStackPanel.SelectedItem as RadioButton).Content);
+                // We need to specify the InvariantCulture since the decimal point depends on the
+                // system language and might parse "0.8" to 8 since the decimal point is a different character
+                return float.Parse((DampingStackPanel.SelectedItem as RadioButton).Content as string, CultureInfo.InvariantCulture);
             }
             return 0.6f;
         }

--- a/WinUIGallery/ControlPages/XamlCompInteropPage.xaml.cs
+++ b/WinUIGallery/ControlPages/XamlCompInteropPage.xaml.cs
@@ -45,7 +45,7 @@ namespace AppUIBasics.ControlPages
             {
                 // We need to specify the InvariantCulture since the decimal point depends on the
                 // system language and might parse "0.8" to 8 since the decimal point is a different character
-                return float.Parse((DampingStackPanel.SelectedItem as RadioButton).Content as string, CultureInfo.InvariantCulture);
+                return (float)Convert.ToDouble((DampingStackPanel.SelectedItem as RadioButton).Content, CultureInfo.InvariantCulture);
             }
             return 0.6f;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes issues with the damping sample since we weren't using 0.2, 0.4 etc but sometimes 2,4,... as damping ratio depending on the users locale
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1049
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
