### PR TITLE
P1 Accessibility Fixes

### DIFF
--- a/WinUIGallery/ConnectedAnimationPages/CollectionPage.xaml
+++ b/WinUIGallery/ConnectedAnimationPages/CollectionPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page
+<Page
     x:Class="AppUIBasics.ConnectedAnimationPages.CollectionPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -30,13 +30,12 @@
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="Views: " Style="{ThemeResource CaptionTextBlockStyle}" FontWeight="Bold"/>
                                 <TextBlock Text="{x:Bind Views}" Style="{ThemeResource CaptionTextBlockStyle}" Margin="5,0,0,0"/>
-                            </StackPanel>
-                            <StackPanel Orientation="Horizontal">
-                                <TextBlock Text="Likes: " Style="{ThemeResource CaptionTextBlockStyle}" FontWeight="Bold"/>
+
+                                <TextBlock Text="Likes: " Style="{ThemeResource CaptionTextBlockStyle}" FontWeight="Bold" Margin="8,0,0,0"/>
                                 <TextBlock Text="{x:Bind Likes}" Style="{ThemeResource CaptionTextBlockStyle}" Margin="5,0,0,0"/>
                             </StackPanel>
                             <StackPanel Orientation="Horizontal">
-                                <TextBlock Text="{x:Bind Description}" Style="{ThemeResource BodyTextBlockStyle}" FontStyle="Italic" Margin="0,12,0,0" TextTrimming="CharacterEllipsis" MaxWidth="500" MaxLines="1"/>
+                                <TextBlock Text="{x:Bind Description}" Style="{ThemeResource BodyTextBlockStyle}" FontStyle="Italic" Margin="0,8,0,0" TextTrimming="CharacterEllipsis" TextWrapping="Wrap" MaxWidth="500" MaxHeight="40" IsTextTrimmedChanged="TextBlock_IsTextTrimmedChanged"/>
                             </StackPanel>
 
                         </StackPanel>

--- a/WinUIGallery/ConnectedAnimationPages/CollectionPage.xaml.cs
+++ b/WinUIGallery/ConnectedAnimationPages/CollectionPage.xaml.cs
@@ -67,5 +67,12 @@ namespace AppUIBasics.ConnectedAnimationPages
             Frame.Navigate(typeof(DetailedInfoPage), _storeditem, new SuppressNavigationTransitionInfo());
         }
 
+        private void TextBlock_IsTextTrimmedChanged(TextBlock sender, IsTextTrimmedChangedEventArgs args)
+        {
+            var textBlock = sender as TextBlock;
+            var text = textBlock.IsTextTrimmed ? textBlock.Text : string.Empty;
+
+            ToolTipService.SetToolTip(textBlock, text);
+        }
     }
 }

--- a/WinUIGallery/ControlPages/ClipboardPage.xaml.cs
+++ b/WinUIGallery/ControlPages/ClipboardPage.xaml.cs
@@ -52,7 +52,7 @@ namespace AppUIBasics.ControlPages
                 var text = await package.GetTextAsync();
                 PasteClipboard2.Text = text;
 
-                UIHelper.AnnounceActionForAccessibility(sender as Button, "Text pasted to clipboard", "TextPastedSuccessNotificationId");
+                UIHelper.AnnounceActionForAccessibility(sender as Button, "Text pasted from clipboard", "TextPastedSuccessNotificationId");
             }
 
         }

--- a/WinUIGallery/ControlPages/ClipboardPage.xaml.cs
+++ b/WinUIGallery/ControlPages/ClipboardPage.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using AppUIBasics.Helper;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Windows.ApplicationModel.DataTransfer;
@@ -26,6 +27,8 @@ namespace AppUIBasics.ControlPages
             package.SetText(textToCopy);
             Clipboard.SetContent(package);
 
+            UIHelper.AnnounceActionForAccessibility(sender as Button, "Text copied to clipboard", "TextCopiedSuccessNotificationId");
+
             VisualStateManager.GoToState(this, "ConfirmationClipboardVisible", false);
             Microsoft.UI.Dispatching.DispatcherQueue dispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
 
@@ -48,6 +51,8 @@ namespace AppUIBasics.ControlPages
             {
                 var text = await package.GetTextAsync();
                 PasteClipboard2.Text = text;
+
+                UIHelper.AnnounceActionForAccessibility(sender as Button, "Text pasted to clipboard", "TextPastedSuccessNotificationId");
             }
 
         }

--- a/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/AccessibilityKeyboardPage.xaml
@@ -470,6 +470,7 @@
                     <Button
                         Grid.Row="1"
                         Click="MakeRedButton_Click"
+                        AutomationProperties.AcceleratorKey="Ctrl+R"
                         Content="Red">
                         <Button.KeyboardAccelerators>
                             <KeyboardAccelerator Key="R" Modifiers="Control" />
