### PR TITLE
Fix pageheader spacing at smaller window widths

### DIFF
--- a/WinUIGallery/Controls/PageHeader.xaml
+++ b/WinUIGallery/Controls/PageHeader.xaml
@@ -18,7 +18,7 @@
             EmptyValue="Collapsed"
             NotEmptyValue="Visible" />
     </UserControl.Resources>
-    <Grid x:Name="headerGrid" Padding="36,24,36,0">
+    <Grid x:Name="headerGrid">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />

--- a/WinUIGallery/ItemPage.xaml
+++ b/WinUIGallery/ItemPage.xaml
@@ -52,14 +52,16 @@
                         <AdaptiveTrigger MinWindowWidth="0" />
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
-                        <Setter Target="pageHeader.Padding" Value="16,48,16,0" />
+                        <Setter Target="pageHeader.Margin" Value="16,12,16,0" />
                         <Setter Target="contentRoot.Padding" Value="16,0,16,16" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
-
-        <controls:PageHeader x:Name="pageHeader" Item="{x:Bind Item}" />
+        <controls:PageHeader
+            x:Name="pageHeader"
+            Margin="36,24,36,0"
+            Item="{x:Bind Item}" />
 
         <!--  Content Region  -->
         <ScrollViewer


### PR DESCRIPTION
This PR fixes an incorrect padding being used when the window has a small window width. The `PageHeader` control would not align correctly with the page content.

Addressing: https://github.com/microsoft/WinUI-Gallery/issues/1502

Before:
![image](https://github.com/microsoft/WinUI-Gallery/assets/9866362/57faee26-9a44-4454-bec7-92c98fc90595)



After:

![image](https://github.com/microsoft/WinUI-Gallery/assets/9866362/4836943e-0e1b-4626-ab19-687dbae7dd1d)
