### PR TITLE
Feat: Better xaml sound demo

### DIFF
--- a/WinUIGallery/ControlPages/SoundPage.xaml
+++ b/WinUIGallery/ControlPages/SoundPage.xaml
@@ -38,22 +38,16 @@ ElementSoundPlayer.SpatialAudioMode = ElementSpatialAudioMode.On
             </local:ControlExample.CSharp>
         </local:ControlExample>
         <local:ControlExample x:Name="Example3" HeaderText="Play Specific System Sound">
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition/>
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
-                <Button Grid.Column="0" Content="Play Sound" ElementSoundMode="Off" Click="Button_Click" HorizontalAlignment="Left"/>
-                <ComboBox x:Name="soundSelection" Grid.Column="1" Header="Pick Custom Sound" SelectedIndex="1" HorizontalAlignment="Right" Margin="50,0,0,0">
-                    <ComboBoxItem>Focus</ComboBoxItem>
-                    <ComboBoxItem>Invoke</ComboBoxItem>
-                    <ComboBoxItem>Show</ComboBoxItem>
-                    <ComboBoxItem>Hide</ComboBoxItem>
-                    <ComboBoxItem>MoveNext</ComboBoxItem>
-                    <ComboBoxItem>MovePrevious</ComboBoxItem>
-                    <ComboBoxItem>GoBack</ComboBoxItem>
-                </ComboBox>
-            </Grid>
+            <StackPanel Orientation="Vertical" Spacing="5">
+                <Button Content="&#x25B6; Focus" ElementSoundMode="Off" Tag="0" Click="Button_Click"/>
+                <Button Content="&#x25B6; Invoke" ElementSoundMode="Off" Tag="1" Click="Button_Click"/>
+                <Button Content="&#x25B6; Show" ElementSoundMode="Off" Tag="2" Click="Button_Click"/>
+                <Button Content="&#x25B6; Hide" ElementSoundMode="Off" Tag="3" Click="Button_Click"/>
+                <Button Content="&#x25B6; MovePrevious" ElementSoundMode="Off" Tag="4" Click="Button_Click"/>
+                <Button Content="&#x25B6; MoveNext" ElementSoundMode="Off" Tag="5" Click="Button_Click"/>
+                <Button Content="&#x25B6; GoBack" ElementSoundMode="Off" Tag="6" Click="Button_Click"/>
+            </StackPanel>
+ 
             <local:ControlExample.CSharp>
                 <x:String xml:space="preserve">
 ElementSoundPlayer.State = ElementSoundPlayerState.On;
@@ -62,8 +56,8 @@ ElementSoundPlayer.Play(ElementSoundKind.Focus);
 ElementSoundPlayer.Play(ElementSoundKind.Invoke);
 ElementSoundPlayer.Play(ElementSoundKind.Show);
 ElementSoundPlayer.Play(ElementSoundKind.Hide);
-ElementSoundPlayer.Play(ElementSoundKind.MoveNext);
 ElementSoundPlayer.Play(ElementSoundKind.MovePrevious);
+ElementSoundPlayer.Play(ElementSoundKind.MoveNext);
 ElementSoundPlayer.Play(ElementSoundKind.GoBack);
                 </x:String>
             </local:ControlExample.CSharp>

--- a/WinUIGallery/ControlPages/SoundPage.xaml.cs
+++ b/WinUIGallery/ControlPages/SoundPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -28,8 +28,9 @@ namespace WinUIGallery.ControlPages
         }
 
         private void Button_Click(object sender, RoutedEventArgs e)
-        {            
-            ElementSoundPlayer.Play((ElementSoundKind)soundSelection.SelectedIndex);
+        {
+            var tagInt = int.Parse((string)(sender as Button).Tag);
+            ElementSoundPlayer.Play((ElementSoundKind)tagInt);
         }
 
         private void spatialAudioBox_Checked(object sender, RoutedEventArgs e)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
See screenshot.

## Motivation and Context
Previously the sound demo requires toggling the ComboBox, but the ComboBox itself will have an element sound too, causing some confusion. Also the ComboBox item ordering is incorrect (MovePrevious -> MoveNext is the correct order)

![image](https://github.com/microsoft/WinUI-Gallery/assets/42881734/56cd7ceb-b47e-4ad1-99a0-1838872325e9)


## How Has This Been Tested?
Manual

## Screenshots (if appropriate):
![image](https://github.com/microsoft/WinUI-Gallery/assets/42881734/6995a5b1-f5bb-401a-897e-e9fb76d393d3)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
