### PR TITLE
[Colors] Adding highcontrast brushes

### DIFF
--- a/WinUIGallery/ControlPages/DesignGuidance/ColorsPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/ColorsPage.xaml
@@ -42,6 +42,7 @@
             <x:String>Stroke</x:String>
             <x:String>Background</x:String>
             <x:String>Signal</x:String>
+            <x:String>High Contrast</x:String>
         </ComboBox>
 
         <controls1:SampleThemeListener Grid.Row="2">

--- a/WinUIGallery/ControlPages/DesignGuidance/ColorsPage.xaml.cs
+++ b/WinUIGallery/ControlPages/DesignGuidance/ColorsPage.xaml.cs
@@ -31,6 +31,9 @@ namespace AppUIBasics.ControlPages
                 case 4:
                     NavigationFrame.Navigate(typeof(SignalSection));
                     break;
+                case 5:
+                    NavigationFrame.Navigate(typeof(HighContrastSection));
+                    break;
             }
         }
 

--- a/WinUIGallery/Controls/DesignGuidance/ColorSections/HighContrastSection.xaml
+++ b/WinUIGallery/Controls/DesignGuidance/ColorSections/HighContrastSection.xaml
@@ -1,0 +1,396 @@
+<!--  Copyright (c) Microsoft Corporation and Contributors.  -->
+<!--  Licensed under the MIT License.  -->
+
+<Page
+    x:Class="WinUIGallery.DesktopWap.Controls.DesignGuidance.ColorSections.HighContrastSection"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:designguidance="using:WinUIGallery.DesktopWap.Controls.DesignGuidance"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <!--  Colors section  -->
+    <StackPanel Margin="0,32,0,0" Spacing="{StaticResource ColorSectionSpacing}">
+        <TextBlock Text="Below are the default highcontrast themes shown. The brush names are the same, and the OS will chose the right colors based on the selected theme." />
+        <!--  Aquatic  -->
+        <TextBlock
+            Margin="0,24,0,0"
+            Style="{StaticResource SubtitleTextBlockStyle}"
+            Text="Aquatic" />
+        <Grid Style="{StaticResource ColorTilesPanelStyle}">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition />
+                <RowDefinition />
+            </Grid.RowDefinitions>
+            <designguidance:ColorTile
+                Background="#FFFFFF"
+                ColorBrushName="SystemColorWindowTextColor"
+                ColorExplanation="Foreground / Text color for Headings, body copy, lists, placeholder text, app and window borders, any UI that can't be interacted with."
+                ColorName="Window Text Color"
+                ColorValue="#FFFFFF"
+                Foreground="#202020"
+                ShowSeparator="False" />
+            <designguidance:ColorTile
+                Grid.Row="1"
+                Background="#202020"
+                ColorBrushName="SystemColorWindowColor"
+                ColorExplanation="Background of pages, panes, popups, and windows."
+                ColorName="Window Color"
+                ColorValue="#202020"
+                Foreground="#FFFFFF"
+                ShowSeparator="False" />
+
+            <designguidance:ColorTile
+                Grid.Column="1"
+                Background="#263B50"
+                ColorBrushName="SystemColorHighlightTextColor"
+                ColorExplanation="Foreground color for text or UI that is in selected, interacted with (hover, pressed), or in progress."
+                ColorName="Highlight Text Color"
+                ColorValue="#263B50"
+                Foreground="#8EE3F0"
+                ShowSeparator="False" />
+            <designguidance:ColorTile
+                Grid.Row="1"
+                Grid.Column="1"
+                Background="#8EE3F0"
+                ColorBrushName="SystemColorHighlightColor"
+                ColorExplanation="Background or accent color for UI that is in selected, interacted with (hover, pressed), or in progress."
+                ColorName="Highlight Color"
+                ColorValue="#8EE3F0"
+                Foreground="#263B50"
+                ShowSeparator="False" />
+
+            <designguidance:ColorTile
+                Grid.Column="2"
+                Background="#FFFFFF"
+                ColorBrushName="SystemColorButtonTextColor"
+                ColorExplanation="Foreground color for buttons and any UI that can be interacted with."
+                ColorName="Button Text Color"
+                ColorValue="#FFFFFF"
+                Foreground="#202020"
+                ShowSeparator="False" />
+            <designguidance:ColorTile
+                Grid.Row="1"
+                Grid.Column="2"
+                Background="#202020"
+                ColorBrushName="SystemColorButtonFaceColor"
+                ColorExplanation="Background color for buttons and any UI that can be interacted with."
+                ColorName="Button Face Color"
+                ColorValue="#202020"
+                Foreground="#FFFFFF"
+                ShowSeparator="False" />
+
+            <designguidance:ColorTile
+                Grid.Column="3"
+                Background="#75E9FC"
+                ColorBrushName="SystemColorHotlightColor"
+                ColorExplanation="Foreground / Text color for hyperlink text."
+                ColorName="Hotlight Color"
+                ColorValue="#75E9FC"
+                Foreground="#202020"
+                ShowSeparator="False" />
+            <designguidance:ColorTile
+                Grid.Row="1"
+                Grid.Column="3"
+                Background="#A6A6A6"
+                ColorBrushName="SystemColorGreyTextColor"
+                ColorExplanation="Foreground / Text color for Inactive (disabled) UI."
+                ColorName="Grey Text Color / Disabled"
+                ColorValue="#A6A6A6"
+                Foreground="#FFFFFF"
+                ShowSeparator="False" />
+        </Grid>
+
+        <!--  Desert  -->
+        <TextBlock
+            Margin="0,24,0,0"
+            Style="{StaticResource SubtitleTextBlockStyle}"
+            Text="Desert" />
+        <Grid Style="{StaticResource ColorTilesPanelStyle}">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition />
+                <RowDefinition />
+            </Grid.RowDefinitions>
+            <designguidance:ColorTile
+                Background="#3D3D3D"
+                ColorBrushName="SystemColorWindowTextColor"
+                ColorExplanation="Foreground / Text color for Headings, body copy, lists, placeholder text, app and window borders, any UI that can't be interacted with."
+                ColorName="Window Text Color"
+                ColorValue="#3D3D3D"
+                Foreground="#FFFAEF"
+                ShowSeparator="False" />
+            <designguidance:ColorTile
+                Grid.Row="1"
+                Background="#FFFAEF"
+                ColorBrushName="SystemColorWindowColor"
+                ColorExplanation="Background of pages, panes, popups, and windows."
+                ColorName="Window Color"
+                ColorValue="#FFFAEF"
+                Foreground="#3D3D3D"
+                ShowSeparator="False" />
+
+            <designguidance:ColorTile
+                Grid.Column="1"
+                Background="#FFF5E3"
+                ColorBrushName="SystemColorHighlightTextColor"
+                ColorExplanation="Foreground color for text or UI that is in selected, interacted with (hover, pressed), or in progress."
+                ColorName="Highlight Text Color"
+                ColorValue="#FFF5E3"
+                Foreground="#903909"
+                ShowSeparator="False" />
+            <designguidance:ColorTile
+                Grid.Row="1"
+                Grid.Column="1"
+                Background="#903909"
+                ColorBrushName="SystemColorHighlightColor"
+                ColorExplanation="Background or accent color for UI that is in selected, interacted with (hover, pressed), or in progress."
+                ColorName="Highlight Color"
+                ColorValue="#903909"
+                Foreground="#FFF5E3"
+                ShowSeparator="False" />
+
+            <designguidance:ColorTile
+                Grid.Column="2"
+                Background="#202020"
+                ColorBrushName="SystemColorButtonTextColor"
+                ColorExplanation="Foreground color for buttons and any UI that can be interacted with."
+                ColorName="Button Text Color"
+                ColorValue="#202020"
+                Foreground="#FFFAEF"
+                ShowSeparator="False" />
+            <designguidance:ColorTile
+                Grid.Row="1"
+                Grid.Column="2"
+                Background="#FFFAEF"
+                ColorBrushName="SystemColorButtonFaceColor"
+                ColorExplanation="Background color for buttons and any UI that can be interacted with."
+                ColorName="Button Face Color"
+                ColorValue="#FFFAEF"
+                Foreground="#202020"
+                ShowSeparator="False" />
+
+            <designguidance:ColorTile
+                Grid.Column="3"
+                Background="#1C5E75"
+                ColorBrushName="SystemColorHotlightColor"
+                ColorExplanation="Foreground / Text color for hyperlink text."
+                ColorName="Hotlight Color"
+                ColorValue="#1C5E75"
+                Foreground="#FFFAEF"
+                ShowSeparator="False" />
+            <designguidance:ColorTile
+                Grid.Row="1"
+                Grid.Column="3"
+                Background="#676767"
+                ColorBrushName="SystemColorGreyTextColor"
+                ColorExplanation="Foreground / Text color for Inactive (disabled) UI."
+                ColorName="Grey Text Color / Disabled"
+                ColorValue="#676767"
+                Foreground="#FFFAEF"
+                ShowSeparator="False" />
+        </Grid>
+
+        <!--  Dusk  -->
+        <TextBlock
+            Margin="0,24,0,0"
+            Style="{StaticResource SubtitleTextBlockStyle}"
+            Text="Dusk" />
+        <Grid Style="{StaticResource ColorTilesPanelStyle}">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition />
+                <RowDefinition />
+            </Grid.RowDefinitions>
+            <designguidance:ColorTile
+                Background="#FFFFFF"
+                ColorBrushName="SystemColorWindowTextColor"
+                ColorExplanation="Foreground / Text color for Headings, body copy, lists, placeholder text, app and window borders, any UI that can't be interacted with."
+                ColorName="Window Text Color"
+                ColorValue="#FFFFFF"
+                Foreground="#2D3236"
+                ShowSeparator="False" />
+            <designguidance:ColorTile
+                Grid.Row="1"
+                Background="#2D3236"
+                ColorBrushName="SystemColorWindowColor"
+                ColorExplanation="Background of pages, panes, popups, and windows."
+                ColorName="Window Color"
+                ColorValue="#2D3236"
+                Foreground="#FFFFFF"
+                ShowSeparator="False" />
+
+            <designguidance:ColorTile
+                Grid.Column="1"
+                Background="#212D3B"
+                ColorBrushName="SystemColorHighlightTextColor"
+                ColorExplanation="Foreground color for text or UI that is in selected, interacted with (hover, pressed), or in progress."
+                ColorName="Highlight Text Color"
+                ColorValue="#212D3B"
+                Foreground="#ABCFF2"
+                ShowSeparator="False" />
+            <designguidance:ColorTile
+                Grid.Row="1"
+                Grid.Column="1"
+                Background="#ABCFF2"
+                ColorBrushName="SystemColorHighlightColor"
+                ColorExplanation="Background or accent color for UI that is in selected, interacted with (hover, pressed), or in progress."
+                ColorName="Highlight Color"
+                ColorValue="#ABCFF2"
+                Foreground="#212D3B"
+                ShowSeparator="False" />
+
+            <designguidance:ColorTile
+                Grid.Column="2"
+                Background="#B6F6F0"
+                ColorBrushName="SystemColorButtonTextColor"
+                ColorExplanation="Foreground color for buttons and any UI that can be interacted with."
+                ColorName="Button Text Color"
+                ColorValue="#B6F6F0"
+                Foreground="#2D3236"
+                ShowSeparator="False" />
+            <designguidance:ColorTile
+                Grid.Row="1"
+                Grid.Column="2"
+                Background="#2D3236"
+                ColorBrushName="SystemColorButtonFaceColor"
+                ColorExplanation="Background color for buttons and any UI that can be interacted with."
+                ColorName="Button Face Color"
+                ColorValue="#2D3236"
+                Foreground="#B6F6F0"
+                ShowSeparator="False" />
+
+            <designguidance:ColorTile
+                Grid.Column="3"
+                Background="#70EBDE"
+                ColorBrushName="SystemColorHotlightColor"
+                ColorExplanation="Foreground / Text color for hyperlink text."
+                ColorName="Hotlight Color"
+                ColorValue="#70EBDE"
+                Foreground="#202020"
+                ShowSeparator="False" />
+            <designguidance:ColorTile
+                Grid.Row="1"
+                Grid.Column="3"
+                Background="#A6A6A6"
+                ColorBrushName="SystemColorGreyTextColor"
+                ColorExplanation="Foreground / Text color for Inactive (disabled) UI."
+                ColorName="Grey Text Color / Disabled"
+                ColorValue="#A6A6A6"
+                Foreground="#FFFFFF"
+                ShowSeparator="False" />
+        </Grid>
+
+        <!--  Night Sky  -->
+        <TextBlock
+            Margin="0,24,0,0"
+            Style="{StaticResource SubtitleTextBlockStyle}"
+            Text="Night Sky" />
+        <Grid Style="{StaticResource ColorTilesPanelStyle}">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition />
+                <RowDefinition />
+            </Grid.RowDefinitions>
+            <designguidance:ColorTile
+                Background="#FFFFFF"
+                ColorBrushName="SystemColorWindowTextColor"
+                ColorExplanation="Foreground / Text color for Headings, body copy, lists, placeholder text, app and window borders, any UI that can't be interacted with."
+                ColorName="Window Text Color"
+                ColorValue="#FFFFFF"
+                Foreground="#000000"
+                ShowSeparator="False" />
+            <designguidance:ColorTile
+                Grid.Row="1"
+                Background="#000000"
+                ColorBrushName="SystemColorWindowColor"
+                ColorExplanation="Background of pages, panes, popups, and windows."
+                ColorName="Window Color"
+                ColorValue="#000000"
+                Foreground="#FFFFFF"
+                ShowSeparator="False" />
+
+            <designguidance:ColorTile
+                Grid.Column="1"
+                Background="#2B2B2B"
+                ColorBrushName="SystemColorHighlightTextColor"
+                ColorExplanation="Foreground color for text or UI that is in selected, interacted with (hover, pressed), or in progress."
+                ColorName="Highlight Text Color"
+                ColorValue="#2B2B2B"
+                Foreground="#D6B4FD"
+                ShowSeparator="False" />
+            <designguidance:ColorTile
+                Grid.Row="1"
+                Grid.Column="1"
+                Background="#D6B4FD"
+                ColorBrushName="SystemColorHighlightColor"
+                ColorExplanation="Background or accent color for UI that is in selected, interacted with (hover, pressed), or in progress."
+                ColorName="Highlight Color"
+                ColorValue="#D6B4FD"
+                Foreground="#2B2B2B"
+                ShowSeparator="False" />
+
+            <designguidance:ColorTile
+                Grid.Column="2"
+                Background="#FFEE32"
+                ColorBrushName="SystemColorButtonTextColor"
+                ColorExplanation="Foreground color for buttons and any UI that can be interacted with."
+                ColorName="Button Text Color"
+                ColorValue="#FFEE32"
+                Foreground="#000000"
+                ShowSeparator="False" />
+            <designguidance:ColorTile
+                Grid.Row="1"
+                Grid.Column="2"
+                Background="#000000"
+                ColorBrushName="SystemColorButtonFaceColor"
+                ColorExplanation="Background color for buttons and any UI that can be interacted with."
+                ColorName="Button Face Color"
+                ColorValue="#000000"
+                Foreground="#FFEE32"
+                ShowSeparator="False" />
+
+            <designguidance:ColorTile
+                Grid.Column="3"
+                Background="#8080FF"
+                ColorBrushName="SystemColorHotlightColor"
+                ColorExplanation="Foreground / Text color for hyperlink text."
+                ColorName="Hotlight Color"
+                ColorValue="#8080FF"
+                Foreground="#FFFFFF"
+                ShowSeparator="False" />
+            <designguidance:ColorTile
+                Grid.Row="1"
+                Grid.Column="3"
+                Background="#A6A6A6"
+                ColorBrushName="SystemColorGreyTextColor"
+                ColorExplanation="Foreground / Text color for Inactive (disabled) UI."
+                ColorName="Grey Text Color / Disabled"
+                ColorValue="#A6A6A6"
+                Foreground="#000000"
+                ShowSeparator="False" />
+        </Grid>
+    </StackPanel>
+</Page>