@@ -480,6 +481,7 @@
                         Grid.Row="1"
                         Grid.Column="1"
                         Click="MakeBlueButton_Click"
+                        AutomationProperties.AcceleratorKey="Ctrl+B"
                         Content="Blue">
                         <Button.KeyboardAccelerators>
                             <KeyboardAccelerator Key="B" Modifiers="Control" />
@@ -496,6 +498,7 @@
                         Grid.Column="2"
                         Click="MakeChartreuseButton_Click"
                         Content="Chartreuse"
+                        AutomationProperties.AcceleratorKey="Ctrl+G"
                         ToolTipService.ToolTip="A greenish-yellow (Ctrl+G)">
                         <Button.KeyboardAccelerators>
                             <KeyboardAccelerator Key="G" Modifiers="Control" />

--- a/WinUIGallery/ControlPages/DesignGuidance/IconsPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/IconsPage.xaml
@@ -156,6 +156,7 @@
             Spacing="8">
             <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}" Text="Fluent Icons Library" />
             <AutoSuggestBox
+                x:Name="IconsAutoSuggestBox"
                 MinWidth="304"
                 MaxWidth="320"
                 HorizontalAlignment="Left"

--- a/WinUIGallery/ControlPages/DesignGuidance/IconsPage.xaml.cs
+++ b/WinUIGallery/ControlPages/DesignGuidance/IconsPage.xaml.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
+using AppUIBasics.Helper;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
@@ -97,6 +98,9 @@ namespace AppUIBasics.ControlPages
             {
                 SelectedItem = FilteredItems[0];
             }
+
+            var outputString = FilteredItems.Count() + " icons found.";
+            UIHelper.AnnounceActionForAccessibility(IconsAutoSuggestBox, outputString, "AutoSuggestBoxNumberIconsFoundId");
         }
 
         private void Icons_TemplatePointerPressed(object sender, PointerRoutedEventArgs e)

--- a/WinUIGallery/ControlPages/DesignGuidance/IconsPage.xaml.cs
+++ b/WinUIGallery/ControlPages/DesignGuidance/IconsPage.xaml.cs
@@ -94,12 +94,20 @@ namespace AppUIBasics.ControlPages
                     FilteredItems.Add(item);
                 }
             }
-            if (FilteredItems.Count > 0)
+
+            string outputString;
+            var filteredItemsCount = FilteredItems.Count;
+
+            if (filteredItemsCount > 0)
             {
                 SelectedItem = FilteredItems[0];
+                outputString = filteredItemsCount > 1 ? filteredItemsCount + " icons found." : "1 icon found.";
+            }
+            else
+            {
+                outputString = "No icon found.";
             }
 
-            var outputString = FilteredItems.Count() + " icons found.";
             UIHelper.AnnounceActionForAccessibility(IconsAutoSuggestBox, outputString, "AutoSuggestBoxNumberIconsFoundId");
         }
 

--- a/WinUIGallery/ControlPages/DesignGuidance/TypographyPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/TypographyPage.xaml
@@ -50,191 +50,197 @@
             HeaderText="Type ramp"
             XamlSource="Typography/TypographySample_xaml.txt">
             <StackPanel HorizontalAlignment="Stretch" Orientation="Vertical">
-                <Canvas Height="450">
-                    <Image
-                        Height="450"
-                        Canvas.ZIndex="0"
-                        Source="{ThemeResource HeaderImage}" />
-                    <Button
-                        x:Name="ShowTypographyButton1"
-                        Canvas.Left="650"
-                        Canvas.Top="60"
-                        Padding="4"
-                        HorizontalAlignment="Right"
-                        VerticalAlignment="Top"
-                        AutomationProperties.Name="Show typography"
-                        Canvas.ZIndex="1"
-                        Click="ShowTypographyButtonClick1"
-                        ToolTipService.ToolTip="Caption">
-                        <FontIcon FontSize="16" Glyph="&#xE946;" />
-                    </Button>
-                    <TeachingTip
-                        x:Name="ShowTypographyInfoTooltip1"
-                        Title="Caption"
-                        Target="{x:Bind ShowTypographyButton1}" />
+                <ScrollViewer Height="450" HorizontalScrollMode="Auto" HorizontalScrollBarVisibility="Auto">
+                    <Canvas Height="450" Width="750">
+                        <Image
+                            Height="450"
+                            Canvas.ZIndex="0"
+                            Source="{ThemeResource HeaderImage}" />
+                        <Button
+                            x:Name="ShowTypographyButton1"
+                            Canvas.Left="650"
+                            Canvas.Top="60"
+                            Padding="4"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Top"
+                            AutomationProperties.Name="Show typography"
+                            Canvas.ZIndex="1"
+                            Click="ShowTypographyButtonClick1"
+                            ToolTipService.ToolTip="Caption">
+                            <FontIcon FontSize="16" Glyph="&#xE946;" />
+                        </Button>
+                        <TeachingTip
+                            x:Name="ShowTypographyInfoTooltip1"
+                            Title="Caption"
+                            Target="{x:Bind ShowTypographyButton1}" />
 
