### PR TITLE
[proof of concept] List lightweight styling resources

### DIFF
--- a/WinUIGallery/ControlPages/ButtonPage.xaml
+++ b/WinUIGallery/ControlPages/ButtonPage.xaml
@@ -12,7 +12,8 @@
 <Page x:Class="AppUIBasics.ControlPages.ButtonPage" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:local="using:AppUIBasics"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:pages="using:AppUIBasics.ControlPages"
       xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
       mc:Ignorable="d">
     <StackPanel>
@@ -119,6 +120,23 @@
                 </x:String>
             </local:ControlExample.Xaml>
         </local:ControlExample>
-        
+
+        <TextBlock Text="Lightweight styling" Style="{ThemeResource BodyStrongTextBlockStyle}" AutomationProperties.HeadingLevel="Level2" Margin="0,16,0,4" />
+        <ListView x:Name="LightweightStylesBox" HorizontalAlignment="Left">
+            <ListView.ItemTemplate>
+                <DataTemplate x:DataType="pages:ButtonResource">
+                    <Grid ColumnSpacing="8" Padding="0,8">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="300" />
+                            <ColumnDefinition Width="*" MinWidth="100" />
+                        </Grid.ColumnDefinitions>
+                        
+                        <TextBlock Text="{x:Bind Name}" Style="{ThemeResource BodyTextBlockStyle}" Grid.Column="0" VerticalAlignment="Center" TextAlignment="Right" />
+                        
+                        <Border Height="40" Grid.Column="1" Background="{x:Bind Brush}" CornerRadius="4" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1" />
+                    </Grid>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
     </StackPanel>
 </Page>

--- a/WinUIGallery/ControlPages/ButtonPage.xaml
+++ b/WinUIGallery/ControlPages/ButtonPage.xaml
@@ -148,7 +148,9 @@
                         </Grid.ColumnDefinitions>
                         
                         <TextBlock Text="{x:Bind Name}" Style="{ThemeResource BodyTextBlockStyle}" Grid.Column="0" VerticalAlignment="Center" TextAlignment="Right" />
-                        
+
+                        <!-- TODO: include hex in view -->
+                        <!-- TODO: allow live restyling? -->
                         <Border Height="40" Grid.Column="1" Background="{x:Bind LightBrush}" CornerRadius="4" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1" />
                         <Border Height="50" Margin="-5" Grid.Column="2" Background="Black" CornerRadius="4" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1" Padding="4">
                             <Border Height="40" Background="{x:Bind DarkBrush}" CornerRadius="4" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1" />

--- a/WinUIGallery/ControlPages/ButtonPage.xaml
+++ b/WinUIGallery/ControlPages/ButtonPage.xaml
@@ -123,17 +123,35 @@
 
         <TextBlock Text="Lightweight styling" Style="{ThemeResource BodyStrongTextBlockStyle}" AutomationProperties.HeadingLevel="Level2" Margin="0,16,0,4" />
         <ListView x:Name="LightweightStylesBox" HorizontalAlignment="Left">
+            <ListView.Header>
+                    <Grid ColumnSpacing="8" Padding="0,8">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="300" />
+                            <ColumnDefinition Width="*" MinWidth="100" />
+                            <ColumnDefinition Width="*" MinWidth="100" />
+                            <ColumnDefinition Width="*" MinWidth="100" />
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock Text="Dark" Style="{ThemeResource BodyTextBlockStyle}" Grid.Column="1" VerticalAlignment="Center" TextAlignment="Center" />
+                        <TextBlock Text="Light" Style="{ThemeResource BodyTextBlockStyle}" Grid.Column="2" VerticalAlignment="Center" TextAlignment="Center" />
+                        <TextBlock Text="High Contrast" Style="{ThemeResource BodyTextBlockStyle}" Grid.Column="3" VerticalAlignment="Center" TextAlignment="Center" />
+                    </Grid>
+            </ListView.Header>
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="pages:ButtonResource">
                     <Grid ColumnSpacing="8" Padding="0,8">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="300" />
                             <ColumnDefinition Width="*" MinWidth="100" />
+                            <ColumnDefinition Width="*" MinWidth="100" />
+                            <ColumnDefinition Width="*" MinWidth="100" />
                         </Grid.ColumnDefinitions>
                         
                         <TextBlock Text="{x:Bind Name}" Style="{ThemeResource BodyTextBlockStyle}" Grid.Column="0" VerticalAlignment="Center" TextAlignment="Right" />
                         
-                        <Border Height="40" Grid.Column="1" Background="{x:Bind Brush}" CornerRadius="4" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1" />
+                        <Border Height="40" Grid.Column="1" Background="{x:Bind DarkBrush}" CornerRadius="4" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1" />
+                        <Border Height="40" Grid.Column="2" Background="{x:Bind LightBrush}" CornerRadius="4" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1" />
+                        <Border Height="40" Grid.Column="3" Background="{x:Bind HighContrastBrush}" CornerRadius="4" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1" />
                     </Grid>
                 </DataTemplate>
             </ListView.ItemTemplate>

