### PR TITLE
Set URI source version numbers dynamically to simplify maintenance

### DIFF
--- a/WinUIGallery/DataModel/ControlInfoData.json
+++ b/WinUIGallery/DataModel/ControlInfoData.json
@@ -54,7 +54,7 @@
             },
             {
               "Title": "WinUI Theme Resources (GitHub)",
-              "Uri": "https://github.com/microsoft/microsoft-ui-xaml/blob/winui3/release/1.5-stable/controls/dev/CommonStyles/Common_themeresources_any.xaml"
+              "Uri": "https://github.com/microsoft/microsoft-ui-xaml/blob/winui3/release/X.Y-stable/controls/dev/CommonStyles/Common_themeresources_any.xaml"
             }
           ]
         }

--- a/WinUIGallery/DataModel/ControlInfoDataSource.cs
+++ b/WinUIGallery/DataModel/ControlInfoDataSource.cs
@@ -15,7 +15,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using WinUIGallery.Common;
-using WinUIGallery.DesktopWap.DataModel;
+using WASDK = Microsoft.WindowsAppSDK;
 
 // The data model defined by this file serves as a representative example of a strongly-typed
 // model.  The property names chosen coincide with data bindings in the standard item templates.
@@ -72,7 +72,7 @@ namespace WinUIGallery.Data
         public ControlInfoDocLink(string title, string uri)
         {
             this.Title = title;
-            this.Uri = uri;
+            this.Uri = uri.Replace("X.Y", string.Format("{0}.{1}", WASDK.Release.Major, WASDK.Release.Minor));
         }
         public string Title { get; set; }
         public string Uri { get; set; }

--- a/WinUIGallery/ItemPage.xaml.cs
+++ b/WinUIGallery/ItemPage.xaml.cs
@@ -25,6 +25,7 @@ using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media.Animation;
 using Microsoft.UI.Xaml.Navigation;
 using WinUIGallery.DesktopWap.Controls;
+using WASDK = Microsoft.WindowsAppSDK;
 
 namespace WinUIGallery
 {
@@ -33,7 +34,7 @@ namespace WinUIGallery
     /// </summary>
     public sealed partial class ItemPage : Page
     {
-        private static string WinUIBaseUrl = "https://github.com/microsoft/microsoft-ui-xaml/tree/winui3/release/1.5-stable/controls/dev/";
+        private static string WinUIBaseUrl = string.Format("https://github.com/microsoft/microsoft-ui-xaml/tree/winui3/release/{0}.{1}-stable/controls/dev/", WASDK.Release.Major, WASDK.Release.Minor);
         private static string GalleryBaseUrl = "https://github.com/microsoft/WinUI-Gallery/tree/main/WinUIGallery/ControlPages/";
 
         public ControlInfoDataItem Item

--- a/WinUIGallery/ItemPage.xaml.cs
+++ b/WinUIGallery/ItemPage.xaml.cs
@@ -34,7 +34,7 @@ namespace WinUIGallery
     /// </summary>
     public sealed partial class ItemPage : Page
     {
-        private static string WinUIBaseUrl = string.Format("https://github.com/microsoft/microsoft-ui-xaml/tree/winui3/release/{0}.{1}-stable/controls/dev/", WASDK.Release.Major, WASDK.Release.Minor);
+        private static string WinUIBaseUrl = string.Format("https://github.com/microsoft/microsoft-ui-xaml/tree/winui3/release/{0}.{1}-stable/controls/dev", WASDK.Release.Major, WASDK.Release.Minor);
         private static string GalleryBaseUrl = "https://github.com/microsoft/WinUI-Gallery/tree/main/WinUIGallery/ControlPages/";
 
         public ControlInfoDataItem Item


### PR DESCRIPTION
Replace hardcoded version numbers embedded in source URIs with associated WASDK version numbers.