### PR TITLE
Bump year

### DIFF
--- a/WinUIGallery/SettingsPage.xaml
+++ b/WinUIGallery/SettingsPage.xaml
@@ -117,7 +117,7 @@
 
                 <!--  About  -->
                 <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="About" />
-                <toolkit:SettingsExpander Description="© 2023 Microsoft. All rights reserved." Header="{StaticResource AppTitleName}">
+                <toolkit:SettingsExpander Description="© 2024 Microsoft. All rights reserved." Header="{StaticResource AppTitleName}">
                     <toolkit:SettingsExpander.HeaderIcon>
                         <BitmapIcon ShowAsMonochrome="False" UriSource="/Assets/Tiles/SmallTile-sdk.png" />
                     </toolkit:SettingsExpander.HeaderIcon>


### PR DESCRIPTION
Nit: bumping year in `SettingsPage.xaml`

![image](https://github.com/microsoft/WinUI-Gallery/assets/9866362/1a06b113-de8e-46ee-ad61-1e47cab6ef8e)