-                    <!--  Body Teaching tip  -->
-                    <Button
-                        x:Name="ShowTypographyButton2"
-                        Canvas.Left="190"
-                        Canvas.Top="280"
-                        Padding="4"
-                        HorizontalAlignment="Right"
-                        VerticalAlignment="Top"
-                        AutomationProperties.Name="Show typography"
-                        Canvas.ZIndex="1"
-                        Click="ShowTypographyButtonClick2"
-                        ToolTipService.ToolTip="Body">
-                        <FontIcon FontSize="16" Glyph="&#xE946;" />
-                    </Button>
-                    <TeachingTip
-                        x:Name="ShowTypographyInfoTooltip2"
-                        Title="Body"
-                        Target="{x:Bind ShowTypographyButton2}" />
+                        <!--  Body Teaching tip  -->
+                        <Button
+                            x:Name="ShowTypographyButton2"
+                            Canvas.Left="190"
+                            Canvas.Top="280"
+                            Padding="4"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Top"
+                            AutomationProperties.Name="Show typography"
+                            Canvas.ZIndex="1"
+                            Click="ShowTypographyButtonClick2"
+                            ToolTipService.ToolTip="Body">
+                            <FontIcon FontSize="16" Glyph="&#xE946;" />
+                        </Button>
+                        <TeachingTip
+                            x:Name="ShowTypographyInfoTooltip2"
+                            Title="Body"
+                            Target="{x:Bind ShowTypographyButton2}" />
 
-                    <!--  Body Strong Teaching tip  -->
-                    <Button
-                        x:Name="ShowTypographyButton3"
-                        Canvas.Left="83"
-                        Canvas.Top="245"
-                        Padding="4"
-                        HorizontalAlignment="Right"
-                        VerticalAlignment="Top"
-                        AutomationProperties.Name="Show typography"
-                        Canvas.ZIndex="1"
-                        Click="ShowTypographyButtonClick3"
-                        ToolTipService.ToolTip="Body Strong">
-                        <FontIcon FontSize="16" Glyph="&#xE946;" />
-                    </Button>
-                    <TeachingTip
-                        x:Name="ShowTypographyInfoTooltip3"
-                        Title="Body Strong"
-                        Target="{x:Bind ShowTypographyButton3}" />
+                        <!--  Body Strong Teaching tip  -->
+                        <Button
+                            x:Name="ShowTypographyButton3"
+                            Canvas.Left="83"
+                            Canvas.Top="245"
+                            Padding="4"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Top"
+                            AutomationProperties.Name="Show typography"
+                            Canvas.ZIndex="1"
+                            Click="ShowTypographyButtonClick3"
+                            ToolTipService.ToolTip="Body Strong">
+                            <FontIcon FontSize="16" Glyph="&#xE946;" />
+                        </Button>
+                        <TeachingTip
+                            x:Name="ShowTypographyInfoTooltip3"
+                            Title="Body Strong"
+                            Target="{x:Bind ShowTypographyButton3}" />
 
-                    <!--  Title Teaching tip  -->
-                    <Button
-                        x:Name="ShowTypographyButton4"
-                        Canvas.Left="320"
-                        Canvas.Top="20"
-                        Padding="4"
-                        HorizontalAlignment="Right"
-                        VerticalAlignment="Top"
-                        AutomationProperties.Name="Show typography"
-                        Canvas.ZIndex="1"
-                        Click="ShowTypographyButtonClick4"
-                        ToolTipService.ToolTip="Title">
-                        <FontIcon FontSize="16" Glyph="&#xE946;" />
-                    </Button>
-                    <TeachingTip
-                        x:Name="ShowTypographyInfoTooltip4"
-                        Title="Title"
-                        Target="{x:Bind ShowTypographyButton4}" />
+                        <!--  Title Teaching tip  -->
+                        <Button
+                            x:Name="ShowTypographyButton4"
+                            Canvas.Left="320"
+                            Canvas.Top="20"
+                            Padding="4"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Top"
+                            AutomationProperties.Name="Show typography"
+                            Canvas.ZIndex="1"
+                            Click="ShowTypographyButtonClick4"
+                            ToolTipService.ToolTip="Title">
+                            <FontIcon FontSize="16" Glyph="&#xE946;" />
+                        </Button>
+                        <TeachingTip
+                            x:Name="ShowTypographyInfoTooltip4"
+                            Title="Title"
+                            Target="{x:Bind ShowTypographyButton4}" />
 
