### PR TITLE
Add ToString method to view model in StandardUICommand sample so accessibility name does not default to data type name.

### DIFF
--- a/WinUIGallery/ControlPages/StandardUICommandPage.xaml.cs
+++ b/WinUIGallery/ControlPages/StandardUICommandPage.xaml.cs
@@ -13,6 +13,11 @@ namespace AppUIBasics.ControlPages
     {
         public string Text { get; set; }
         public ICommand Command { get; set; }
+
+        public override string ToString()
+        {
+            return Text;
+        }
     }
 
     public sealed partial class StandardUICommandPage : Page


### PR DESCRIPTION
Without a ToString, accessibility tools end up using the TypeName. 

![image](https://github.com/microsoft/WinUI-Gallery/assets/28935693/6604dc35-626d-484d-b300-4c366acdb6fd)

After fix:
![image](https://github.com/microsoft/WinUI-Gallery/assets/28935693/d809ffdd-7532-4177-a5a5-06a81fa21ac5)
