### PR TITLE
Improve accessibility of ListView page - list view items UIA description includes more information.

### DIFF
--- a/WinUIGallery/ControlPages/ListViewPage.xaml.cs
+++ b/WinUIGallery/ControlPages/ListViewPage.xaml.cs
@@ -398,7 +398,7 @@ namespace AppUIBasics.ControlPages
 
         public override string ToString()
         {
-            return Name;
+            return $"{Name}, {Company}";
         }
 #endregion
     }


### PR DESCRIPTION
This issue was brought up here:

[JAWS cannot read non-simple ListViewItems · Issue #8109 · microsoft/microsoft-ui-xaml](https://github.com/microsoft/microsoft-ui-xaml/issues/8109)

We update the ToString of the data item in the ListView to include both the Name and the Company which gives a better experience for screen readers.