-                    <!--  Display Teaching tip  -->
-                    <Button
-                        x:Name="ShowTypographyButton5"
-                        Canvas.Left="160"
-                        Canvas.Top="110"
-                        Padding="4"
-                        HorizontalAlignment="Right"
-                        VerticalAlignment="Top"
-                        AutomationProperties.Name="Show typography"
-                        Canvas.ZIndex="1"
-                        Click="ShowTypographyButtonClick5">
-                        <FontIcon FontSize="16" Glyph="&#xE946;" />
-                    </Button>
-                    <TeachingTip
-                        x:Name="ShowTypographyInfoTooltip5"
-                        Title="Display"
-                        Target="{x:Bind ShowTypographyButton5}" />
+                        <!--  Display Teaching tip  -->
+                        <Button
+                            x:Name="ShowTypographyButton5"
+                            Canvas.Left="160"
+                            Canvas.Top="110"
+                            Padding="4"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Top"
+                            AutomationProperties.Name="Show typography"
+                            Canvas.ZIndex="1"
+                            Click="ShowTypographyButtonClick5">
+                            <FontIcon FontSize="16" Glyph="&#xE946;" />
+                        </Button>
+                        <TeachingTip
+                            x:Name="ShowTypographyInfoTooltip5"
+                            Title="Display"
+                            Target="{x:Bind ShowTypographyButton5}" />
+                    </Canvas>
+                </ScrollViewer>
 
