### PR TITLE
Correct Japanese icon name

### DIFF
--- a/WinUIGallery/DataModel/IconsData.json
+++ b/WinUIGallery/DataModel/IconsData.json
@@ -1177,19 +1177,19 @@
   },
   {
     "Code": "E87C",
-    "Name": "JpnRomanji"
+    "Name": "JpnRomaji"
   },
   {
     "Code": "E87D",
-    "Name": "JpnRomanjiLock"
+    "Name": "JpnRomajiLock"
   },
   {
     "Code": "E87E",
-    "Name": "JpnRomanjiShift"
+    "Name": "JpnRomajiShift"
   },
   {
     "Code": "E87F",
-    "Name": "JpnRomanjiShiftLock"
+    "Name": "JpnRomajiShiftLock"
   },
   {
     "Code": "E880",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Corrects the Japanese icon name used in the **Icons** page.
## Description
<!--- Describe your changes in detail -->
The correct word is "ROMAJI" and not "ROMANJI".
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Confirmed by checking the **Icons** page.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
