### PR TITLE
Allow dragging last tab out of window

### DIFF
--- a/WinUIGallery/TabViewPages/TabViewWindowingSamplePage.xaml.cs
+++ b/WinUIGallery/TabViewPages/TabViewWindowingSamplePage.xaml.cs
@@ -51,17 +51,6 @@ namespace WinUIGallery.TabViewPages
             {
                 WindowHelper.GetWindowForElement(this).Close();
             }
-            // If there is only one tab left, disable dragging and reordering of Tabs.
-            else if (sender.TabItems.Count == 1)
-            {
-                sender.CanReorderTabs = false;
-                sender.CanDragTabs = false;
-            }
-            else
-            {
-                sender.CanReorderTabs = true;
-                sender.CanDragTabs = true;
-            }
         }
 
         public void LoadDemoData()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR removes the code that blocked dragging the last tab. I think this also addresses the other open issue since we might not have properly updated the tab-allowance state.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #399
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
