### PR TITLE
SplitView Sample -> `fix` the mismatch between rendered content and source code

### DIFF
--- a/WinUIGallery/ControlPages/SplitViewPage.xaml
+++ b/WinUIGallery/ControlPages/SplitViewPage.xaml
@@ -118,10 +118,6 @@
             &lt;ListView x:Name="NavLinksList" Margin="0,12,0,0" SelectionMode="Single" Grid.Row="1" VerticalAlignment="Stretch"
                     ItemClick="NavLinksList_ItemClick" IsItemClickEnabled="True"
                     ItemsSource="{x:Bind NavLinks}" ItemTemplate="{StaticResource NavLinkItemTemplate}"/&gt;
-            &lt;StackPanel Orientation="Horizontal" Grid.Row="2" Margin="14,24,0,24" &gt;
-                &lt;SymbolIcon Symbol="Setting" /&gt;
-                &lt;TextBlock Text="Settings" Margin="24,0,0,0" VerticalAlignment="Center"/&gt;
-            &lt;/StackPanel&gt;
         &lt;/Grid&gt;
     &lt;/SplitView.Pane&gt;
  


### PR DESCRIPTION
## Description
A simple update to resolve discrepancies between the rendered content and the displayed source code, the only change is:
- Remove the code that does not match from the displayed source code (SplitViewPage.xaml).

## Motivation and Context
- The similarity between SplitView and NavigationView might be confusing for learners, so it would be best to remove it.
- fixes this issue: https://github.com/microsoft/WinUI-Gallery/issues/1587

## How Has This Been Tested?
**Manually Tested**

## Screenshots:
![image](https://github.com/user-attachments/assets/939c7f48-f94e-425a-b6d4-72a1c56e9242)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
