### PR TITLE
[FIX] Fix typo in file picker sample source

### DIFF
--- a/WinUIGallery/ControlPagesSampleCode/System/FilePickerSample1_cs.txt
+++ b/WinUIGallery/ControlPagesSampleCode/System/FilePickerSample1_cs.txt
@@ -1,7 +1,7 @@
 ﻿private async void PickAFileButton_Click(object sender, RoutedEventArgs e)
 {
     // Clear previous returned file name, if it exists, between iterations of this scenario
-    OutputTextBlock.Text = "";
+    PickAFileOutputTextBlock.Text = "";
 
     // Create a file picker
     var openPicker = new Windows.Storage.Pickers.FileOpenPicker();


### PR DESCRIPTION
There was a mismatch in the name for TextBlock control in the first FilePicker sample. Changed name from `OutputTextBlock` to `PickAFileOutputTextBlock` in the sample source text file.

## How Has This Been Tested?
N/A, typo fix.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
