### PR TITLE
Add a icon to the exe file

### DIFF
--- a/WinUIGallery/WinUIGallery.csproj
+++ b/WinUIGallery/WinUIGallery.csproj
@@ -36,6 +36,7 @@
         <WindowsAppSdkSelfContained Condition="'$(WindowsAppSdkSelfContained)' == '' and '$(PublishSingleFile)' == 'true'">true</WindowsAppSdkSelfContained>
         <!-- Enable ExplicitlyIncludeVersionInfo workaround by setting WindowsAppSdkSelfContained earlier than the mock package would -->
         <WindowsAppSdkSelfContained Condition="'$(IsInWinUIRepo)' == 'true' and '$(WindowsAppSdkSelfContained)'==''">true</WindowsAppSdkSelfContained>
+        <ApplicationIcon>Assets\Tiles\GalleryIcon.ico</ApplicationIcon>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Packaged)' != 'true' and '$(SingleProject)'=='true'">


### PR DESCRIPTION
Added a icon to the apps exe file.

## Description
Set the exe icon in the project properties to "Assets\Tiles\GalleryIcon.ico"

## Motivation and Context
Don't know why the exe doesn't have an icon.
Fixed this issue: https://github.com/microsoft/WinUI-Gallery/issues/1600

## How Has This Been Tested?
No testing needed.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/3edf60e8-b517-4448-851a-a6df71945a9d)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
