### PR TITLE
Fix: AutoSuggestBox Page crash

### DIFF
--- a/WinUIGallery/ControlPages/AutoSuggestBoxPage.xaml.cs
+++ b/WinUIGallery/ControlPages/AutoSuggestBoxPage.xaml.cs
@@ -234,7 +234,8 @@ namespace WinUIGallery.ControlPages
             {
                 ControlDetails.Visibility = Visibility.Visible;
 
-                BitmapImage image = new BitmapImage(new Uri(control.IconGlyph));
+
+                BitmapImage image = control.IconGlyph == null? null : new BitmapImage(new Uri(control.IconGlyph));
                 ControlImage.Source = image;
 
                 ControlTitle.Text = control.Title;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The individual control pages' IconGlyph are all `null`. Causing the crash in the AutoSuggestBox page.

## Motivation and Context
Closes #1581


## How Has This Been Tested?
Manual.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
