### PR TITLE
Update to support submodule builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,8 +18,9 @@
     <!-- If conflicting build and publish deps.json files exist in this or referenced projects,
         use only the publish deps.json files, and remove the corresponding build deps.json files. -->
     <ItemGroup>
-      <_PublishDepsJsonFiles Include="@(PackagingOutputs->HasMetadata('CopyToPublishDirectory'))"
-        Condition="$([System.String]::Copy(%(FileName)%(Extension)).EndsWith('.deps.json'))" />
+      <_PublishPackagingOutputs Include="@(PackagingOutputs->HasMetadata('CopyToPublishDirectory'))"/>
+      <_PublishDepsJsonFiles Include="@(_PublishPackagingOutputs)"
+        Condition="'@(_PublishPackagingOutputs)' != '' and $([System.String]::Copy(%(FileName)%(Extension)).EndsWith('.deps.json'))" />
       <PackagingOutputs Remove="@(_PublishDepsJsonFiles)" MatchOnMetadata="TargetPath"/>
       <PackagingOutputs Include="@(_PublishDepsJsonFiles)"/>
     </ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,3 +1,28 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" Condition="Exists($([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../')))" />
+
+  <!-- Building both in the WinUI repo and standalone, WinUIGallery's dependencies now require latest SDKs -->
+  <PropertyGroup>
+    <SamplesTargetFrameworkMoniker>net8.0-windows10.0.22621.0</SamplesTargetFrameworkMoniker>
+    <WindowsSdkTargetPlatformVersion>10.0.22621.756</WindowsSdkTargetPlatformVersion>
+    <WindowsAppSdkTargetPlatformVersion>10.0.17763.0</WindowsAppSdkTargetPlatformVersion>
+    <MicrosoftWindowsSDKBuildToolsNugetPackageVersion>10.0.22621.756</MicrosoftWindowsSDKBuildToolsNugetPackageVersion>
+  </PropertyGroup>
+
+  <!-- If we aren't building in the WinUI repo, import the necessary missing props we'd normally pick up from its Directory.Build.props hierarchy -->
+  <!-- The UseStandalone property allows this to be overridden, in order to buildSamples to build without changing the entire repo -->
+  <Import Project="Standalone.props" Condition="'$(IsInWinUIRepo)' != 'true' OR '$(UseStandalone)' == 'true'"/>
+
+  <!-- Temporary workaround until WinAppSDK 1.5.2 provides fix -->
+  <Target Name="RemoveConflictingDepsJsonFiles" AfterTargets="GetPackagingOutputs">
+    <!-- If conflicting build and publish deps.json files exist in this or referenced projects,
+        use only the publish deps.json files, and remove the corresponding build deps.json files. -->
+    <ItemGroup>
+      <_PublishDepsJsonFiles Include="@(PackagingOutputs->HasMetadata('CopyToPublishDirectory'))"
+        Condition="$([System.String]::Copy(%(FileName)%(Extension)).EndsWith('.deps.json'))" />
+      <PackagingOutputs Remove="@(_PublishDepsJsonFiles)" MatchOnMetadata="TargetPath"/>
+      <PackagingOutputs Include="@(_PublishDepsJsonFiles)"/>
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/UITests/README.md
+++ b/UITests/README.md
@@ -17,7 +17,7 @@ The easiest way to deploy the WinUI 3 Gallery for unit test execution is to simp
 1. Build and publish the WinUI 3 Gallery from the command line, e.g.:
 
 ```shell
-    >dotnet.exe publish WinUIGallery\WinUIGallery.sln /p:AppxPackageDir=AppxPackages\ /p:platform=x64 /p:PublishProfile=./WinUIGallery/Properties/PublishProfiles/win10-x64.pubxml
+    >dotnet.exe publish WinUIGallery\WinUIGallery.sln /p:AppxPackageDir=AppxPackages\ /p:platform=x64 /p:PublishProfile=./WinUIGallery/Properties/PublishProfiles/win-x64.pubxml
 ```
 
 1. Locate the WinUI 3 Gallery package output folder from above and deploy for testing:

--- a/UITests/UITests.csproj
+++ b/UITests/UITests.csproj
@@ -8,13 +8,6 @@
         <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     </PropertyGroup>
 
-    <!-- Build output related paths -->
-    <PropertyGroup>
-        <ProjectRoot>$(MSBuildThisFileDirectory)..\</ProjectRoot>
-        <ArtifactsBinRoot>$(MSBuildThisFileDirectory)\bin\</ArtifactsBinRoot>
-        <TestBinplaceDestinationPath>\$(Platform)\$(Configuration)\$(TargetFramework)</TestBinplaceDestinationPath>
-    </PropertyGroup>
-
     <ItemGroup>
         <PackageReference Include="Appium.WebDriver" Version="4.4.0" />
         <PackageReference Include="Axe.Windows" Version="2.1.0" />
@@ -23,7 +16,10 @@
         <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     </ItemGroup>
 
-  <Target Name="CopyControlInfoData" AfterTargets="AfterBuild">
-      <Copy SourceFiles="$(ProjectRoot)\WinUIGallery\DataModel\ControlInfoData.json" DestinationFiles="$(ArtifactsBinRoot)\$(TestBinplaceDestinationPath)\ControlInfoData.json" />
-  </Target>
+    <ItemGroup>
+      <None Include="$(MSBuildThisFileDirectory)..\WinUIGallery\DataModel\ControlInfoData.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+    </ItemGroup>
+
 </Project>

--- a/WinUIGallery/Directory.Build.props
+++ b/WinUIGallery/Directory.Build.props
@@ -24,8 +24,4 @@
   <PropertyGroup Condition="'$(IsInWinUIRepo)' != 'true' AND '$(BuildAllAppFlavors)' == ''">
     <BuildAllAppFlavors>true</BuildAllAppFlavors>
   </PropertyGroup>
-    
-  <!-- If we aren't building in the WinUI repo, import the necessary missing props we'd normally pick up from its Directory.Build.props hierarchy -->
-  <!-- The UseStandalone property allows this to be overridden, in order to buildReleaseSamples to build without changing the entire repo -->
-  <Import Project="Standalone.props" Condition="'$(IsInWinUIRepo)' != 'true' OR '$(UseStandalone)' == 'true'"/>
 </Project>

--- a/WinUIGalleryUnitTests/WinUIGalleryUnitTests.csproj
+++ b/WinUIGalleryUnitTests/WinUIGalleryUnitTests.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\WinUIGallery\standalone.props" />
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>$(SamplesTargetFrameworkMoniker)</TargetFramework>
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion>$(WindowsSdkTargetPlatformVersion)</TargetPlatformVersion>
+    <TargetPlatformMinVersion>$(WindowsAppSdkTargetPlatformVersion)</TargetPlatformMinVersion>
     <RootNamespace>WinUIGalleryUnitTests</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>

--- a/standalone.props
+++ b/standalone.props
@@ -1,15 +1,11 @@
 <Project>
   <PropertyGroup>
     <!-- The NuGet versions of dependencies to build against. -->
-    <SamplesTargetFrameworkMoniker>net8.0-windows10.0.22621.0</SamplesTargetFrameworkMoniker>
     <WindowsAppSdkPackageVersion>1.5.240227000</WindowsAppSdkPackageVersion>
     <MicrosoftNETCoreUniversalWindowsPlatformVersion>6.2.11</MicrosoftNETCoreUniversalWindowsPlatformVersion>
     <GraphicsWin2DVersion>1.0.4</GraphicsWin2DVersion>
     <ColorCodeVersion>2.0.13</ColorCodeVersion>
     <CommunityToolkitWinUIVersion>8.0.230907</CommunityToolkitWinUIVersion>
-    <WindowsSdkTargetPlatformVersion>10.0.22621.756</WindowsSdkTargetPlatformVersion>
-    <MicrosoftWindowsSDKBuildToolsNugetPackageVersion>10.0.22621.756</MicrosoftWindowsSDKBuildToolsNugetPackageVersion>
-    <WindowsAppSdkTargetPlatformVersion>10.0.17763.0</WindowsAppSdkTargetPlatformVersion>
     <MicrosoftCsWinRTPackageVersion>2.0.3</MicrosoftCsWinRTPackageVersion>
     <!-- We have multiple projects in the same directory, which means we need to separate their output paths-->
     <BaseIntermediateOutputPath>obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>


### PR DESCRIPTION
WinUIGallery's dependencies now require latest SDKs, so should specify these regardless of how the project is built (standalone vs submodule).

The unit test project was not setting standalone properties properly - factored out common directory.build.props.

Added a workaround for conflicting build and publish deps.json files until WinAppSDK provides the fix.