### PR TITLE
Remove useless api check in the animation interop page code sample

### DIFF
--- a/WinUIGallery/ControlPagesSampleCode/Motion/AnimationInterop/AnimationInteropSample4_cs.txt
+++ b/WinUIGallery/ControlPagesSampleCode/Motion/AnimationInterop/AnimationInteropSample4_cs.txt
@@ -1,8 +1,5 @@
 ﻿private void ActualSizeExample_Loaded(object sender, RoutedEventArgs e)
 {
-    // Only create an expression using ActualSize if the API exists to do so.
-    if (!(ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))) return;
-
     // We will lay out some buttons in a circle.
     // The formulas we will use are:
     //   X = radius * cos(theta) + xOffset

--- a/WinUIGallery/ControlPagesSampleCode/Motion/AnimationInterop/AnimationInteropSample5_cs.txt
+++ b/WinUIGallery/ControlPagesSampleCode/Motion/AnimationInterop/AnimationInteropSample5_cs.txt
@@ -1,8 +1,5 @@
 ﻿private void ActualOffsetExample_Loaded(object sender, RoutedEventArgs e)
 {
-    // Only create an expression using ActualSize if the API exists to do so.
-    if (!(ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))) return;
-
     // This sample positions a popup relative to a block of text that has variable layout size based on font size.
     var anim = _compositor.CreateExpressionAnimation();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove api check in code sample of winui3 animation interop page

## Motivation and Context
Because it's unnecessary. WinUI3 has decoupled compositor

## How Has This Been Tested?
Manual

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
