### PR TITLE
Change DropDownButton's MenuFlyout Placement to be left-aligned

### DIFF
--- a/WinUIGallery/ControlPages/DropDownButtonPage.xaml
+++ b/WinUIGallery/ControlPages/DropDownButtonPage.xaml
@@ -30,7 +30,7 @@
                     <FontIcon Glyph="&#xE715;"/>
                 </DropDownButton.Content>
                 <DropDownButton.Flyout>
-                    <MenuFlyout Placement="Bottom">
+                    <MenuFlyout Placement="BottomEdgeAlignedLeft">
                         <MenuFlyoutItem Text="Send">
                             <MenuFlyoutItem.Icon>
                                 <FontIcon Glyph="&#xE725;"/>

--- a/WinUIGallery/ControlPages/DropDownButtonPage.xaml
+++ b/WinUIGallery/ControlPages/DropDownButtonPage.xaml
@@ -13,7 +13,7 @@
             <StackPanel x:Name="Control1" Orientation="Horizontal">
                 <DropDownButton Content="Email">
                     <DropDownButton.Flyout>
-                        <MenuFlyout Placement="Bottom">
+                        <MenuFlyout Placement="BottomEdgeAlignedLeft">
                             <MenuFlyoutItem Text="Send"/>
                             <MenuFlyoutItem Text="Reply"/>
                             <MenuFlyoutItem Text="Reply All"/>


### PR DESCRIPTION
## Description
Once [PR 9838266: Fix text truncation on DropDownButton MenuFlyout](https://microsoft.visualstudio.com/WinUI/_git/microsoft-ui-xaml-lift/pullrequest/9838266) is completed, DropDownButton's MenuFlyout will no longer truncate longer text when text is scaled up. As a result, at the WinUI3 Gallery app-level, we need to set MenuFlyout's Placement to BottomEdgeAlignedLeft, so that longer text will not end result in MenuFlyout covering the NavigationView.

## Motivation and Context
This helps resolve an accessibility issue, in tandem with controls-side changes in the above mentioned PR.

## How Has This Been Tested?
Ad-hoc testing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
