### PR TITLE
Turn off trimming (until it works with Gallery). Turn off Self-Contai…

### DIFF
--- a/WinUIGallery/Properties/PublishProfiles/win10-arm64-unpackaged.pubxml
+++ b/WinUIGallery/Properties/PublishProfiles/win10-arm64-unpackaged.pubxml
@@ -7,10 +7,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>ARM64</Platform>
     <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
-    <SelfContained>True</SelfContained>
+    <SelfContained>$(IsInWinUIRepo)</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishAppxPackage>False</PublishAppxPackage>
     <PublishReadyToRun>False</PublishReadyToRun>
-    <PublishTrimmed>$(Optimized)</PublishTrimmed>
+    <PublishTrimmed>False</PublishTrimmed>
   </PropertyGroup>
 </Project>

--- a/WinUIGallery/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/WinUIGallery/Properties/PublishProfiles/win10-arm64.pubxml
@@ -7,10 +7,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>ARM64</Platform>
     <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
-    <SelfContained>True</SelfContained>
+    <SelfContained>$(IsInWinUIRepo)</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishAppxPackage>True</PublishAppxPackage>
     <PublishReadyToRun>False</PublishReadyToRun>
-    <PublishTrimmed>$(Optimized)</PublishTrimmed>
+    <PublishTrimmed>False</PublishTrimmed>
   </PropertyGroup>
 </Project>

--- a/WinUIGallery/Properties/PublishProfiles/win10-x64-unpackaged.pubxml
+++ b/WinUIGallery/Properties/PublishProfiles/win10-x64-unpackaged.pubxml
@@ -7,10 +7,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
     <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
-    <SelfContained>True</SelfContained>
+    <SelfContained>$(IsInWinUIRepo)</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishAppxPackage>False</PublishAppxPackage>
     <PublishReadyToRun>False</PublishReadyToRun>
-    <PublishTrimmed>$(Optimized)</PublishTrimmed>
+    <PublishTrimmed>False</PublishTrimmed>
   </PropertyGroup>
 </Project>

--- a/WinUIGallery/Properties/PublishProfiles/win10-x64.pubxml
+++ b/WinUIGallery/Properties/PublishProfiles/win10-x64.pubxml
@@ -7,10 +7,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
     <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
-    <SelfContained>True</SelfContained>
+    <SelfContained>$(IsInWinUIRepo)</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishAppxPackage>True</PublishAppxPackage>
     <PublishReadyToRun>False</PublishReadyToRun>
-    <PublishTrimmed>$(Optimized)</PublishTrimmed>
+    <PublishTrimmed>False</PublishTrimmed>
   </PropertyGroup>
 </Project>

--- a/WinUIGallery/Properties/PublishProfiles/win10-x86-unpackaged.pubxml
+++ b/WinUIGallery/Properties/PublishProfiles/win10-x86-unpackaged.pubxml
@@ -7,10 +7,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
     <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
-    <SelfContained>True</SelfContained>
+    <SelfContained>$(IsInWinUIRepo)</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishAppxPackage>False</PublishAppxPackage>
     <PublishReadyToRun>False</PublishReadyToRun>
-    <PublishTrimmed>$(Optimized)</PublishTrimmed>
+    <PublishTrimmed>False</PublishTrimmed>
   </PropertyGroup>
 </Project>

--- a/WinUIGallery/Properties/PublishProfiles/win10-x86.pubxml
+++ b/WinUIGallery/Properties/PublishProfiles/win10-x86.pubxml
@@ -7,10 +7,10 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
     <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
-    <SelfContained>True</SelfContained>
+    <SelfContained>$(IsInWinUIRepo)</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishAppxPackage>True</PublishAppxPackage>
     <PublishReadyToRun>False</PublishReadyToRun>
-    <PublishTrimmed>$(Optimized)</PublishTrimmed>
+    <PublishTrimmed>False</PublishTrimmed>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Turn off trimming (until it works with Gallery)
- Turn off Self-Contained for public repo

## Description
Trimming does not yet work and was causing crashes in Release builds.
This will be re-enabled once the issues are resolved.
