### PR TITLE
Fix: Escape glyph hex in xaml

### DIFF
--- a/WinUIGallery/ControlPages/AppBarButtonPage.xaml
+++ b/WinUIGallery/ControlPages/AppBarButtonPage.xaml
@@ -61,7 +61,7 @@
                 <x:String xml:space="preserve">
 &lt;AppBarButton Label="FontIcon" Click="AppBarButton_Click"&gt;
     &lt;AppBarButton.Icon&gt;
-        &lt;FontIcon FontFamily="Candara" Glyph="&#x03A3;"/&gt;
+        &lt;FontIcon FontFamily="Candara" Glyph="&amp;#x03A3;"/&gt;
     &lt;/AppBarButton.Icon&gt;
 &lt;/AppBarButton&gt;
                 </x:String>

--- a/WinUIGallery/ControlPages/AppBarToggleButtonPage.xaml
+++ b/WinUIGallery/ControlPages/AppBarToggleButtonPage.xaml
@@ -67,7 +67,7 @@
                 <x:String xml:space="preserve">
 &lt;AppBarToggleButton Label="FontIcon" Click="AppBarButton_Click"&gt;
     &lt;AppBarToggleButton.Icon&gt;
-        &lt;FontIcon FontFamily="Candara" Glyph="&#x03A3;"/&gt;
+        &lt;FontIcon FontFamily="Candara" Glyph="&amp;#x03A3;"/&gt;
     &lt;/AppBarToggleButton.Icon&gt;
 &lt;/AppBarToggleButton&gt;
                 </x:String>

--- a/WinUIGallery/ControlPages/InfoBadgePage.xaml
+++ b/WinUIGallery/ControlPages/InfoBadgePage.xaml
@@ -123,7 +123,7 @@
         &lt;SymbolIcon Symbol="Sync" HorizontalAlignment="Center"/&gt;
         &lt;InfoBadge Background="#C42B1C" HorizontalAlignment="Right" VerticalAlignment="Top"&gt;
             &lt;InfoBadge.IconSource&gt;
-                &lt;FontIconSource FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xF13C;" /&gt;
+                &lt;FontIconSource FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&amp;#xF13C;" /&gt;
             &lt;/InfoBadge.IconSource&gt;
         &lt;/InfoBadge&gt;
     &lt;/Grid&gt;

--- a/WinUIGallery/ControlPages/InfoBadgePage.xaml
+++ b/WinUIGallery/ControlPages/InfoBadgePage.xaml
@@ -20,7 +20,7 @@
     mc:Ignorable="d">
 
     <StackPanel>
-        <local:ControlExample x:Name="Example1" HeaderText="InfoBadge embedded in NavigationView" HorizontalContentAlignment="Stretch" >
+        <local:ControlExample x:Name="Example1" HeaderText="InfoBadge embedded in NavigationView " HorizontalContentAlignment="Stretch" >
             <local:ControlExample.Example>
                 <Grid>
                     <Grid.RowDefinitions>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Escape glyph hex in xaml sample

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://github.com/microsoft/WinUI-Gallery/assets/42881734/f299b147-1dad-40ca-aacc-fe980c8b14dd)
->
![image](https://github.com/microsoft/WinUI-Gallery/assets/42881734/4252a0b8-f5e2-46e7-b0f2-c59e793c161e)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
