### PR TITLE
Set TrimMode explicitly back to partial for .NET 7 compat

### DIFF
--- a/WinUIGallery/Properties/PublishProfiles/win10-arm64-unpackaged.pubxml
+++ b/WinUIGallery/Properties/PublishProfiles/win10-arm64-unpackaged.pubxml
@@ -7,10 +7,16 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>ARM64</Platform>
     <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <!--NOTE: this refers to .NET (not WinAppSDK) self-containment which must always be true, 
+        since there is no Windows framework package available for .NET 5+ -->
     <SelfContained>True</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishAppxPackage>False</PublishAppxPackage>
     <PublishReadyToRun>False</PublishReadyToRun>
     <PublishTrimmed>$(Optimized)</PublishTrimmed>
+    <!--With .NET 7, trimming mode default changed from partial to full which is more 
+        aggressive and includes all assemblies, not just those that have explicitly opted
+        into trimming, causing application errors.-->
+    <TrimMode>partial</TrimMode>
   </PropertyGroup>
 </Project>

--- a/WinUIGallery/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/WinUIGallery/Properties/PublishProfiles/win10-arm64.pubxml
@@ -7,10 +7,16 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>ARM64</Platform>
     <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <!--NOTE: this refers to .NET (not WinAppSDK) self-containment which must always be true, 
+        since there is no Windows framework package available for .NET 5+ -->
     <SelfContained>True</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishAppxPackage>True</PublishAppxPackage>
     <PublishReadyToRun>False</PublishReadyToRun>
     <PublishTrimmed>$(Optimized)</PublishTrimmed>
+    <!--With .NET 7, trimming mode default changed from partial to full which is more 
+        aggressive and includes all assemblies, not just those that have explicitly opted
+        into trimming, causing application errors.-->
+    <TrimMode>partial</TrimMode>
   </PropertyGroup>
 </Project>

--- a/WinUIGallery/Properties/PublishProfiles/win10-x64-unpackaged.pubxml
+++ b/WinUIGallery/Properties/PublishProfiles/win10-x64-unpackaged.pubxml
@@ -7,10 +7,16 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
     <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <!--NOTE: this refers to .NET (not WinAppSDK) self-containment which must always be true, 
+        since there is no Windows framework package available for .NET 5+ -->
     <SelfContained>True</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishAppxPackage>False</PublishAppxPackage>
     <PublishReadyToRun>False</PublishReadyToRun>
     <PublishTrimmed>$(Optimized)</PublishTrimmed>
+    <!--With .NET 7, trimming mode default changed from partial to full which is more 
+        aggressive and includes all assemblies, not just those that have explicitly opted
+        into trimming, causing application errors.-->
+    <TrimMode>partial</TrimMode>
   </PropertyGroup>
 </Project>

--- a/WinUIGallery/Properties/PublishProfiles/win10-x64.pubxml
+++ b/WinUIGallery/Properties/PublishProfiles/win10-x64.pubxml
@@ -7,10 +7,16 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
     <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <!--NOTE: this refers to .NET (not WinAppSDK) self-containment which must always be true, 
+        since there is no Windows framework package available for .NET 5+ -->
     <SelfContained>True</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishAppxPackage>True</PublishAppxPackage>
     <PublishReadyToRun>False</PublishReadyToRun>
     <PublishTrimmed>$(Optimized)</PublishTrimmed>
+    <!--With .NET 7, trimming mode default changed from partial to full which is more 
+        aggressive and includes all assemblies, not just those that have explicitly opted
+        into trimming, causing application errors.-->
+    <TrimMode>partial</TrimMode>
   </PropertyGroup>
 </Project>

--- a/WinUIGallery/Properties/PublishProfiles/win10-x86-unpackaged.pubxml
+++ b/WinUIGallery/Properties/PublishProfiles/win10-x86-unpackaged.pubxml
@@ -7,10 +7,16 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
     <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <!--NOTE: this refers to .NET (not WinAppSDK) self-containment which must always be true, 
+        since there is no Windows framework package available for .NET 5+ -->
     <SelfContained>True</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishAppxPackage>False</PublishAppxPackage>
     <PublishReadyToRun>False</PublishReadyToRun>
     <PublishTrimmed>$(Optimized)</PublishTrimmed>
+    <!--With .NET 7, trimming mode default changed from partial to full which is more 
+        aggressive and includes all assemblies, not just those that have explicitly opted
+        into trimming, causing application errors.-->
+    <TrimMode>partial</TrimMode>
   </PropertyGroup>
 </Project>

--- a/WinUIGallery/Properties/PublishProfiles/win10-x86.pubxml
+++ b/WinUIGallery/Properties/PublishProfiles/win10-x86.pubxml
@@ -7,10 +7,16 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
     <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <!--NOTE: this refers to .NET (not WinAppSDK) self-containment which must always be true, 
+        since there is no Windows framework package available for .NET 5+ -->
     <SelfContained>True</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishAppxPackage>True</PublishAppxPackage>
     <PublishReadyToRun>False</PublishReadyToRun>
     <PublishTrimmed>$(Optimized)</PublishTrimmed>
+    <!--With .NET 7, trimming mode default changed from partial to full which is more 
+        aggressive and includes all assemblies, not just those that have explicitly opted
+        into trimming, causing application errors.-->
+    <TrimMode>partial</TrimMode>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
See:
https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trimming-options?pivots=dotnet-7-0