### PR TITLE
Readd navigation stack capabilities

### DIFF
--- a/WinUIGallery/Helper/NavigationHelper.cs
+++ b/WinUIGallery/Helper/NavigationHelper.cs
@@ -170,7 +170,7 @@ namespace AppUIBasics.Helper
     {
         private Frame Frame { get; set; }
         private NavigationView CurrentNavView { get; set; }
-        private bool hasAlreadyProcessedKeyDown = false;
+        private bool isKeyDownProcessed = false;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RootNavigationHelper"/> class.
@@ -199,13 +199,13 @@ namespace AppUIBasics.Helper
 
         private bool TryGoBack()
         {
+            bool navigated = false;
             // Don't go back if the nav pane is overlayed.
             if (this.CurrentNavView.IsPaneOpen && (this.CurrentNavView.DisplayMode == NavigationViewDisplayMode.Compact || this.CurrentNavView.DisplayMode == NavigationViewDisplayMode.Minimal))
             {
-                return false;
+                return navigated;
             }
 
-            bool navigated = false;
             if (this.Frame.CanGoBack)
             {
                 this.Frame.GoBack();
@@ -241,7 +241,7 @@ namespace AppUIBasics.Helper
 
         private void CurrentNavView_KeyDown(object sender, Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
         {
-            if (e.Handled || hasAlreadyProcessedKeyDown)
+            if (e.Handled || isKeyDownProcessed)
             {
                 return;
             }
@@ -273,13 +273,13 @@ namespace AppUIBasics.Helper
                     // When the next key or Alt+Right are pressed navigate forward.
                     e.Handled = TryGoForward();
                 }
-                hasAlreadyProcessedKeyDown = e.Handled;
+                isKeyDownProcessed = e.Handled;
             }
         }
 
         private void CurrentNavView_KeyUp(object sender, Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
         {
-            hasAlreadyProcessedKeyDown = false;
+            isKeyDownProcessed = false;
         }
     }
 

--- a/WinUIGallery/Helper/NavigationHelper.cs
+++ b/WinUIGallery/Helper/NavigationHelper.cs
@@ -199,7 +199,7 @@ namespace AppUIBasics.Helper
 
         private bool TryGoBack()
         {
-            // don't go back if the nav pane is overlayed
+            // Don't go back if the nav pane is overlayed.
             if (this.CurrentNavView.IsPaneOpen && (this.CurrentNavView.DisplayMode == NavigationViewDisplayMode.Compact || this.CurrentNavView.DisplayMode == NavigationViewDisplayMode.Minimal))
             {
                 return false;
@@ -248,13 +248,13 @@ namespace AppUIBasics.Helper
 
             var virtualKey = e.Key;
 
-            // Only investigate further when Left, Right, or the dedicated Previous or Next keys
-            // are pressed
+            // Only investigate further when Left, Right, or the dedicated
+            // Previous or Next keys are pressed.
             if (virtualKey == VirtualKey.Left || virtualKey == VirtualKey.Right ||
                 (int)virtualKey == 166 || (int)virtualKey == 167)
             {
                 var downState = CoreVirtualKeyStates.Down;
-                // VirtualKeys 'Menu' key is also the 'Alt' key on the keyboard
+                // VirtualKeys 'Menu' key is also the 'Alt' key on the keyboard.
                 bool isMenuKeyPressed = (InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Menu) & downState) == downState;
                 bool isControlKeyPressed = (InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control) & downState) == downState;
                 bool isShiftKeyPressed = (InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift) & downState) == downState;
@@ -264,13 +264,13 @@ namespace AppUIBasics.Helper
                 if (((int)virtualKey == 166 && isModifierKeyPressed) ||
                     (virtualKey == VirtualKey.Left && isOnlyAltPressed))
                 {
-                    // When the previous key or Alt+Left are pressed navigate back
+                    // When the previous key or Alt+Left are pressed navigate back.
                     e.Handled = TryGoBack();
                 }
                 else if (((int)virtualKey == 167 && isModifierKeyPressed) ||
                     (virtualKey == VirtualKey.Right && isOnlyAltPressed))
                 {
-                    // When the next key or Alt+Right are pressed navigate forward
+                    // When the next key or Alt+Right are pressed navigate forward.
                     e.Handled = TryGoForward();
                 }
                 hasAlreadyProcessedKeyDown = e.Handled;

--- a/WinUIGallery/Helper/NavigationHelper.cs
+++ b/WinUIGallery/Helper/NavigationHelper.cs
@@ -170,7 +170,7 @@ namespace AppUIBasics.Helper
     {
         private Frame Frame { get; set; }
         private NavigationView CurrentNavView { get; set; }
-        private bool alreadyProcessedKeyDown = false;
+        private bool hasAlreadyProcessedKeyDown = false;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RootNavigationHelper"/> class.
@@ -241,7 +241,7 @@ namespace AppUIBasics.Helper
 
         private void CurrentNavView_KeyDown(object sender, Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
         {
-            if (e.Handled || alreadyProcessedKeyDown)
+            if (e.Handled || hasAlreadyProcessedKeyDown)
             {
                 return;
             }
@@ -254,31 +254,32 @@ namespace AppUIBasics.Helper
                 (int)virtualKey == 166 || (int)virtualKey == 167)
             {
                 var downState = CoreVirtualKeyStates.Down;
-                bool menuKey = (InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Menu) & downState) == downState;
-                bool controlKey = (InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control) & downState) == downState;
-                bool shiftKey = (InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift) & downState) == downState;
-                bool noModifiers = !menuKey && !controlKey && !shiftKey;
-                bool onlyAlt = menuKey && !controlKey && !shiftKey;
+                // VirtualKeys 'Menu' key is also the 'Alt' key on the keyboard
+                bool isMenuKeyPressed = (InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Menu) & downState) == downState;
+                bool isControlKeyPressed = (InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control) & downState) == downState;
+                bool isShiftKeyPressed = (InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift) & downState) == downState;
+                bool isModifierKeyPressed = !isMenuKeyPressed && !isControlKeyPressed && !isShiftKeyPressed;
+                bool isOnlyAltPressed = isMenuKeyPressed && !isControlKeyPressed && !isShiftKeyPressed;
 
