### PR TITLE
Fix Pivot control's description

### DIFF
--- a/WinUIGallery/DataModel/ControlInfoData.json
+++ b/WinUIGallery/DataModel/ControlInfoData.json
@@ -1903,7 +1903,7 @@
           "ApiNamespace": "Microsoft.UI.Xaml.Controls",
           "Subtitle": "Presents information from different sources in a tabbed view.",
           "ImagePath": "ms-appx:///Assets/ControlImages/Placeholder.png",
-          "Description": "<p>Pivot is deprecated. Please use the <b>SelectorBar</b> and <b>SelectorBarItem.</b></p><p>A Pivot allows you to show a collection of items from different sources in a tabbed view.<p>",
+          "Description": "Pivot is deprecated. Please use the SelectorBar and SelectorBarItem. A Pivot allows you to show a collection of items from different sources in a tabbed view.",
           "Content": "<p>This page shows a simplified <b>Pivot</b> control with minimal content to demonstrate basic <b>Pivot</b> usage. Look at the <i>PivotPage.xaml</i> file in Visual Studio to see the full code for this page.</p><p>A <b>Pivot</b> control typically takes up the full page.</p>",
           "SourcePath": "/CommonStyles/Pivot_themeresources.xaml",
           "Docs": [


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Change Pivot control's description back to plain text since html tags are not supported here.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1504 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run the app and confirmed that the `Pivot` description doesn't have html tags.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
