### PR TITLE
Update SignalSection: "System / Critical" and IsClosable="False"

### DIFF
--- a/WinUIGallery/Controls/DesignGuidance/ColorSections/SignalSection.xaml
+++ b/WinUIGallery/Controls/DesignGuidance/ColorSections/SignalSection.xaml
@@ -19,6 +19,7 @@
             Description="Used for accent fills on controls">
             <InfoBar
                 Title="Title"
+                IsClosable="False"
                 IsOpen="True"
                 Message="This is body text. Windows 11 is faster and more intuitive."
                 Severity="Error" />
@@ -30,7 +31,7 @@
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-           
+
             <designguidance:ColorTile
                 Background="{ThemeResource SystemFillColorSuccessBrush}"
                 ColorBrushName="SystemFillColorSuccessBrush"
@@ -49,8 +50,8 @@
                 Foreground="{ThemeResource TextFillColorInverseBrush}"
                 ShowSeparator="False" />
             <designguidance:ColorTile
-                Background="{ThemeResource SystemFillColorCriticalBrush}"
                 Grid.Column="2"
+                Background="{ThemeResource SystemFillColorCriticalBrush}"
                 ColorBrushName="SystemFillColorCriticalBrush"
                 ColorExplanation="Badge"
                 ColorName="System / Critical"
@@ -64,7 +65,7 @@
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-            
+
             <designguidance:ColorTile
                 Grid.Column="0"
                 Background="{ThemeResource SystemFillColorSuccessBackgroundBrush}"
@@ -82,12 +83,12 @@
                 ColorValue="#433519, 100%"
                 ShowSeparator="False" />
             <designguidance:ColorTile
+                Grid.Column="2"
                 Background="{ThemeResource SystemFillColorCriticalBackgroundBrush}"
                 ColorBrushName="SystemFillColorCriticalBackgroundBrush"
                 ColorExplanation="Infobar Background"
-                ColorName="Accent / Selected Text Background"
+                ColorName="System / Critical Background"
                 ColorValue="#442726, 100%"
-                Grid.Column="2"
                 ShowSeparator="False" />
 
         </Grid>
@@ -105,7 +106,7 @@
                 ColorValue="#60CDFF (100%)"
                 Foreground="{ThemeResource TextFillColorInverseBrush}"
                 ShowSeparator="False" />
-          
+
             <designguidance:ColorTile
                 Grid.Column="1"
                 Background="{ThemeResource SystemFillColorNeutralBrush}"
@@ -138,7 +139,7 @@
                 ColorBrushName="SystemFillColorAttentionBackgroundBrush"
                 ColorExplanation="Infobar Background"
                 ColorName="System / Attention Background"
-                ColorValue="#FFFFFF (0B, 3.26%)"/>
+                ColorValue="#FFFFFF (0B, 3.26%)" />
             <designguidance:ColorTile
                 Grid.Column="1"
                 Background="{ThemeResource SystemFillColorNeutralBackgroundBrush}"


### PR DESCRIPTION
## Description

- Updated text to match content: "System / Critical Background". Fixing a typo.
- Also set **IsClosable="False**" on the InfoBar, because when it's closed, user needs to nav to the page again to see it.

## Motivation and Context

Incorrect text.
Illogical use case for InfoBar.

## Screenshots (if appropriate):

![image](https://github.com/microsoft/WinUI-Gallery/assets/65828559/51edb52b-ffcd-4f1d-b186-27c1483f4d4b)![image](https://github.com/microsoft/WinUI-Gallery/assets/65828559/1a4a942c-a33d-4cd7-b82b-3cc4325ea568)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
