### PR TITLE
Fix theming in spacing page

### DIFF
--- a/WinUIGallery/ControlPages/DesignGuidance/SpacingPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/SpacingPage.xaml
@@ -91,7 +91,9 @@
                         HorizontalAlignment="Center"
                         Style="{StaticResource SubtitleTextBlockStyle}"
                         Text="Page with cards layout" />
-                    <Image Grid.Row="1" Source="{ThemeResource CardsImage}" />
+                    <controls:SampleThemeListener Grid.Row="1">
+                        <Image Source="{ThemeResource CardsImage}" />
+                    </controls:SampleThemeListener>
                 </Grid>
                 <Grid VerticalAlignment="Top" RowSpacing="12">
                     <Grid.RowDefinitions>
@@ -102,7 +104,9 @@
                         HorizontalAlignment="Center"
                         Style="{StaticResource SubtitleTextBlockStyle}"
                         Text="Form layout" />
-                    <Image Grid.Row="1" Source="{ThemeResource DialogImage}" />
+                    <controls:SampleThemeListener Grid.Row="1">
+                        <Image Source="{ThemeResource DialogImage}" />
+                    </controls:SampleThemeListener>
                 </Grid>
             </StackPanel>
         </ScrollView>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixing text on spacing page being hard to read when using the theme switch button. This was caused because we didn't include SampleThemeListener and the default behavior of ItemsPages is to switch the theme of the entire page if none are used in a sample page.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1637
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
