### PR TITLE
Fix YAML syntax error on bug_report.yaml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,7 +1,7 @@
 name: Bug report
 description: File a bug report
 title: "Bug title"
-labels: ["bug"], ["needs-triage"]
+labels: ["bug", "needs-triage"]
 body:
   - type: dropdown
     validations:


### PR DESCRIPTION
## Description
Fixed the YAML syntax on "labels".

## Motivation and Context
The "Bug report" issue template is not working due to this error.

## How Has This Been Tested?
Checked that the syntax error is fixed on a local branch.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
