### PR TITLE
Fix RadioButtons image abnormal.

### DIFF
--- a/WinUIGallery/DataModel/ControlInfoData.json
+++ b/WinUIGallery/DataModel/ControlInfoData.json
@@ -1715,7 +1715,7 @@
           "Title": "RadioButtons",
           "ApiNamespace": "Microsoft.UI.Xaml.Controls",
           "Subtitle": "A control that displays a group of mutually exclusive options with keyboarding and accessibility support.",
-          "ImagePath": "ms-appx:///Assets/ControlImages/RadioButton.png",
+          "ImagePath": "ms-appx:///Assets/ControlImages/RadioButtons.png",
           "Description": "A control that displays a group of mutually exclusive options with keyboarding and accessibility support.",
           "Content": "<p>Look at the <i>RadioButtonsPage.xaml</i> file in Visual Studio to see the full code for this page.</p>",
           "SourcePath": "/RadioButtons",


### PR DESCRIPTION
## Description
Fix RadioButtons image abnormal.

## Motivation and Context
make RadioButtons image see normal.

## How Has This Been Tested?
1.click Layout at NavigationView;
2.you can see abnormal.

## Screenshots:
abnorml:
![image](https://github.com/microsoft/WinUI-Gallery/assets/46436509/d7d04cd7-794b-4def-aa10-4afaf9f937a7)

after fix this it show normal.
normal:
![image](https://github.com/microsoft/WinUI-Gallery/assets/46436509/5c355d10-76a3-41fd-8958-a3c89db11893)

## Types of changes
- [x] Bug fix