-                if (((int)virtualKey == 166 && noModifiers) ||
-                    (virtualKey == VirtualKey.Left && onlyAlt))
+                if (((int)virtualKey == 166 && isModifierKeyPressed) ||
+                    (virtualKey == VirtualKey.Left && isOnlyAltPressed))
                 {
                     // When the previous key or Alt+Left are pressed navigate back
                     e.Handled = TryGoBack();
                 }
-                else if (((int)virtualKey == 167 && noModifiers) ||
-                    (virtualKey == VirtualKey.Right && onlyAlt))
+                else if (((int)virtualKey == 167 && isModifierKeyPressed) ||
+                    (virtualKey == VirtualKey.Right && isOnlyAltPressed))
                 {
                     // When the next key or Alt+Right are pressed navigate forward
                     e.Handled = TryGoForward();
                 }
-                alreadyProcessedKeyDown = e.Handled;
+                hasAlreadyProcessedKeyDown = e.Handled;
             }
         }
 
         private void CurrentNavView_KeyUp(object sender, Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
         {
-            alreadyProcessedKeyDown = false;
+            hasAlreadyProcessedKeyDown = false;
         }
     }
 

--- a/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
@@ -34,6 +34,7 @@ namespace AppUIBasics
     {
         public Windows.System.VirtualKey ArrowKey;
         public Microsoft.UI.Dispatching.DispatcherQueue dispatcherQueue;
+        private RootFrameNavigationHelper _navHelper;
         private UISettings _settings;
 
 
@@ -73,6 +74,8 @@ namespace AppUIBasics
         {
             this.InitializeComponent();
             dispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
+
+            _navHelper = new RootFrameNavigationHelper(rootFrame, NavigationViewControl);
 
             SetDeviceFamily();
             AddNavigationMenuItems();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding back the usage of the NavigationHelper to allow navigating between pages. Note that certain APIs are missing in WinUI 3 compared to UWP so we are diverging from the WinUI 2 version here.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1205
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