-                </Canvas>
-                <Grid Margin="0,48,0,24" HorizontalAlignment="Stretch">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="286" />
-                        <ColumnDefinition Width="156" />
-                        <ColumnDefinition Width="140" />
-                        <ColumnDefinition Width="*" />
-                    </Grid.ColumnDefinitions>
-                    <TextBlock
-                        Margin="24,0,0,0"
-                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                        Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="Example" />
-                    <TextBlock
-                        Grid.Column="1"
-                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                        Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="Variable Font" />
-                    <TextBlock
-                        Grid.Column="2"
-                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                        Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="Size / Line height" />
-                    <TextBlock
-                        Grid.Column="3"
-                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                        Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="Style" />
-                </Grid>
-                <controls:TypographyControl
-                    HorizontalAlignment="Stretch"
-                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                    Example="Caption"
-                    ExampleStyle="{StaticResource CaptionTextBlockStyle}"
-                    ResourceName="CaptionTextBlockStyle"
-                    SizeLinHeight="12/16 epx"
-                    VariableFont="Small, Regular"
-                    Weight="400" />
-                <controls:TypographyControl
-                    Example="Body"
-                    ExampleStyle="{StaticResource BodyTextBlockStyle}"
-                    ResourceName="BodyTextBlockStyle"
-                    SizeLinHeight="14/20 epx"
-                    VariableFont="Text, Regular"
-                    Weight="400" />
-                <controls:TypographyControl
-                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                    Example="Body Strong"
-                    ExampleStyle="{StaticResource BodyStrongTextBlockStyle}"
-                    ResourceName="BodyStrongTextBlockStyle"
-                    SizeLinHeight="14/20 epx"
-                    VariableFont="Text, SemiBold"
-                    Weight="600" />
-                <controls:TypographyControl
-                    Height="76"
-                    Example="Subtitle"
-                    ExampleStyle="{StaticResource SubtitleTextBlockStyle}"
-                    ResourceName="SubtitleTextBlockStyle"
-                    SizeLinHeight="20/28 epx"
-                    VariableFont="Display, SemiBold"
-                    Weight="600" />
-                <controls:TypographyControl
-                    Height="86"
-                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                    Example="Title"
-                    ExampleStyle="{StaticResource TitleTextBlockStyle}"
-                    ResourceName="TitleTextBlockStyle"
-                    SizeLinHeight="28/36 epx"
-                    VariableFont="Display, SemiBold"
-                    Weight="600" />
-                <controls:TypographyControl
-                    Height="98"
-                    Example="Title Large"
-                    ExampleStyle="{StaticResource TitleLargeTextBlockStyle}"
-                    ResourceName="TitleLargeTextBlockStyle"
-                    SizeLinHeight="40/52 epx"
-                    VariableFont="Display, SemiBold"
-                    Weight="600" />
-                <controls:TypographyControl
-                    Height="106"
-                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                    Example="Display"
-                    ExampleStyle="{StaticResource DisplayTextBlockStyle}"
-                    ResourceName="DisplayTextBlockStyle"
-                    SizeLinHeight="68/92 epx"
-                    VariableFont="Display, SemiBold"
-                    Weight="600" />
+                <ScrollViewer HorizontalScrollMode="Auto" HorizontalScrollBarVisibility="Auto">
+                    <StackPanel>
+                        <Grid Margin="0,48,0,24" HorizontalAlignment="Stretch">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="286" />
+                                <ColumnDefinition Width="156" />
+                                <ColumnDefinition Width="140" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock
+                                Margin="24,0,0,0"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                Style="{StaticResource CaptionTextBlockStyle}"
+                                Text="Example" />
+                            <TextBlock
+                                Grid.Column="1"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                Style="{StaticResource CaptionTextBlockStyle}"
+                                Text="Variable Font" />
+                            <TextBlock
+                                Grid.Column="2"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                Style="{StaticResource CaptionTextBlockStyle}"
+                                Text="Size / Line height" />
+                            <TextBlock
+                                Grid.Column="3"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                Style="{StaticResource CaptionTextBlockStyle}"
+                                Text="Style" />
+                        </Grid>
+                        <controls:TypographyControl
+                            HorizontalAlignment="Stretch"
+                            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            Example="Caption"
+                            ExampleStyle="{StaticResource CaptionTextBlockStyle}"
+                            ResourceName="CaptionTextBlockStyle"
+                            SizeLinHeight="12/16 epx"
+                            VariableFont="Small, Regular"
+                            Weight="400" />
+                        <controls:TypographyControl
+                            Example="Body"
+                            ExampleStyle="{StaticResource BodyTextBlockStyle}"
+                            ResourceName="BodyTextBlockStyle"
+                            SizeLinHeight="14/20 epx"
+                            VariableFont="Text, Regular"
+                            Weight="400" />
+                        <controls:TypographyControl
+                            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            Example="Body Strong"
+                            ExampleStyle="{StaticResource BodyStrongTextBlockStyle}"
+                            ResourceName="BodyStrongTextBlockStyle"
+                            SizeLinHeight="14/20 epx"
+                            VariableFont="Text, SemiBold"
+                            Weight="600" />
+                        <controls:TypographyControl
+                            Height="76"
+                            Example="Subtitle"
+                            ExampleStyle="{StaticResource SubtitleTextBlockStyle}"
+                            ResourceName="SubtitleTextBlockStyle"
+                            SizeLinHeight="20/28 epx"
+                            VariableFont="Display, SemiBold"
+                            Weight="600" />
+                        <controls:TypographyControl
+                            Height="86"
+                            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            Example="Title"
+                            ExampleStyle="{StaticResource TitleTextBlockStyle}"
+                            ResourceName="TitleTextBlockStyle"
+                            SizeLinHeight="28/36 epx"
+                            VariableFont="Display, SemiBold"
+                            Weight="600" />
+                        <controls:TypographyControl
+                            Height="98"
+                            Example="Title Large"
+                            ExampleStyle="{StaticResource TitleLargeTextBlockStyle}"
+                            ResourceName="TitleLargeTextBlockStyle"
+                            SizeLinHeight="40/52 epx"
+                            VariableFont="Display, SemiBold"
+                            Weight="600" />
+                        <controls:TypographyControl
+                            Height="106"
+                            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                            Example="Display"
+                            ExampleStyle="{StaticResource DisplayTextBlockStyle}"
+                            ResourceName="DisplayTextBlockStyle"
+                            SizeLinHeight="68/92 epx"
+                            VariableFont="Display, SemiBold"
+                            Weight="600" />
+                    </StackPanel>
+                </ScrollViewer>
             </StackPanel>
         </local:ControlExample>
     </Grid>

--- a/WinUIGallery/ControlPages/FilePickerPage.xaml.cs
+++ b/WinUIGallery/ControlPages/FilePickerPage.xaml.cs
@@ -60,12 +60,14 @@ namespace AppUIBasics.ControlPages
                 
                 span.Inlines.Add(run1);
                 span.Inlines.Add(run2);
-                PickAFileOutputTextBlock.Inlines.Add(span);     
+                PickAFileOutputTextBlock.Inlines.Add(span);
             }
             else
             {
                 PickAFileOutputTextBlock.Text = "Operation cancelled.";
             }
+
+            UIHelper.AnnounceActionForAccessibility(sender as Button, PickAFileOutputTextBlock.Text, "FilePickedNotificationId");
         }
         private async void PickAPhotoButton_Click(object sender, RoutedEventArgs e)
         {
@@ -111,6 +113,8 @@ namespace AppUIBasics.ControlPages
             {
                 PickAPhotoOutputTextBlock.Text = "Operation cancelled.";
             }
+
+            UIHelper.AnnounceActionForAccessibility(sender as Button, PickAPhotoOutputTextBlock.Text, "PhotoPickedNotificationId");
         }
 
         private async void PickFilesButton_Click(object sender, RoutedEventArgs e)
