### PR TITLE
Fix: Prevent FilePicker button double-click

### DIFF
--- a/WinUIGallery/ControlPages/FilePickerPage.xaml.cs
+++ b/WinUIGallery/ControlPages/FilePickerPage.xaml.cs
@@ -27,6 +27,10 @@ namespace WinUIGallery.ControlPages
 
         private async void PickAFileButton_Click(object sender, RoutedEventArgs e)
         {
+            //disable the button to avoid double-clicking
+            var senderButton = sender as Button;
+            senderButton.IsEnabled = false;
+
             // Clear previous returned file name, if it exists, between iterations of this scenario
             PickAFileOutputTextBlock.Text = "";
 
@@ -67,10 +71,16 @@ namespace WinUIGallery.ControlPages
                 PickAFileOutputTextBlock.Text = "Operation cancelled.";
             }
 
+            //re-enable the button
+            senderButton.IsEnabled = true;
             UIHelper.AnnounceActionForAccessibility(sender as Button, PickAFileOutputTextBlock.Text, "FilePickedNotificationId");
         }
         private async void PickAPhotoButton_Click(object sender, RoutedEventArgs e)
         {
+            //disable the button to avoid double-clicking
+            var senderButton = sender as Button;
+            senderButton.IsEnabled = false;
+
             // Clear previous returned file name, if it exists, between iterations of this scenario
             PickAPhotoOutputTextBlock.Text = "";
 
@@ -114,11 +124,17 @@ namespace WinUIGallery.ControlPages
                 PickAPhotoOutputTextBlock.Text = "Operation cancelled.";
             }
 
+            //re-enable the button
+            senderButton.IsEnabled = true;
             UIHelper.AnnounceActionForAccessibility(sender as Button, PickAPhotoOutputTextBlock.Text, "PhotoPickedNotificationId");
         }
 
         private async void PickFilesButton_Click(object sender, RoutedEventArgs e)
         {
+            //disable the button to avoid double-clicking
+            var senderButton = sender as Button;
+            senderButton.IsEnabled = false;
+
             // Clear previous returned file name, if it exists, between iterations of this scenario
             PickFilesOutputTextBlock.Text = "";
 
@@ -164,11 +180,17 @@ namespace WinUIGallery.ControlPages
                 PickFilesOutputTextBlock.Text = "Operation cancelled.";
             }
 
+            //re-enable the button
+            senderButton.IsEnabled = true;
             UIHelper.AnnounceActionForAccessibility(sender as Button, PickFilesOutputTextBlock.Text, "FilesPickedNotificationId");
         }
 
         private async void PickFolderButton_Click(object sender, RoutedEventArgs e)
         {
+            //disable the button to avoid double-clicking
+            var senderButton = sender as Button;
+            senderButton.IsEnabled = false;
+
             // Clear previous returned file name, if it exists, between iterations of this scenario
             PickFolderOutputTextBlock.Text = "";
 
@@ -211,11 +233,17 @@ namespace WinUIGallery.ControlPages
                 PickFolderOutputTextBlock.Text = "Operation cancelled.";
             }
 
+            //re-enable the button
+            senderButton.IsEnabled = true;
             UIHelper.AnnounceActionForAccessibility(sender as Button, PickFolderOutputTextBlock.Text, "FolderPickedNotificationId");
         }
 
         private async void SaveFileButton_Click(object sender, RoutedEventArgs e)
         {
+            //disable the button to avoid double-clicking
+            var senderButton = sender as Button;
+            senderButton.IsEnabled = false;
+
             // Clear previous returned file name, if it exists, between iterations of this scenario
             SaveFileOutputTextBlock.Text = "";
 
@@ -278,6 +306,8 @@ namespace WinUIGallery.ControlPages
                 SaveFileOutputTextBlock.Text = "Operation cancelled.";
             }
 
+            //re-enable the button
+            senderButton.IsEnabled = true;
             UIHelper.AnnounceActionForAccessibility(sender as Button, SaveFileOutputTextBlock.Text, "FileSavedNotificationId");
         }
     }

