### PR TITLE
Fix app crash trying to show the search results page

### DIFF
--- a/UITests/Tests/SearchResults.cs
+++ b/UITests/Tests/SearchResults.cs
@@ -30,6 +30,7 @@ namespace UITests.Tests
 
         [TestMethod]
         [DataRow("a")]  // "a" should return results for all groups.
+        [TestProperty("Description", "Validate the accessibility of the search results page.")]
         public void ValidateSearchResultsPageAccessibility(string searchText)
         {
             var search = Session.FindElementByName("Search");
@@ -47,6 +48,7 @@ namespace UITests.Tests
             {
                 Thread.Sleep(1000);
                 menuItem.Click();
+                AxeHelper.AssertNoAccessibilityErrors();
             }
         }
     }

--- a/UITests/Tests/SearchResults.cs
+++ b/UITests/Tests/SearchResults.cs
@@ -1,0 +1,53 @@
+﻿//******************************************************************************
+//
+// Copyright (c) 2024 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenQA.Selenium;
+using System.Threading;
+
+namespace UITests.Tests
+{
+    [TestClass]
+    public class SearchResults : TestBase
+    {
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext context)
+        {
+        }
+
+        [TestMethod]
+        [DataRow("a")]  // "a" should return results for all groups.
+        public void ValidateSearchResultsPageAccessibility(string searchText)
+        {
+            var search = Session.FindElementByName("Search");
+            search.Clear();
+
+            search.SendKeys(searchText);
+            search.SendKeys(Keys.Enter);
+
+            Thread.Sleep(100);
+
+            var resultsNavView = Session.FindElementByAccessibilityId("resultsNavView");
+            var resultItems = resultsNavView.FindElements(By.ClassName("Microsoft.UI.Xaml.Controls.NavigationViewItem"));
+
+            foreach (var menuItem in resultItems)
+            {
+                Thread.Sleep(1000);
+                menuItem.Click();
+            }
+        }
+    }
+}

--- a/WinUIGallery/DataModel/ControlInfoDataSource.cs
+++ b/WinUIGallery/DataModel/ControlInfoDataSource.cs
@@ -231,6 +231,7 @@ namespace AppUIBasics.Data
 
                     item.BadgeString = badgeString;
                     item.IncludedInBuild = pageType is not null;
+                    item.ImagePath ??= "ms-appx:///Assets/ControlImages/Placeholder.png";
 #nullable disable
                 });
 


### PR DESCRIPTION
## Description
Set the placeholder image "Placeholder.png" in case that ControlInfoDataPath item's ImagePath is null.

## Motivation and Context
Fixes #1438.

## How Has This Been Tested?
Tested on the updated app.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