@@ -159,6 +163,8 @@ namespace AppUIBasics.ControlPages
             {
                 PickFilesOutputTextBlock.Text = "Operation cancelled.";
             }
+
+            UIHelper.AnnounceActionForAccessibility(sender as Button, PickFilesOutputTextBlock.Text, "FilesPickedNotificationId");
         }
 
         private async void PickFolderButton_Click(object sender, RoutedEventArgs e)
@@ -204,6 +210,8 @@ namespace AppUIBasics.ControlPages
             {
                 PickFolderOutputTextBlock.Text = "Operation cancelled.";
             }
+
+            UIHelper.AnnounceActionForAccessibility(sender as Button, PickFolderOutputTextBlock.Text, "FolderPickedNotificationId");
         }
 
         private async void SaveFileButton_Click(object sender, RoutedEventArgs e)
@@ -269,7 +277,8 @@ namespace AppUIBasics.ControlPages
             {
                 SaveFileOutputTextBlock.Text = "Operation cancelled.";
             }
-        }
 
+            UIHelper.AnnounceActionForAccessibility(sender as Button, SaveFileOutputTextBlock.Text, "FileSavedNotificationId");
+        }
     }
 }

--- a/WinUIGallery/ControlPages/ItemsViewPage.xaml
+++ b/WinUIGallery/ControlPages/ItemsViewPage.xaml
@@ -137,24 +137,25 @@ private void BasicItemsView_ItemInvoked(ItemsView sender, ItemsViewItemInvokedEv
                         </Style>
                     </StackPanel.Resources>
 
-                    <TextBlock Margin="0,15,0,10" Text="Layout" FontWeight="SemiBold"/>
-                    
-                    <RadioButtons>
+                    <RadioButtons Header="Layout" FontWeight="SemiBold">
                         <RadioButton
                             Checked="RbLayout_Checked"
                             Content="LinedFlowLayout"
                             GroupName="ItemsViewLayouts"
+                            FontWeight="Normal"
                             IsChecked="True"/>
 
                         <RadioButton
                             Checked="RbLayout_Checked"
                             Content="UniformGridLayout"
-                            GroupName="ItemsViewLayouts"/>
+                            GroupName="ItemsViewLayouts"
+                            FontWeight="Normal"/>
 
                         <RadioButton
                             Checked="RbLayout_Checked"
                             Content="StackLayout"
-                            GroupName="ItemsViewLayouts"/>
+                            GroupName="ItemsViewLayouts"
+                            FontWeight="Normal"/>
                     </RadioButtons>
 
                     <StackPanel x:Name="spLinedFlowLayoutOptions" MinHeight="300">

--- a/WinUIGallery/ControlPages/ListViewPage.xaml
+++ b/WinUIGallery/ControlPages/ListViewPage.xaml
@@ -378,7 +378,8 @@ sent or received, and those values are bound in the DataTemplate.--&gt;
                                 <TextBlock Text="{x:Bind Title}" FontSize="14" FontWeight="SemiBold" Style="{ThemeResource BaseTextBlockStyle}"
                                            HorizontalAlignment="Left" Margin="0,0,0,6" LineHeight="20"/>
                                 <TextBlock Text="{x:Bind Description}" FontFamily="Segoe UI" FontWeight="Normal" Style="{ThemeResource BodyTextBlockStyle}"
-                                           TextTrimming="CharacterEllipsis" Width="350" TextWrapping="NoWrap"/>
+                                           Width="350" MaxHeight="60" Margin="0,0,0,10"
+                                           TextTrimming="CharacterEllipsis" TextWrapping="Wrap" IsTextTrimmedChanged="TextBlock_IsTextTrimmedChanged"/>
                                 <StackPanel Orientation="Horizontal">
                                     <TextBlock Text="{x:Bind Views}" Style="{ThemeResource CaptionTextBlockStyle}" Margin="0"/>
                                     <TextBlock Text=" Views " Style="{ThemeResource CaptionTextBlockStyle}"/>

--- a/WinUIGallery/ControlPages/ListViewPage.xaml.cs
+++ b/WinUIGallery/ControlPages/ListViewPage.xaml.cs
@@ -323,6 +323,18 @@ namespace AppUIBasics.ControlPages
                 new Message("Message " + ++messageNumber, DateTime.Now, HorizontalAlignment.Left)
                 );
         }
+
+        //===================================================================================================================
+        // ListView with Images Sample
+        //===================================================================================================================
+
+        private void TextBlock_IsTextTrimmedChanged(TextBlock sender, IsTextTrimmedChangedEventArgs args)
+        {
+            var textBlock = sender as TextBlock;
+            var text = textBlock.IsTextTrimmed ? textBlock.Text : string.Empty;
+
+            ToolTipService.SetToolTip(textBlock, text);
+        }
     }
 
     public class Message