--- a/WinUIGallery/ControlPagesSampleCode/System/FilePickerSample1_cs.txt
+++ b/WinUIGallery/ControlPagesSampleCode/System/FilePickerSample1_cs.txt
@@ -1,5 +1,9 @@
 ﻿private async void PickAFileButton_Click(object sender, RoutedEventArgs e)
 {
+    //disable the button to avoid double-clicking
+    var senderButton = sender as Button;
+    senderButton.IsEnabled = false;
+    
     // Clear previous returned file name, if it exists, between iterations of this scenario
     PickAFileOutputTextBlock.Text = "";
 
@@ -29,4 +33,7 @@
     {
         PickAFileOutputTextBlock.Text = "Operation cancelled.";
     }
+
+    //re-enable the button
+    senderButton.IsEnabled = true;
 }

--- a/WinUIGallery/ControlPagesSampleCode/System/FilePickerSample2_cs.txt
+++ b/WinUIGallery/ControlPagesSampleCode/System/FilePickerSample2_cs.txt
@@ -1,5 +1,9 @@
 ﻿private async void PickAPhotoButton_Click(object sender, RoutedEventArgs e)
 {
+    //disable the button to avoid double-clicking
+    var senderButton = sender as Button;
+    senderButton.IsEnabled = false;
+
     // Clear previous returned file name, if it exists, between iterations of this scenario
     PickAPhotoOutputTextBlock.Text = "";
 
@@ -32,4 +36,7 @@
     {
         PickAPhotoOutputTextBlock.Text = "Operation cancelled.";
     }
+    
+    //re-enable the button
+    senderButton.IsEnabled = true;
 }

--- a/WinUIGallery/ControlPagesSampleCode/System/FilePickerSample3_cs.txt
+++ b/WinUIGallery/ControlPagesSampleCode/System/FilePickerSample3_cs.txt
@@ -1,5 +1,9 @@
 ﻿private async void PickFilesButton_Click(object sender, RoutedEventArgs e)
 {
+    //disable the button to avoid double-clicking
+    var senderButton = sender as Button;
+    senderButton.IsEnabled = false;
+
     // Clear previous returned file name, if it exists, between iterations of this scenario
     PickFilesOutputTextBlock.Text = "";
 
@@ -35,4 +39,7 @@
     {
         PickFilesOutputTextBlock.Text = "Operation cancelled.";
     }
+
+    //re-enable the button
+    senderButton.IsEnabled = true;
 }

--- a/WinUIGallery/ControlPagesSampleCode/System/FilePickerSample4_cs.txt
+++ b/WinUIGallery/ControlPagesSampleCode/System/FilePickerSample4_cs.txt
@@ -1,5 +1,9 @@
 ﻿private async void PickFolderButton_Click(object sender, RoutedEventArgs e)
 {
+    //disable the button to avoid double-clicking
+    var senderButton = sender as Button;
+    senderButton.IsEnabled = false;
+
     // Clear previous returned file name, if it exists, between iterations of this scenario
     PickFolderOutputTextBlock.Text = "";
 
@@ -30,4 +34,7 @@
     {
         PickFolderOutputTextBlock.Text = "Operation cancelled.";
     }
+
+    //re-enable the button
+    senderButton.IsEnabled = true;
 }

--- a/WinUIGallery/ControlPagesSampleCode/System/FilePickerSample5_cs.txt
+++ b/WinUIGallery/ControlPagesSampleCode/System/FilePickerSample5_cs.txt
@@ -1,5 +1,9 @@
 ﻿private async void SaveFileButton_Click(object sender, RoutedEventArgs e)
 {
+    //disable the button to avoid double-clicking
+    var senderButton = sender as Button;
+    senderButton.IsEnabled = false;
+
     // Clear previous returned file name, if it exists, between iterations of this scenario
     SaveFileOutputTextBlock.Text = "";
 
@@ -64,4 +68,7 @@
     {
         SaveFileOutputTextBlock.Text = "Operation cancelled.";
     }
+
+    //re-enable the button
+    senderButton.IsEnabled = true;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR will prevent double-clicking the button, preventing two FilePicker dialogs to appear at the same time.

## Motivation and Context
Currently, if you click the buttons on FilePicker page fast enough, two FilePicker dialogs will show up. Code examples are also added to show a correct implementation.

## How Has This Been Tested?
Manual.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
