### PR TITLE
Title Bar height fix

### DIFF
--- a/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
@@ -102,6 +102,7 @@ namespace WinUIGallery
 
                 AppWindow appWindow = WindowHelper.GetAppWindow(window);
                 appWindow.SetIcon("Assets/Tiles/GalleryIcon.ico");
+                appWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Tall;
                 _settings = new UISettings();
                 _settings.ColorValuesChanged += _settings_ColorValuesChanged; // cannot use FrameworkElement.ActualThemeChanged event because the triggerTitleBarRepaint workaround no longer works
             };


### PR DESCRIPTION
Changed the height of the Title Bar caption buttons (minimize, maximize, close) from 32px to 48px so it matches the height of the AppTitleBar UIElement.

## Description
Set the PreferredHeightOption of the Title Bar to Tall.

## Motivation and Context
The current caption buttons look weird. The fix is also just one line.

## How Has This Been Tested?
No testing needed.

## Screenshots:
![image](https://github.com/user-attachments/assets/65e75644-6c5e-489a-a56f-9778c67c405f)

## Types of changes
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