--- a/WinUIGallery/ControlPages/ButtonPage.xaml
+++ b/WinUIGallery/ControlPages/ButtonPage.xaml
@@ -132,8 +132,8 @@
                             <ColumnDefinition Width="*" MinWidth="100" />
                         </Grid.ColumnDefinitions>
 
-                        <TextBlock Text="Dark" Style="{ThemeResource BodyTextBlockStyle}" Grid.Column="1" VerticalAlignment="Center" TextAlignment="Center" />
-                        <TextBlock Text="Light" Style="{ThemeResource BodyTextBlockStyle}" Grid.Column="2" VerticalAlignment="Center" TextAlignment="Center" />
+                        <TextBlock Text="Light" Style="{ThemeResource BodyTextBlockStyle}" Grid.Column="1" VerticalAlignment="Center" TextAlignment="Center" />
+                        <TextBlock Text="Dark" Style="{ThemeResource BodyTextBlockStyle}" Grid.Column="2" VerticalAlignment="Center" TextAlignment="Center" />
                         <TextBlock Text="High Contrast" Style="{ThemeResource BodyTextBlockStyle}" Grid.Column="3" VerticalAlignment="Center" TextAlignment="Center" />
                     </Grid>
             </ListView.Header>
@@ -149,8 +149,10 @@
                         
                         <TextBlock Text="{x:Bind Name}" Style="{ThemeResource BodyTextBlockStyle}" Grid.Column="0" VerticalAlignment="Center" TextAlignment="Right" />
                         
-                        <Border Height="40" Grid.Column="1" Background="{x:Bind DarkBrush}" CornerRadius="4" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1" />
-                        <Border Height="40" Grid.Column="2" Background="{x:Bind LightBrush}" CornerRadius="4" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1" />
+                        <Border Height="40" Grid.Column="1" Background="{x:Bind LightBrush}" CornerRadius="4" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1" />
+                        <Border Height="50" Margin="-5" Grid.Column="2" Background="Black" CornerRadius="4" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1" Padding="4">
+                            <Border Height="40" Background="{x:Bind DarkBrush}" CornerRadius="4" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1" />
+                        </Border>
                         <Border Height="40" Grid.Column="3" Background="{x:Bind HighContrastBrush}" CornerRadius="4" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" BorderThickness="1" />
                     </Grid>
                 </DataTemplate>

--- a/WinUIGallery/ControlPages/ButtonPage.xaml.cs
+++ b/WinUIGallery/ControlPages/ButtonPage.xaml.cs
@@ -34,6 +34,10 @@ namespace AppUIBasics.ControlPages
                 {
                     return d.ThemeDictionaries.SelectMany((t) =>
                     {
+                        // TODO: this isn't the best approach. It works, since lightweight styles always have a key that starts with "Button",
+                        // but it would be nicer to inspect the default template somehow & get a complete list of styles.
+                        //
+                        // Similarly, it'd be nice to automatically know to fetch things like "AccentButton".
                         return (t.Value as ResourceDictionary)
                             .Where((r) => r.Key.ToString().StartsWith("Button") && r.Value is SolidColorBrush)
                             .Select((r) =>

--- a/WinUIGallery/ControlPages/ButtonPage.xaml.cs
+++ b/WinUIGallery/ControlPages/ButtonPage.xaml.cs
@@ -7,16 +7,43 @@
 // PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
 //
 //*********************************************************
+using System.Linq;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 
 namespace AppUIBasics.ControlPages
 {
+    public sealed class ButtonResource
+    {
+        public string Name;
+        public SolidColorBrush Brush;
+    }
+
     public sealed partial class ButtonPage : Page
     {
         public ButtonPage()
         {
             this.InitializeComponent();
+
+            var buttonResources = Application.Current.Resources.MergedDictionaries
+                .SelectMany((d) =>
+                {
+                    return d.ThemeDictionaries.SelectMany((t) =>
+                    {
+                        return (t.Value as ResourceDictionary).Where((r) => r.Key.ToString().StartsWith("Button"));
+                    });
+                })
+                .Where(r => r.Value is SolidColorBrush)
+                .Select((r) =>
+                {
+                    return new ButtonResource()
+                    {
+                        Name = r.Key.ToString(),
+                        Brush = r.Value as SolidColorBrush
+                    };
+                });
+            LightweightStylesBox.ItemsSource = buttonResources;
         }
 
         private void Button_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Today, it is very difficult to get a list of [lightweight styles](https://learn.microsoft.com/en-us/windows/apps/design/style/xaml-styles#lightweight-styling) for a given control.

This change introduces a **proof of concept** that can automatically fetch a list of lightweight styles for a given control. It does this by reading the Application `ResourceDictionary`s for brushes that have the correct prefixes.

## Thoughts

* How do we order the styles?
* How about non-brush styles?
* Are there some styles that are colors instead?
* How do we generalize this for all controls?

## Screenshots

![a simple list of brushes](https://github.com/microsoft/WinUI-Gallery/assets/432939/56d5f563-fecb-4cff-8311-9602e9d80388)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
