### PR TITLE
feat: Update NumberBox example to reflect spin button placement in displayed XAML code

### DIFF
--- a/WinUIGallery/ContentIncludes.props
+++ b/WinUIGallery/ContentIncludes.props
@@ -249,7 +249,6 @@
     <Content Include="ControlPagesSampleCode\NavigationView\NavigationViewSample6.txt" />
     <Content Include="ControlPagesSampleCode\NavigationView\NavigationViewSample8_xaml.txt" />
     <Content Include="ControlPagesSampleCode\NavigationView\NavigationViewSample9_xaml.txt" />
-    <Content Include="ControlPagesSampleCode\NumberBox\NumberBoxSample2_xaml.txt" />
     <Content Include="ControlPagesSampleCode\NumberBox\NumberBoxSample3_cs.txt" />
     <Content Include="ControlPagesSampleCode\NumberBox\NumberBoxSample3_xaml.txt" />
     <Content Include="ControlPagesSampleCode\System\FilePickerSample1_cs.txt" />

--- a/WinUIGallery/ControlPages/NumberBoxPage.xaml
+++ b/WinUIGallery/ControlPages/NumberBoxPage.xaml
@@ -29,9 +29,8 @@
                 </x:String>
             </local:ControlExample.Xaml>
         </local:ControlExample>
-        
-        <local:ControlExample HeaderText="A NumberBox with a spin button." 
-                              XamlSource="NumberBox/NumberBoxSample2_xaml.txt">
+
+        <local:ControlExample HeaderText="A NumberBox with a spin button.">
             <local:ControlExample.Example>
                 <NumberBox x:Name="NumberBoxSpinButtonPlacementExample"
                               VerticalAlignment="Top"
@@ -44,13 +43,27 @@
                 </NumberBox>
             </local:ControlExample.Example>
             <local:ControlExample.Options>
-                <RadioButtons x:Name="SpinButtonPlacementGroup" Header="SpinButton placement">
-                    <RadioButton Content="Inline" Tag="Inline" Checked="RadioButton_Checked" />
-                    <RadioButton Content="Compact" Tag="Compact" Checked="RadioButton_Checked" IsChecked="True" />
+                <RadioButtons x:Name="SpinButtonPlacementGroup" Header="SpinButton placement" SelectedIndex="0" SelectionChanged="SpinButtonPlacementGroup_SelectionChanged">
+                    <x:String>Inline</x:String>
+                    <x:String>Compact</x:String>
                 </RadioButtons>
             </local:ControlExample.Options>
+            <local:ControlExample.Xaml>
+                <x:String xml:space="preserve">
+&lt;NumberBox
+    x:Name="NumberBoxSpinButtonPlacementExample"
+    Header="Enter an integer:" 
+    Value="1" 
+    SpinButtonPlacementMode="$(SpinButtonPlacementMode)"
+    SmallChange="10"
+    LargeChange="100" /&gt;
+                </x:String>
+            </local:ControlExample.Xaml>
+            <local:ControlExample.Substitutions>
+                <local:ControlExampleSubstitution Key="SpinButtonPlacementMode" Value="{x:Bind SpinButtonPlacementGroup.SelectedItem, Mode=OneWay}"/>
+            </local:ControlExample.Substitutions>
         </local:ControlExample>
-        
+
         <local:ControlExample HeaderText="A formatted NumberBox that rounds to the nearest 0.25." 
                               XamlSource="NumberBox/NumberBoxSample3_xaml.txt"
                               CSharpSource="NumberBox/NumberBoxSample3_cs.txt">

--- a/WinUIGallery/ControlPages/NumberBoxPage.xaml.cs
+++ b/WinUIGallery/ControlPages/NumberBoxPage.xaml.cs
@@ -38,18 +38,16 @@ namespace WinUIGallery.ControlPages
             FormattedNumberBox.NumberFormatter = formatter;
         }
 
-        private void RadioButton_Checked(object sender, RoutedEventArgs e)
+        private void SpinButtonPlacementGroup_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (sender is RadioButton rb && NumberBoxSpinButtonPlacementExample != null)
+            if (sender is RadioButtons radioButtons)
             {
-                string spinButtonPlacementModeName = rb.Tag.ToString();
-
-                switch (spinButtonPlacementModeName)
+                switch (radioButtons.SelectedIndex)
                 {
-                    case "Inline":
+                    case 0:
                         NumberBoxSpinButtonPlacementExample.SpinButtonPlacementMode = NumberBoxSpinButtonPlacementMode.Inline;
                         break;
-                    case "Compact":
+                    case 1:
                         NumberBoxSpinButtonPlacementExample.SpinButtonPlacementMode = NumberBoxSpinButtonPlacementMode.Compact;
                         break;
                 }

--- a/WinUIGallery/ControlPagesSampleCode/NumberBox/NumberBoxSample2_xaml.txt
+++ b/WinUIGallery/ControlPagesSampleCode/NumberBox/NumberBoxSample2_xaml.txt
@@ -1,6 +1,0 @@
-﻿<NumberBox x:Name="NumberBoxSpinButtonPlacementExample"
-    Header="Enter an integer:" 
-    Value="1" 
-    SpinButtonPlacementMode="Compact" 
-    SmallChange="10"
-    LargeChange="100" />


### PR DESCRIPTION
## Description
This update ensures that the example code reflects user selections between `Inline` and `Compact` spin button placements, improving the accuracy and relevance of the displayed example, main changes are:
- **Updated** XAML to dynamically reflect spin button placement changes in the displayed code.
  - Replaced static XAML with dynamic code binding that updates based on user selection.
- **Modified** `RadioButtons` control to use `SelectionChanged` event handler for updating the `SpinButtonPlacementMode` of the `NumberBox`.
- **Added** XAML substitution to ensure the displayed source code shows the correct `SpinButtonPlacementMode`.
- **Removed** obsolete XAML source file `NumberBoxSample2_xaml.txt`.

## Motivation and Context
The previous implementation did not dynamically update the example source code based on user interactions with the spin button placement options. This change improves user experience by providing accurate and up-to-date example code that matches the current UI configuration, helping users better understand how different settings affect the `NumberBox` control.

## How Has This Been Tested?
**Manual Testing**: The changes were tested by interacting with the RadioButtons control to switch between `Inline` and `Compact` spin button placements. The displayed example code was verified to accurately update according to the selected option.

## Screenshots:
![image](https://github.com/user-attachments/assets/13602b8c-02b4-4f9b-b687-16b2e7e2ed29)
![image](https://github.com/user-attachments/assets/4cfdc55c-acc4-4df3-a5e2-9100bb812dcf)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
