### PR TITLE
Fix: Interactive element is no longer interactive after adding it a second time

### DIFF
--- a/WinUIGallery/ControlPages/EasingFunctionPage.xaml
+++ b/WinUIGallery/ControlPages/EasingFunctionPage.xaml
@@ -58,7 +58,7 @@
                     <Storyboard x:Name="Storyboard2">
                         <DoubleAnimation Storyboard.TargetName="Translation2" Storyboard.TargetProperty="X" Duration="0:0:0.15">
                             <DoubleAnimation.EasingFunction>
-                                <ExponentialEase Exponent="4.5" EasingMode="EaseIn" />
+                                <ExponentialEase Exponent="{x:Bind AccelerateEasingExponent.Value, Mode=OneWay}" EasingMode="EaseIn" />
                             </DoubleAnimation.EasingFunction>
                         </DoubleAnimation>
                     </Storyboard>
@@ -74,18 +74,25 @@
                     </Rectangle.RenderTransform>
                 </Rectangle>
             </Grid>
-
+            
+            <local:ControlExample.Options>
+                <NumberBox x:Name="AccelerateEasingExponent" Header="Exponent" AutomationProperties.Name="Accelerate easing exponent" Value="4.5"/>
+            </local:ControlExample.Options>
+            
             <local:ControlExample.Xaml>
                 <x:String xml:space="preserve">
 &lt;Storyboard x:Name="Storyboard2"&gt;
     &lt;DoubleAnimation Storyboard.TargetName="Translation" Storyboard.TargetProperty="X" From="0" To="200" &gt;
         &lt;DoubleAnimation.EasingFunction&gt;
-            &lt;ExponentialEase Exponent="4.5" EasingMode="EaseIn" /&gt;
+            &lt;ExponentialEase Exponent="$(AccelerateEasingExponent)" EasingMode="EaseIn" /&gt;
         &lt;/DoubleAnimation.EasingFunction&gt;
     &lt;/DoubleAnimation&gt;
 &lt;/Storyboard&gt;
                 </x:String>
             </local:ControlExample.Xaml>
+            <local:ControlExample.Substitutions>
+                <local:ControlExampleSubstitution Key="AccelerateEasingExponent" Value="{x:Bind AccelerateEasingExponent.Value, Mode=OneWay}"/>
+            </local:ControlExample.Substitutions>
         </local:ControlExample>
 
 
@@ -95,7 +102,7 @@
                     <Storyboard x:Name="Storyboard3">
                         <DoubleAnimation Storyboard.TargetName="Translation3" Storyboard.TargetProperty="X" Duration="0:0:0.3">
                             <DoubleAnimation.EasingFunction>
-                                <ExponentialEase Exponent="7" EasingMode="EaseOut" />
+                                <ExponentialEase Exponent="{x:Bind DecelerateEasingExponent.Value, Mode=OneWay}" EasingMode="EaseOut" />
                             </DoubleAnimation.EasingFunction>
                         </DoubleAnimation>
                     </Storyboard>
@@ -111,17 +118,25 @@
                     </Rectangle.RenderTransform>
                 </Rectangle>
             </Grid>
+
+            <local:ControlExample.Options>
+                <NumberBox x:Name="DecelerateEasingExponent" Header="Exponent" AutomationProperties.Name="Decelerate easing exponent" Value="7"/>
+            </local:ControlExample.Options>
+            
             <local:ControlExample.Xaml>
                 <x:String xml:space="preserve">
 &lt;Storyboard x:Name="Storyboard3"&gt;
     &lt;DoubleAnimation Storyboard.TargetName="Translation" Storyboard.TargetProperty="X" From="0" To="200" &gt;
         &lt;DoubleAnimation.EasingFunction&gt;
-            &lt;ExponentialEase Exponent="7" EasingMode="EaseOut" /&gt;
+            &lt;ExponentialEase Exponent="$(DecelerateEasingExponent)" EasingMode="EaseOut" /&gt;
         &lt;/DoubleAnimation.EasingFunction&gt;
     &lt;/DoubleAnimation&gt;
 &lt;/Storyboard&gt;
                 </x:String>
             </local:ControlExample.Xaml>
+            <local:ControlExample.Substitutions>
+                <local:ControlExampleSubstitution Key="DecelerateEasingExponent" Value="{x:Bind DecelerateEasingExponent.Value, Mode=OneWay}"/>
+            </local:ControlExample.Substitutions>
         </local:ControlExample>
 
         <local:ControlExample x:Name="Example4" HeaderText="Other XAML Easing Functions">

--- a/WinUIGallery/ControlPages/TitleBarPage.xaml.cs
+++ b/WinUIGallery/ControlPages/TitleBarPage.xaml.cs
@@ -192,6 +192,23 @@ namespace AppUIBasics.ControlPages
             UIHelper.AnnounceActionForAccessibility(sender as UIElement, "TitleBar size and width changed", "TitleBarChangedNotificationActivityId");
         }
 
