### PR TITLE
TextSection Color Design Guidance Update Color Contrast 

### DIFF
--- a/WinUIGallery/Controls/DesignGuidance/ColorSections/TextSection.xaml
+++ b/WinUIGallery/Controls/DesignGuidance/ColorSections/TextSection.xaml
@@ -53,7 +53,7 @@
                 ColorExplanation="Pressed only (not accessible)"
                 ColorName="Text / Tertiary"
                 ColorValue="#000000 (72, 44.58%)"
-                Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
+                Foreground="{ThemeResource TextFillColorPrimaryBrush}"
                 ShowSeparator="False" />
             <designguidance:ColorTile
                 Grid.Column="3"
@@ -62,7 +62,7 @@
                 ColorExplanation="Disabled only (not accessible)"
                 ColorName="Text / Disabled"
                 ColorValue="#000000 (5C, 36.14%)"
-                Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
+                Foreground="{ThemeResource TextFillColorPrimaryBrush}"
                 ShowSeparator="False" />
         </Grid>
 
@@ -118,7 +118,7 @@
                 ColorExplanation="Disabled only (not accessible)"
                 ColorName="Accent Text / Disabled"
                 ColorValue="#000000 (5C, 36.14%)"
-                Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
+                Foreground="{ThemeResource TextFillColorPrimaryBrush}"
                 ShowSeparator="False" />
         </Grid>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update text color for the tertiary and disabled brush colours to satisfy colour contrast for accessibility:

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes internal bug: 
[Bug 51099086](https://dev.azure.com/microsoft/OS/_workitems/edit/51099086): [WinUI 3 Gallery: Design Guidance: Color]: Color contrast ratio for "Text / Disabled" text is 2.77:1 which is less than 4.5:1.

## Screenshots
**Before:**
![image](https://github.com/microsoft/WinUI-Gallery/assets/7976322/4f211cda-42ab-42ee-9b08-68470e029566)

**After:**
![image](https://github.com/microsoft/WinUI-Gallery/assets/7976322/56bd1c53-a42d-4ffc-bb23-335c31433993)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