--- a/WinUIGallery/ControlPages/ProgressRingPage.xaml
+++ b/WinUIGallery/ControlPages/ProgressRingPage.xaml
@@ -24,7 +24,7 @@
             <ProgressRing x:Name="ProgressRing1" IsActive="{x:Bind ProgressToggle.IsOn, Mode=OneWay}" AutomationProperties.Name="Progress image" Height="60" Width="60" VerticalAlignment="Top" Margin="10,10,0,0"/>
             <local:ControlExample.Options>
                 <StackPanel>
-                    <ToggleSwitch x:Name="ProgressToggle" AutomationProperties.Name="Progress options" Header="Toggle work" OffContent="Do work" OnContent="Working" IsOn="True" />
+                    <ToggleSwitch x:Name="ProgressToggle" AutomationProperties.Name="Progress Options" Header="Progress Options" OffContent="Do work" OnContent="Working" IsOn="True" />
                     <ComboBox x:Name="BackgroundComboBox1" SelectionChanged="Background_SelectionChanged"  Header="Background color" PlaceholderText="Pick a color" Width="200">
                         <x:String>Transparent</x:String>
                         <x:String>LightGray</x:String>

--- a/WinUIGallery/Controls/DesignGuidance/ColorTile.xaml.cs
+++ b/WinUIGallery/Controls/DesignGuidance/ColorTile.xaml.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation and Contributors.
 // Licensed under the MIT License.
 
+using AppUIBasics.Helper;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
@@ -75,6 +76,7 @@ namespace WinUIGallery.DesktopWap.Controls.DesignGuidance
             package.SetText(ColorBrushName);
             Clipboard.SetContent(package);
 
+            UIHelper.AnnounceActionForAccessibility(sender as Button, "Brush name copied to clipboard", "BrushNameCopiedSuccessNotificationId");
         }
     }
 }

--- a/WinUIGallery/Controls/PageHeader.xaml
+++ b/WinUIGallery/Controls/PageHeader.xaml
@@ -142,7 +142,7 @@
                             Subtitle="Share with others or paste this link into the Run dialog to open the app to this page directly."
                             Target="{x:Bind CopyLinkButton}">
                             <TeachingTip.HeroContent>
-                                <Image Source="/Assets/CopyLinkTeachingTip.png" AutomationProperties.Name="Image of copied text in run dialogue."/>
+                                <Image Source="/Assets/CopyLinkTeachingTip.png" AutomationProperties.Name="Image of copied text in Run Dialog."/>
                             </TeachingTip.HeroContent>
                         </TeachingTip>
                     </local:CopyButton.Resources>

--- a/WinUIGallery/Controls/PageHeader.xaml
+++ b/WinUIGallery/Controls/PageHeader.xaml
@@ -142,7 +142,7 @@
                             Subtitle="Share with others or paste this link into the Run dialog to open the app to this page directly."
                             Target="{x:Bind CopyLinkButton}">
                             <TeachingTip.HeroContent>
-                                <Image Source="/Assets/CopyLinkTeachingTip.png" />
+                                <Image Source="/Assets/CopyLinkTeachingTip.png" AutomationProperties.Name="Image of copied text in run dialogue."/>
                             </TeachingTip.HeroContent>
                         </TeachingTip>
                     </local:CopyButton.Resources>

--- a/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
@@ -21,6 +21,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
 using Windows.Foundation;
 using Windows.System.Profile;
@@ -278,6 +279,31 @@ namespace AppUIBasics
         {
             // Delay necessary to ensure NavigationView visual state can match navigation
             Task.Delay(500).ContinueWith(_ => this.NavigationViewLoaded?.Invoke(), TaskScheduler.FromCurrentSynchronizationContext());
+            GetTogglePaneButton(sender, e);
+
+            var navigationView = sender as NavigationView;
+            navigationView.RegisterPropertyChangedCallback(NavigationView.IsPaneOpenProperty, OnIsPaneOpenChanged);
+        }
+
+        private void OnIsPaneOpenChanged(DependencyObject sender, DependencyProperty dp)
+        {
+            var navigationView = sender as NavigationView;
+            var announcementText = navigationView.IsPaneOpen ? "Navigation Pane Opened" : "Navigation Pane Closed";
+
+            UIHelper.AnnounceActionForAccessibility(navigationView, announcementText, "NavigationViewPaneIsOpenChangeNotificationId");
+        }
+
+        private void GetTogglePaneButton(object sender, RoutedEventArgs e)
+        {
+            var navView = sender as NavigationView;
+            var rootGrid = VisualTreeHelper.GetChild(navView, 0) as Grid;
+
+            // Find the back button.
+            var paneToggleButtonGrid = VisualTreeHelper.GetChild(rootGrid, 0) as Grid;
+            var buttonHolderGrid = VisualTreeHelper.GetChild(paneToggleButtonGrid, 1) as Grid;
+            var navigationViewTogglePaneButton = VisualTreeHelper.GetChild(buttonHolderGrid, 2) as Button;
+
+
         }
 
         private void OnNavigationViewSelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)

