### PR TITLE
Fix Listbox text truncation when text is scaled up

### DIFF
--- a/WinUIGallery/ControlPages/ListBoxPage.xaml
+++ b/WinUIGallery/ControlPages/ListBoxPage.xaml
@@ -22,7 +22,6 @@
                         <x:String>Green</x:String>
                         <x:String>Red</x:String>
                         <x:String>Yellow</x:String>
-                        <x:String>Placeholder dummy dummy dummy dummy dummy dummy dummy dummy dummy dummy dummy dummy dummy dummy dummy</x:String>
                     </ListBox>
                     <Rectangle x:Name="Control1Output" Height="30" Width="100" Margin="0,10,0,0" />
                 </StackPanel>

--- a/WinUIGallery/ControlPages/ListBoxPage.xaml
+++ b/WinUIGallery/ControlPages/ListBoxPage.xaml
@@ -17,18 +17,19 @@
         <local:ControlExample x:Name="Example1" HeaderText="A ListBox with items defined inline and its width set.">
             <local:ControlExample.Example>
                 <StackPanel>
-                    <ListBox x:Name="ListBox1" SelectionChanged="ColorListBox_SelectionChanged" Width="200" HighContrastAdjustment="Auto">
+                    <ListBox x:Name="ListBox1" SelectionChanged="ColorListBox_SelectionChanged" MinWidth="200" HighContrastAdjustment="Auto">
                         <x:String>Blue</x:String>
                         <x:String>Green</x:String>
                         <x:String>Red</x:String>
                         <x:String>Yellow</x:String>
+                        <x:String>Placeholder dummy dummy dummy dummy dummy dummy dummy dummy dummy dummy dummy dummy dummy dummy dummy</x:String>
                     </ListBox>
                     <Rectangle x:Name="Control1Output" Height="30" Width="100" Margin="0,10,0,0" />
                 </StackPanel>
             </local:ControlExample.Example>
             <local:ControlExample.Xaml>
                 <x:String xml:space="preserve">
-&lt;ListBox SelectionChanged="ColorListBox_SelectionChanged" Width="200"&gt;
+&lt;ListBox SelectionChanged="ColorListBox_SelectionChanged" MinWidth="200"&gt;
     &lt;x:String&gt;Blue&lt;x:String&gt;
     &lt;x:String&gt;Green&lt;x:String&gt;
     &lt;x:String&gt;Red&lt;x:String&gt;

--- a/WinUIGallery/ControlPages/ListBoxPage.xaml
+++ b/WinUIGallery/ControlPages/ListBoxPage.xaml
@@ -14,7 +14,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d">
     <StackPanel>
-        <local:ControlExample x:Name="Example1" HeaderText="A ListBox with items defined inline and its width set.">
+        <local:ControlExample x:Name="Example1" HeaderText="A ListBox with items defined inline and its minimum width set.">
             <local:ControlExample.Example>
                 <StackPanel>
                     <ListBox x:Name="ListBox1" SelectionChanged="ColorListBox_SelectionChanged" MinWidth="200" HighContrastAdjustment="Auto">


### PR DESCRIPTION
## Description
This change updates the Width set on ListBox to be MinWidth instead.

## Motivation and Context
This fixes an accessibility issue in WinUI3 Gallery, where ListBox would truncate longer text when text scaling is sized up. 

## How Has This Been Tested?
Ad-hoc testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