+        private void setTxtBoxAsPasthrough(FrameworkElement txtBoxNonClientArea)
+        {
+            GeneralTransform transformTxtBox = txtBoxNonClientArea.TransformToVisual(null);
+            Rect bounds = transformTxtBox.TransformBounds(new Rect(0, 0, txtBoxNonClientArea.ActualWidth, txtBoxNonClientArea.ActualHeight));
+
+            var scale = WindowHelper.GetRasterizationScaleForElement(this);
+
+            var transparentRect = new Windows.Graphics.RectInt32(
+                _X: (int)Math.Round(bounds.X * scale),
+                _Y: (int)Math.Round(bounds.Y * scale),
+                _Width: (int)Math.Round(bounds.Width * scale),
+                _Height: (int)Math.Round(bounds.Height * scale)
+            );
+            var rectArr = new Windows.Graphics.RectInt32[] { transparentRect };
+            SetClickThruRegions(rectArr);
+        }
+
         private void AddInteractiveElements_Click(object sender, RoutedEventArgs e)
         {
             var txtBoxNonClientArea = UIHelper.FindElementByName(sender as UIElement, "AppTitleBarTextBox") as FrameworkElement;
@@ -204,7 +221,11 @@ namespace AppUIBasics.ControlPages
             {
                 addInteractiveElements.Content = "Remove interactive control from titlebar";
                 txtBoxNonClientArea.Visibility = Visibility.Visible;
-                if (!sizeChangedEventHandlerAdded)
+                if (sizeChangedEventHandlerAdded)
+                {
+                    setTxtBoxAsPasthrough(txtBoxNonClientArea);
+                }
+                else
                 {
                     sizeChangedEventHandlerAdded = true;
                     // run this code when textbox has been made visible and its actual width and height has been calculated
@@ -212,26 +233,14 @@ namespace AppUIBasics.ControlPages
                     {
                         if (txtBoxNonClientArea.Visibility != Visibility.Collapsed)
                         {
-                            GeneralTransform transformTxtBox = txtBoxNonClientArea.TransformToVisual(null);
-                            Rect bounds = transformTxtBox.TransformBounds(new Rect(0, 0, txtBoxNonClientArea.ActualWidth, txtBoxNonClientArea.ActualHeight));
-
-                            var scale = WindowHelper.GetRasterizationScaleForElement(this);
-
-                            var transparentRect = new Windows.Graphics.RectInt32(
-                                _X: (int)Math.Round(bounds.X * scale),
-                                _Y: (int)Math.Round(bounds.Y * scale),
-                                _Width: (int)Math.Round(bounds.Width * scale),
-                                _Height: (int)Math.Round(bounds.Height * scale)
-                            );
-                            var rectArr = new Windows.Graphics.RectInt32[] { transparentRect };
-                            SetClickThruRegions(rectArr);
+                            setTxtBoxAsPasthrough(txtBoxNonClientArea);
                         }
                     };
                 }
-                txtBoxNonClientArea.Width += 1; //to trigger size changed event
+
+                // announce visual change to automation
+                UIHelper.AnnounceActionForAccessibility(sender as UIElement, "TitleBar size and width changed", "TitleBarChangedNotificationActivityId");
             }
-            // announce visual change to automation
-            UIHelper.AnnounceActionForAccessibility(sender as UIElement, "TitleBar size and width changed", "TitleBarChangedNotificationActivityId");
         }
        
     }

--- a/WinUIGallery/Navigation/NavigationRootPage.xaml
+++ b/WinUIGallery/Navigation/NavigationRootPage.xaml
@@ -59,8 +59,8 @@
             AutomationProperties.AutomationId="AppTitleBar"
             Canvas.ZIndex="1"
             IsHitTestVisible="True">
-            <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
-                <Image Width="18" Source="ms-appx:///Assets/Tiles/TitlebarLogo.png" />
+            <StackPanel VerticalAlignment="Stretch" Orientation="Horizontal">
+                <Image Width="18" VerticalAlignment="Center" Source="ms-appx:///Assets/Tiles/TitlebarLogo.png" />
                 <TextBlock
                     x:Name="AppTitle"
                     Margin="12,0,0,0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- `AppTitleBarTextBox` 's `Width` is not set, so `Width +=1 ` does nothing
- The `SizeChanged` event handler is called **once**, because of `Visibility` changed, and it was put in a `StackPanel` that's vertically constrained, so the size change will occur once, not because `Width += 1`. Consecutive adding it to the title bar no longer triggers the event handler, therefore the issue
- And `Width += 1` is a dirty hack anyway, does not need that.

## Motivation and Context
Close #1470


## How Has This Been Tested?
Manual.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