--- a/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
@@ -229,7 +229,7 @@ namespace AppUIBasics
                 NavigationViewControl.MenuItems.Add(itemGroup);
             }
 
-            Home.Loaded += OnNewControlsMenuItemLoaded;
+            Home.Loaded += OnHomeMenuItemLoaded;
         }
 
         private void OnMenuFlyoutItemClick(object sender, RoutedEventArgs e)
@@ -267,7 +267,7 @@ namespace AppUIBasics
             DeviceFamily = parsedDeviceType;
         }
 
-        private void OnNewControlsMenuItemLoaded(object sender, RoutedEventArgs e)
+        private void OnHomeMenuItemLoaded(object sender, RoutedEventArgs e)
         {
             if ( NavigationViewControl.DisplayMode == NavigationViewDisplayMode.Expanded)
             {

--- a/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
@@ -279,7 +279,6 @@ namespace AppUIBasics
         {
             // Delay necessary to ensure NavigationView visual state can match navigation
             Task.Delay(500).ContinueWith(_ => this.NavigationViewLoaded?.Invoke(), TaskScheduler.FromCurrentSynchronizationContext());
-            GetTogglePaneButton(sender, e);
 
             var navigationView = sender as NavigationView;
             navigationView.RegisterPropertyChangedCallback(NavigationView.IsPaneOpenProperty, OnIsPaneOpenChanged);
@@ -291,19 +290,6 @@ namespace AppUIBasics
             var announcementText = navigationView.IsPaneOpen ? "Navigation Pane Opened" : "Navigation Pane Closed";
 
             UIHelper.AnnounceActionForAccessibility(navigationView, announcementText, "NavigationViewPaneIsOpenChangeNotificationId");
-        }
-
-        private void GetTogglePaneButton(object sender, RoutedEventArgs e)
-        {
-            var navView = sender as NavigationView;
-            var rootGrid = VisualTreeHelper.GetChild(navView, 0) as Grid;
-
-            // Find the back button.
-            var paneToggleButtonGrid = VisualTreeHelper.GetChild(rootGrid, 0) as Grid;
-            var buttonHolderGrid = VisualTreeHelper.GetChild(paneToggleButtonGrid, 1) as Grid;
-            var navigationViewTogglePaneButton = VisualTreeHelper.GetChild(buttonHolderGrid, 2) as Button;
-
-
         }
 
         private void OnNavigationViewSelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Miscellaneous p1 accessibility fixes:

- [Bug 44661786](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/44661786): [WinUI Accessibility: Design guidance -> Accessibility-> Keyboard support]: Screen reader is announcing incorrect information about the shortcuts.
- [Bug 46762667](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/46762667): [WinUI 3 Gallery: Item View]: Screen reader fails to announce the label for the radio buttons present in under 'Layout' group.
- [Bug 46763238](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/46763238): [WinUI 3 Gallery: Progress Ring]: Accessibility name and visual name is not same for working toggle button present under 'Toggle Work' group.
- [Bug 46818786](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/46818786): [WinUI 3 Gallery: Clipboard]: Screen reader is not announcing the success message after activating the 'Copy Text to the Clipboard' button.
- [Bug 46818852](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/46818852): [WinUI 3 Gallery: FilePicker]: Screen reader is not announcing the success message after activating the 'Open a file/Open a picture/Save a file' button.
- [Bug 46820249](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/46820249): [WinUI 3 Gallery: Design Guidance: Color]: Upon invoking 'Copy brush name' button screen reader is on mute and there is no visual changes.
- [Bug 46820807](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/46820807): [WinUI 3 Gallery: Typography]: Some parts of right side of the screen is getting truncated in High DPI mode also not having scroll bar to scroll towards right.
- [Bug 46821911](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/46821911): [WinUI 3 Gallery: List View]: Text present beside the images which present under 'List view with image' heading is getting truncated in normal mode.
- [Bug 46825231](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/46825231): [WinUI 3 Gallery: Connected Animation]: Text present beside the images which present in 'Connected Animation' card is getting truncated in normal mode.
- [Bug 41570653](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/41570653): [WinUI Accessibility-> Left Navigation Pane]: No success information announced by screen reader, when user invokes open/close navigation button.
- [Bug 41597549](https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/41597549): [WinUI Gallery] WinUI Accessibility-> TeachingTip: Unable to navigate to the image present in "Quickly reference this sample!" dialog using caps arrow keys.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
