### PR TITLE
Add schema for ControlInfoData.json

### DIFF
--- a/WinUIGallery/DataModel/ControlInfoData.json
+++ b/WinUIGallery/DataModel/ControlInfoData.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "ControlInfoDataSchema.json",
   "Groups": [
     {
       "UniqueId": "Design_Guidance",

--- a/WinUIGallery/DataModel/ControlInfoDataSchema.json
+++ b/WinUIGallery/DataModel/ControlInfoDataSchema.json
@@ -14,7 +14,7 @@
                     },
                     "Title": {
                         "type": "string",
-                        "description": "Title appears on the control group page"
+                        "description": "The name of the control group. Will be displayed on the control group page and navigation"
                     },
                     "Subtitle": {
                         "type": "string",
@@ -30,7 +30,7 @@
                     },
                     "IconGlyph": {
                         "type": "string",
-                        "description": "Appears as an icon for the NavigationViewItem of this control group"
+                        "description": "Glyph of this control group. Will be displayed as an icon for the NavigationViewItem of this control group"
                     },
                     "ApiNamespace": {
                         "type": "string",
@@ -38,7 +38,7 @@
                     },
                     "IsSpecialSection": {
                         "type": "boolean",
-                        "description": "Special section is hard-coded in NavigationRootPage.xaml",
+                        "description": "Indicates that this section is not a regular control section but is added to the navigation differently",
                         "default": true
                     },
                     "Folder": {
@@ -58,7 +58,7 @@
                                 },
                                 "Title": {
                                     "type": "string",
-                                    "description": "Title appears on the overview card and control page of this control"
+                                    "description": "Name of this control. Will be displayed in the overview card and on top of the control page of this control"
                                 },
                                 "ApiNamespace": {
                                     "type": "string",
@@ -66,15 +66,15 @@
                                 },
                                 "Subtitle": {
                                     "type": "string",
-                                    "description": "Subtitle appears on the overview card of this control"
+                                    "description": "Brief usage of this control. Will be displayed on the overview card of this control"
                                 },
                                 "Description": {
                                     "type": "string",
-                                    "description": "Appears on the control page"
+                                    "description": "Description of this control. Will be displayed on the control page, below the Title of this control"
                                 },
                                 "ImagePath": {
                                     "type": "string",
-                                    "description": "Appears as the image of this control on the overriew card. Should be a uri starts with ms-appx:///Assets/ControlImages/..."
+                                    "description": "An image icon of this control. Will be displayed on the overriew card of this control. Should be a uri starts with ms-appx:///Assets/ControlImages/..."
                                 },
                                 "IconGlyph": {
                                     "type": "string",
@@ -87,12 +87,12 @@
                                 "IsNew": {
                                     "type": "boolean",
                                     "default": true,
-                                    "description": "Show on the Recently Added Sample section on the main page and will add a dot on the overview card of this control"
+                                    "description": "Whether this is a newly added control. If true, it will be displayed in the Recently Added Sample section on the main page and will have a dot on the overview card of this control"
                                 },
                                 "IsUpdated": {
                                     "type": "boolean",
                                     "default": true,
-                                    "description": "Show on the Recently Updated Sample section on the main page and will add a dot on the overview card of this control"
+                                    "description": "Whether the example page of this control has been updated lately. If true, it will be displayed in the Recently Updated Sample section on the main page and will have a dot on the overview card of this control"
                                 },
                                 "Docs": {
                                     "type": "array",
@@ -116,7 +116,7 @@
                                     "type": "array",
                                     "items": {
                                         "type": "string",
-                                        "description": "Name of the related control"
+                                        "description": "ID of the related control"
                                     },
                                     "description": "Array of names of the related control"
                                 }

--- a/WinUIGallery/DataModel/ControlInfoDataSchema.json
+++ b/WinUIGallery/DataModel/ControlInfoDataSchema.json
@@ -1,0 +1,132 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "Groups": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "UniqueId": {
+                        "type": "string",
+                        "description": "Globally unique id of this group",
+                        "uniqueItems": true
+                    },
+                    "Title": {
+                        "type": "string",
+                        "description": "Title appears on the control group page"
+                    },
+                    "Subtitle": {
+                        "type": "string",
+                        "description": "Not used. Can leave empty"
+                    },
+                    "Description": {
+                        "type": "string",
+                        "description": "Not used. Can leave empty"
+                    },
+                    "ImagePath": {
+                        "type": "string",
+                        "description": "Not used. Can leave empty"
+                    },
+                    "IconGlyph": {
+                        "type": "string",
+                        "description": "Appears as an icon for the NavigationViewItem of this control group"
+                    },
+                    "ApiNamespace": {
+                        "type": "string",
+                        "description": "ApiNamespace of a control group is not used. Can leave empty"
+                    },
+                    "IsSpecialSection": {
+                        "type": "boolean",
+                        "description": "Special section is hard-coded in NavigationRootPage.xaml",
+                        "default": true
+                    },
+                    "Folder": {
+                        "type": "string",
+                        "description": "Use to indicate a special child item for this folder. Only used when IsSpecialSection is true"
+                    },
+                    "Items": {
+                        "type": "array",
+                        "description": "Individual control info",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "UniqueId": {
+                                    "type": "string",
+                                    "description": "Globally unique id of this control",
+                                    "uniqueItems": true
+                                },
+                                "Title": {
+                                    "type": "string",
+                                    "description": "Title appears on the overview card and control page of this control"
+                                },
+                                "ApiNamespace": {
+                                    "type": "string",
+                                    "description": "Namespace of this control will appear below the tile on the control's detail page'"
+                                },
+                                "Subtitle": {
+                                    "type": "string",
+                                    "description": "Subtitle appears on the overview card of this control"
+                                },
+                                "Description": {
+                                    "type": "string",
+                                    "description": "Appears on the control page"
+                                },
+                                "ImagePath": {
+                                    "type": "string",
+                                    "description": "Appears as the image of this control on the overriew card. Should be a uri starts with ms-appx:///Assets/ControlImages/..."
+                                },
+                                "IconGlyph": {
+                                    "type": "string",
+                                    "description": "Not used. Leave empty"
+                                },
+                                "Content": {
+                                    "type": "string",
+                                    "description": "Not used. Leave empty"
+                                },
+                                "IsNew": {
+                                    "type": "boolean",
+                                    "default": true,
+                                    "description": "Show on the Recently Added Sample section on the main page and will add a dot on the overview card of this control"
+                                },
+                                "IsUpdated": {
+                                    "type": "boolean",
+                                    "default": true,
+                                    "description": "Show on the Recently Updated Sample section on the main page and will add a dot on the overview card of this control"
+                                },
+                                "Docs": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "Title": {
+                                                "type": "string",
+                                                "description": "Link name that appears in the Documentation dropdown"
+                                            },
+                                            "Uri": {
+                                                "type": "string",
+                                                "description": "Documentation link url"
+                                            }
+                                        },
+                                        "required": [ "Title", "Uri" ]
+                                    },
+                                    "description": "Add a link to the doc in the Documentation dropdown on the detail page of this control"
+                                },
+                                "RelatedControls": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string",
+                                        "description": "Name of the related control"
+                                    },
+                                    "description": "Array of names of the related control"
+                                }
+                            },
+                            "required": [ "UniqueId", "Title"]
+                        }
+                    }
+                },
+                "required": [ "UniqueId", "Title", "Items" ]
+            }
+        }
+    }
+}


### PR DESCRIPTION

## Description
I added a schema file for the `ControlInfoData.json` to make adding new control / control group to it simpler. Now you get nice intellisense for all properties and error message for missing required ones. The schema should be automatically picked up by any reasonable editors.

## Motivation and Context
I just happens to know this.

## How Has This Been Tested?
The current file reports no mismatch for this schema.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/479a5292-842a-4dec-be0d-33eb0dbfb86c)

![image](https://github.com/user-attachments/assets/482bdfcb-2d94-43d0-af15-fb06aebe6129)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