--- a/WinUIGallery/Controls/DesignGuidance/ColorSections/HighContrastSection.xaml.cs
+++ b/WinUIGallery/Controls/DesignGuidance/ColorSections/HighContrastSection.xaml.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation and Contributors.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace WinUIGallery.DesktopWap.Controls.DesignGuidance.ColorSections
+{
+    public sealed partial class HighContrastSection : Page
+    {
+        public HighContrastSection()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/WinUIGallery/WinUIGallery.csproj
+++ b/WinUIGallery/WinUIGallery.csproj
@@ -136,6 +136,7 @@
         <None Remove="ControlPages\Typography.xaml" />
         <None Remove="Controls\CopyButton\CopyButton.xaml" />
         <None Remove="Controls\DesignGuidance\ColorPageExample.xaml" />
+        <None Remove="Controls\DesignGuidance\ColorSections\HighContrastSection.xaml" />
         <None Remove="Controls\DesignGuidance\ColorSections\SignalSection.xaml" />
         <None Remove="Controls\DesignGuidance\ColorSections\TextSection.xaml" />
         <None Remove="Controls\DesignGuidance\ColorTile.xaml" />
@@ -177,6 +178,9 @@
     <ItemGroup>
         <Page Update="ControlPages\InfoBadgePage.xaml">
             <Generator>MSBuild:Compile</Generator>
+        </Page>
+        <Page Update="Controls\DesignGuidance\ColorSections\HighContrastSection.xaml">
+          <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
         </Page>
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
This PR adds a `High Contrast` page to the colors overview, and shows the 8 high contrast brushes that come with WinUI.

This closes: #1217

New high contrast page:
![image](https://github.com/microsoft/WinUI-Gallery/assets/9866362/48aaac45-f3ff-483f-91f9-f95b8ba324f1)



Screenshot from WinUI Visual Library Figma (source):
![image](https://github.com/microsoft/WinUI-Gallery/assets/9866362/1323d9df-fd4a-44de-a5b2-95500911fab0)
