### PR TITLE
Added Missing Curly Brace in Sample Text Document

### DIFF
--- a/WinUIGallery/ControlPagesSampleCode/System/FilePickerSample1_cs.txt
+++ b/WinUIGallery/ControlPagesSampleCode/System/FilePickerSample1_cs.txt
@@ -26,4 +26,5 @@
     else
     {
         PickAFileOutputTextBlock.Text = "Operation cancelled.";
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Corrected a little mistake in the sample text document. I added a curly brace at the end of the file.

## Motivation and Context
I found the issue while using the app, as I tried to copy the code part, and then I came across the mistake.

## How Has This Been Tested?
Its just a txtFile, no tests needed.

## Screenshots (if appropriate):
![image](https://github.com/microsoft/WinUI-Gallery/assets/54930399/b0271f64-c770-4c9b-9851-45cb28271810)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
