### PR TITLE
Fix/add link to nonclientinputsource

### DIFF
--- a/WinUIGallery/ControlPages/TitleBarPage.xaml
+++ b/WinUIGallery/ControlPages/TitleBarPage.xaml
@@ -157,7 +157,8 @@
                            Microsoft.UI.AppWindowTitlebar
                         </Hyperlink>
                         and
-                        <Italic>Microsoft.UI.NonClientInputPointerSource apis</Italic>
+                        <Hyperlink NavigateUri="https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.input.inputnonclientpointersource">Microsoft.UI.NonClientInputPointerSource</Hyperlink>
+                        <Italic>apis</Italic>
                         <LineBreak></LineBreak>
                         <LineBreak></LineBreak>
                         WinUI allows  <Bold> mix and match </Bold> of higher level WinUI custom titlebar apis with lower level AppWindow and NonClientInputPointerSource apis for most cases.

--- a/WinUIGallery/ControlPages/TitleBarPage.xaml
+++ b/WinUIGallery/ControlPages/TitleBarPage.xaml
@@ -157,11 +157,11 @@
                            Microsoft.UI.AppWindowTitlebar
                         </Hyperlink>
                         and
-                        <Hyperlink NavigateUri="https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.input.inputnonclientpointersource">Microsoft.UI.NonClientInputPointerSource</Hyperlink>
+                        <Hyperlink NavigateUri="https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.input.inputnonclientpointersource">Microsoft.UI.InputNonClientPointerSource</Hyperlink>
                         <Italic>apis</Italic>
                         <LineBreak></LineBreak>
                         <LineBreak></LineBreak>
-                        WinUI allows  <Bold> mix and match </Bold> of higher level WinUI custom titlebar apis with lower level AppWindow and NonClientInputPointerSource apis for most cases.
+                        WinUI allows  <Bold> mix and match </Bold> of higher level WinUI custom titlebar apis with lower level AppWindow and InputNonClientPointerSource apis for most cases.
                         One exception is one should not use <Italic> Window.SetTitlebar </Italic> api along with any lower level api which also sets drag regions as it can result in unexpected behavior.
                         If needed, set <Italic> Window.SetTitlebar </Italic> to null (default case) and proceed to use lower level apis for drag functionality.
                         <LineBreak></LineBreak>

--- a/WinUIGallery/ControlPages/TitleBarPage.xaml
+++ b/WinUIGallery/ControlPages/TitleBarPage.xaml
@@ -157,7 +157,7 @@
                            Microsoft.UI.AppWindowTitlebar
                         </Hyperlink>
                         and
-                        <Hyperlink NavigateUri="https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.input.inputnonclientpointersource">Microsoft.UI.InputNonClientPointerSource</Hyperlink>
+                        <Hyperlink NavigateUri="https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.input.inputnonclientpointersource">Microsoft.UI.Input.InputNonClientPointerSource</Hyperlink>
                         <Italic>apis</Italic>
                         <LineBreak></LineBreak>
                         <LineBreak></LineBreak>


### PR DESCRIPTION
## Description
![image](https://github.com/user-attachments/assets/423ac92d-49c6-409d-a187-4c7aa4ae2cd6)
The api name have been incorrect for so long. I corrected it and also added a link to it.


## Motivation and Context

## How Has This Been Tested?
Manual

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/f62182c8-9281-4254-8256-d29f6ad1ac5a)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
