### PR TITLE
Fixing `ListBox` XAML code example syntax

### DIFF
--- a/WinUIGallery/ControlPages/ListBoxPage.xaml
+++ b/WinUIGallery/ControlPages/ListBoxPage.xaml
@@ -29,10 +29,10 @@
             <local:ControlExample.Xaml>
                 <x:String xml:space="preserve">
 &lt;ListBox SelectionChanged="ColorListBox_SelectionChanged" MinWidth="200"&gt;
-    &lt;x:String&gt;Blue&lt;x:String&gt;
-    &lt;x:String&gt;Green&lt;x:String&gt;
-    &lt;x:String&gt;Red&lt;x:String&gt;
-    &lt;x:String&gt;Yellow&lt;x:String&gt;
+    &lt;x:String&gt;Blue&lt;/x:String&gt;
+    &lt;x:String&gt;Green&lt;/x:String&gt;
+    &lt;x:String&gt;Red&lt;/x:String&gt;
+    &lt;x:String&gt;Yellow&lt;/x:String&gt;
 &lt;/ListBox&gt;
                 </x:String>
             </local:ControlExample.Xaml>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The ListBox example is missing `/` in the closing tags of the options

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Examples shouldn't have invalid syntax

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Screenshots (if appropriate):
![Screenshot 2023-11-23 102932](https://github.com/microsoft/WinUI-Gallery/assets/8790386/8bc8d159-7369-4d97-a2de-7b496ada9e21)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
