### PR TITLE
Fix Selection Indicator for GridView sample

### DIFF
--- a/WinUIGallery/ControlPages/GridViewPage.xaml
+++ b/WinUIGallery/ControlPages/GridViewPage.xaml
@@ -104,7 +104,7 @@
                 <GridView x:Name="StyledGrid"
                           ItemTemplate="{StaticResource ImageOverlayTemplate}">
                     <GridView.ItemContainerStyle>
-                        <Style TargetType="GridViewItem">
+                        <Style TargetType="GridViewItem" BasedOn="{StaticResource DefaultGridViewItemStyle}">
                             <Setter Property="Margin" Value="5"/>
                         </Style>
                     </GridView.ItemContainerStyle>
@@ -155,7 +155,7 @@ some parts of the GridViewItems (i.e. the margins). --&gt;
     ItemTemplate="{StaticResource ImageOverlayTemplate}"&gt;
 
     &lt;GridView.ItemContainerStyle&gt;
-        &lt;Style TargetType="GridViewItem"&gt;
+        &lt;Style TargetType="GridViewItem" BasedOn="{StaticResource DefaultGridViewItemStyle}"&gt;
             &lt;Setter Property="Margin" Value="$(ColMargin), $(RowMargin), $(ColMargin), $(RowMargin)"/&gt;
         &lt;/Style&gt;
     &lt;/GridView.ItemContainerStyle&gt;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Due to a missing BasedOn, the selection indicator and other interface characteristics where missing on the custom layout sample.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1072
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
