### PR TITLE
Bulk merge of SceneGraph demo code from feature/demo

### DIFF
--- a/WinUIGallery/ControlPages/ContentDialogPage.xaml.cs
+++ b/WinUIGallery/ControlPages/ContentDialogPage.xaml.cs
@@ -63,7 +63,7 @@ namespace WinUIGallery.ControlPages
         private async void Dialog_Closing(ContentDialog sender, ContentDialogClosingEventArgs args)
         {
 #if !AB_BUILD
-            if (SettingsPage.useComputeSharpAnimations)
+            if (SettingsPage.computeSharpAnimationState != SettingsPage.ComputeSharpAnimationState.NONE)
             {
                 // Get a deferral until the shader starts rendering.
                 // This keeps the dialog open until the capture is complete.

--- a/WinUIGallery/ControlPages/ContentDialogPage.xaml.cs
+++ b/WinUIGallery/ControlPages/ContentDialogPage.xaml.cs
@@ -102,8 +102,10 @@ namespace WinUIGallery.ControlPages
 
         private RenderTargetBitmap m_bitmap = new RenderTargetBitmap();
         private RenderTargetBitmap m_fullBitmap = new RenderTargetBitmap();
+
 #if !AB_BUILD
         private Rect m_dialogRect = new();
 #endif // #if !AB_BUILD
     }
 }
+

--- a/WinUIGallery/ControlPages/ContentDialogPage.xaml.cs
+++ b/WinUIGallery/ControlPages/ContentDialogPage.xaml.cs
@@ -91,7 +91,7 @@ namespace WinUIGallery.ControlPages
 
                 overlayPanel.AddOverlay(dialogShaderPanel, offset);
 
-                await Task.Delay(TimeSpan.FromSeconds(1.0f)); // sync with duration in TwirlDismiss
+                await Task.Delay(TimeSpan.FromSeconds(1.2f)); // sync with duration in TwirlDismiss
 
                 overlayPanel.ClearOverlays();
             }

--- a/WinUIGallery/ControlPages/ContentDialogPage.xaml.cs
+++ b/WinUIGallery/ControlPages/ContentDialogPage.xaml.cs
@@ -66,45 +66,45 @@ namespace WinUIGallery.ControlPages
             if (SettingsPage.useComputeSharpAnimations)
             {
                 // Get a deferral until the shader starts rendering.
+                // This keeps the dialog open until the capture is complete.
                 var deferral = args.GetDeferral();
 
-                m_dialogRect = await sender.CaptureTo(m_bitmap);
+                // Capture the dialog to our bitmap and get the dialog dimensions.
+                var dialogRect = await sender.CaptureTo(m_bitmap);
 
-                // Calculate offset from Window root to the overlay element
-                var transform = this.XamlRoot.Content.TransformToVisual(overlayPanel);
+                // Calculate offset from Window root to the overlay panel
+                var transform = XamlRoot.Content.TransformToVisual(overlayPanel);
                 var overlayOffset = transform.TransformPoint(new Point(0, 0));
+
+                // Create our shader panel which will run "TwirlDismiss" on the dialog capture.
                 var dialogShaderPanel = new ShaderPanel();
                 dialogShaderPanel.InitializeForShader<TwirlDismiss>();
-                dialogShaderPanel.Translation = new Vector3((float)overlayOffset.X, (float)overlayOffset.Y, 0);
-                dialogShaderPanel.Width = m_dialogRect.Width;
-                dialogShaderPanel.Height = m_dialogRect.Height;
+                dialogShaderPanel.Width = dialogRect.Width;
+                dialogShaderPanel.Height = dialogRect.Height;
+                dialogShaderPanel.Translation = new Vector3(
+                    (float)overlayOffset.X,
+                    (float)overlayOffset.Y,
+                    0);
 
-                // Offset from the overlay element to the dialog
-                Point offset = new() { X = m_dialogRect.X, Y = m_dialogRect.Y };
+                await dialogShaderPanel.SetShaderInputAsync(m_bitmap);
 
-                // We need to do some shenanigans because the render actually happens on a background thread,
-                // which is where the event gets fired.
-                var dispatcher = DispatcherQueue;
-                dialogShaderPanel.FirstRender += (s, e) => dispatcher.TryEnqueue(() => deferral.Complete());
-
-                await dialogShaderPanel.SetRenderTargetBitmapAsync(m_bitmap);
-
+                // Display the shader panel by adding it as an overlay.
+                Point offset = new() { X = dialogRect.X, Y = dialogRect.Y };
                 overlayPanel.AddOverlay(dialogShaderPanel, offset);
 
-                await Task.Delay(TimeSpan.FromSeconds(1.2f)); // sync with duration in TwirlDismiss
-
-                overlayPanel.ClearOverlays();
+                // Close the dialog once the shader starts running, and remove the shader panel when
+                // it's done.
+                dialogShaderPanel.FirstRender += (s, e) => deferral.Complete();
+                dialogShaderPanel.ShaderCompleted += (s, e) => overlayPanel.ClearOverlay(dialogShaderPanel);
             }
 #else
             await Task.CompletedTask;
 #endif // #if !AB_BUILD
         }
 
-        private RenderTargetBitmap m_bitmap = new RenderTargetBitmap();
-        private RenderTargetBitmap m_fullBitmap = new RenderTargetBitmap();
-
 #if !AB_BUILD
-        private Rect m_dialogRect = new();
+        // The bitmap that holds the screen capture of the dialog so we can run shaders on it.
+        private RenderTargetBitmap m_bitmap = new RenderTargetBitmap();
 #endif // #if !AB_BUILD
     }
 }

--- a/WinUIGallery/Navigation/NavigationRootPage.xaml
+++ b/WinUIGallery/Navigation/NavigationRootPage.xaml
@@ -161,7 +161,8 @@
             IsTabStop="False"
             IsTitleBarAutoPaddingEnabled="True"
             Loaded="OnNavigationViewControlLoaded"
-            SelectionChanged="OnNavigationViewSelectionChanged">
+            SelectionChanged="OnNavigationViewSelectionChanged"
+            Background="{ThemeResource GalleryBackgroundBrush}">
 
             <!-- Custom TitleBar with NavigationView L-Pattern Overwriting resources -->
             <NavigationView.Resources>
@@ -269,6 +270,6 @@
                 <NavigationViewItemSeparator />
             </NavigationView.MenuItems>
         </NavigationView>
-        <shaders:OverlayPanel x:Name="overlayPanel"/>
+        <shaders:OverlayPanel x:Name="overlayPanel" Background="Transparent"/>
     </Grid>
 </Page>

--- a/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
@@ -197,13 +197,11 @@ namespace WinUIGallery
                 shaderPanel.Width = frame.RenderSize.Width;
                 shaderPanel.Height = frame.RenderSize.Height;
 
-                float transitionDuration = 1.5f;
                 if (SettingsPage.computeSharpAnimationState == SettingsPage.ComputeSharpAnimationState.WIPE)
                 {
                     shaderPanel.InitializeForShader<Wipe>();
                     float radians = (float)new Random().NextDouble() * 3.14f * 2;
                     shaderPanel.WipeDirection = new Vector2(MathF.Cos(radians), MathF.Sin(radians));
-                    transitionDuration = 2.0f;
                 }
                 else
                 {
@@ -214,7 +212,7 @@ namespace WinUIGallery
                     opacityAnimation.InsertKeyFrame(0.0f, 1.0f);
                     opacityAnimation.InsertKeyFrame(0.5f, 1.0f);
                     opacityAnimation.InsertKeyFrame(1.0f, 0.0f);
-                    opacityAnimation.Duration = TimeSpan.FromSeconds(transitionDuration);
+                    opacityAnimation.Duration = shaderPanel.Duration;
                     overlayVisual.StartAnimation("Opacity", opacityAnimation);
                 }
 
@@ -222,15 +220,12 @@ namespace WinUIGallery
                 Point offset = transform.TransformPoint(new Point(0, 0));
                 Rect clip = new Rect(offset.X, offset.Y, shaderPanel.Width, shaderPanel.Height);
 
-                await shaderPanel.SetRenderTargetBitmapAsync(m_fullBitmap, clip);
+                await shaderPanel.SetShaderInputAsync(m_fullBitmap, clip);
+
                 overlayPanel.AddOverlay(shaderPanel, offset);
+                shaderPanel.ShaderCompleted += (s, e) => overlayPanel.ClearOverlay(shaderPanel);
 
                 NavigateHelper(pageType, targetPageArguments, navigationTransitionInfo);
-
-                // Delay the navigation for animation
-                await Task.Delay(TimeSpan.FromSeconds(transitionDuration));
-
-                overlayPanel.ClearOverlay(shaderPanel);
 #else
                 NavigateHelper(pageType, targetPageArguments, navigationTransitionInfo);
                 await Task.CompletedTask;

--- a/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
@@ -35,6 +35,7 @@ using WinUIGallery.Shaders;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.UI.Xaml.Media.Animation;
 using System.Security.AccessControl;
+using System.Numerics;
 
 namespace WinUIGallery
 {
@@ -179,7 +180,7 @@ namespace WinUIGallery
             Microsoft.UI.Xaml.Media.Animation.NavigationTransitionInfo navigationTransitionInfo = null)
         {
             // Don't do the animation for the first navigation
-            if (firstNavigation || !SettingsPage.useComputeSharpAnimations)
+            if (firstNavigation || SettingsPage.computeSharpAnimationState == SettingsPage.ComputeSharpAnimationState.NONE)
             {
                 firstNavigation = false;
                 NavigateHelper(pageType, targetPageArguments, navigationTransitionInfo);
@@ -191,27 +192,38 @@ namespace WinUIGallery
 
                 overlayPanel.ClearOverlays();
 
+                UIElement frame = rootFrame;
                 var shaderPanel = new ShaderPanel();
-                shaderPanel.InitializeForShader<RippleFade>();
-                shaderPanel.Width = rootFrame.ActualWidth;
-                shaderPanel.Height = rootFrame.ActualHeight;
+                shaderPanel.Width = frame.RenderSize.Width;
+                shaderPanel.Height = frame.RenderSize.Height;
 
-                var transform = rootFrame.TransformToVisual(null);
+                float transitionDuration = 1.5f;
+                if (SettingsPage.computeSharpAnimationState == SettingsPage.ComputeSharpAnimationState.WIPE)
+                {
+                    shaderPanel.InitializeForShader<Wipe>();
+                    float radians = (float)new Random().NextDouble() * 3.14f * 2;
+                    shaderPanel.WipeDirection = new Vector2(MathF.Cos(radians), MathF.Sin(radians));
+                    transitionDuration = 2.0f;
+                }
+                else
+                {
+                    shaderPanel.InitializeForShader<RippleFade>();
+                    var overlayVisual = ElementCompositionPreview.GetElementVisual(overlayPanel);
+                    var compositor = overlayVisual.Compositor;
+                    var opacityAnimation = compositor.CreateScalarKeyFrameAnimation();
+                    opacityAnimation.InsertKeyFrame(0.0f, 1.0f);
+                    opacityAnimation.InsertKeyFrame(0.5f, 1.0f);
+                    opacityAnimation.InsertKeyFrame(1.0f, 0.0f);
+                    opacityAnimation.Duration = TimeSpan.FromSeconds(transitionDuration);
+                    overlayVisual.StartAnimation("Opacity", opacityAnimation);
+                }
+
+                var transform = frame.TransformToVisual(null);
                 Point offset = transform.TransformPoint(new Point(0, 0));
                 Rect clip = new Rect(offset.X, offset.Y, shaderPanel.Width, shaderPanel.Height);
 
                 await shaderPanel.SetRenderTargetBitmapAsync(m_fullBitmap, clip);
                 overlayPanel.AddOverlay(shaderPanel, offset);
-
-                float transitionDuration = 1.5f;
-                var overlayVisual = ElementCompositionPreview.GetElementVisual(overlayPanel);
-                var compositor = overlayVisual.Compositor;
-                var opacityAnimation = compositor.CreateScalarKeyFrameAnimation();
-                opacityAnimation.InsertKeyFrame(0.0f, 1.0f);
-                opacityAnimation.InsertKeyFrame(0.5f, 1.0f);
-                opacityAnimation.InsertKeyFrame(1.0f, 0.0f);
-                opacityAnimation.Duration = TimeSpan.FromSeconds(transitionDuration);
-                overlayVisual.StartAnimation("Opacity", opacityAnimation);
 
                 NavigateHelper(pageType, targetPageArguments, navigationTransitionInfo);
 

--- a/WinUIGallery/SettingsPage.xaml
+++ b/WinUIGallery/SettingsPage.xaml
@@ -102,9 +102,13 @@
 
                 <toolkit:SettingsCard Header="ComputeSharp Animations">
                     <toolkit:SettingsCard.HeaderIcon>
-                        <FontIcon Glyph="&#xECAD;" />
+                        <FontIcon Glyph="&#xF594;" />
                     </toolkit:SettingsCard.HeaderIcon>
-                    <ToggleSwitch x:Name="computeSharpAnimations" Toggled="computeSharpAnimations_Toggled" IsOn="True"/>
+                    <ComboBox x:Name="computeSharpAnimations" SelectionChanged="computeSharpAnimations_SelectionChanged">
+                        <ComboBoxItem Content="None" />
+                        <ComboBoxItem Content="Wipe" />
+                        <ComboBoxItem Content="Ripple" />
+                    </ComboBox>
                 </toolkit:SettingsCard>
 
                 <!--  About  -->

--- a/WinUIGallery/SettingsPage.xaml.cs
+++ b/WinUIGallery/SettingsPage.xaml.cs
@@ -36,7 +36,9 @@ namespace WinUIGallery
 
         public string WinAppSdkRuntimeDetails => App.WinAppSdkRuntimeDetails;
         private int lastNavigationSelectionMode = 0;
-        public static bool useComputeSharpAnimations = true;
+
+        public enum ComputeSharpAnimationState { NONE, WIPE, RIPPLE };
+        public static ComputeSharpAnimationState computeSharpAnimationState = ComputeSharpAnimationState.NONE;
 
         public SettingsPage()
         {
@@ -77,6 +79,19 @@ namespace WinUIGallery
                     navigationLocation.SelectedIndex = 1;
                 }
                 lastNavigationSelectionMode = navigationLocation.SelectedIndex;
+            }
+
+            if (computeSharpAnimationState == ComputeSharpAnimationState.NONE)
+            {
+                computeSharpAnimations.SelectedIndex = 0;
+            }
+            else if (computeSharpAnimationState == ComputeSharpAnimationState.WIPE)
+            {
+                computeSharpAnimations.SelectedIndex = 1;
+            }
+            else if (computeSharpAnimationState == ComputeSharpAnimationState.RIPPLE)
+            {
+                computeSharpAnimations.SelectedIndex = 2;
             }
 
             if (ElementSoundPlayer.State == ElementSoundPlayerState.On)
@@ -164,9 +179,20 @@ namespace WinUIGallery
         
         }
 
-        private void computeSharpAnimations_Toggled(object sender, RoutedEventArgs e)
+        private void computeSharpAnimations_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            useComputeSharpAnimations = !useComputeSharpAnimations;
+            if (computeSharpAnimations.SelectedIndex == 0)
+            {
+                computeSharpAnimationState = ComputeSharpAnimationState.NONE;
+            }
+            else if (computeSharpAnimations.SelectedIndex == 1)
+            {
+                computeSharpAnimationState = ComputeSharpAnimationState.WIPE;
+            }
+            else if (computeSharpAnimations.SelectedIndex == 2)
+            {
+                computeSharpAnimationState = ComputeSharpAnimationState.RIPPLE;
+            }
         }
     }
 }

--- a/WinUIGallery/Shaders/CaptureHelper.cs
+++ b/WinUIGallery/Shaders/CaptureHelper.cs
@@ -40,7 +40,7 @@ namespace WinUIGallery.Shaders
             var child3 = VisualTreeHelper.GetChild(child2, 0);
 
             var dialogContent = child3 as Border;
-            var dpi = GetDpi(dialog);
+            var dpi = GetDpi(dialog) / 96.0f;
 
             // Get transform from dialog content to the window wide dialog.
             // This will let us position things later.
@@ -55,17 +55,12 @@ namespace WinUIGallery.Shaders
 
             var transformedBounds = transform.TransformBounds(originalBounds);
 
-            transformedBounds.X = transformedBounds.X;
-            transformedBounds.Y = transformedBounds.Y;
-            transformedBounds.Width = transformedBounds.Width;
-            transformedBounds.Height = transformedBounds.Height;
-
-            await renderTarget.RenderAsync(dialogContent, (int)(dialogContent.RenderSize.Width * 96.0f / dpi), (int)(dialogContent.RenderSize.Height * 96.0f / dpi));
+            await renderTarget.RenderAsync(dialogContent, (int)(transformedBounds.Width / dpi), (int)(transformedBounds.Height / dpi));
 
             return transformedBounds;
         }
 
-        private static float GetDpi(UIElement element)
+        public static float GetDpi(UIElement element)
         {
             var window = WindowHelper.GetWindowForElement(element);
             var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(window);

--- a/WinUIGallery/Shaders/OverlayPanel.xaml
+++ b/WinUIGallery/Shaders/OverlayPanel.xaml
@@ -8,5 +8,5 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Canvas Background="Transparent" x:Name="overlayRootCanvas" IsHitTestVisible="False" />
+    <Canvas x:Name="overlayRootCanvas" IsHitTestVisible="False" Background="Transparent"/>
 </UserControl>

--- a/WinUIGallery/Shaders/PixelShaderRenderer.cs
+++ b/WinUIGallery/Shaders/PixelShaderRenderer.cs
@@ -34,17 +34,16 @@ namespace WinUIGallery.Shaders
         public int2 InputSizeInt2 => new int2(InputSize.Width, InputSize.Height);
     }
 
-    // Unfortunately we need to use type erasure to instantiate through generics...
-    delegate object ConstantBufferFactory(ShaderDrawData drawData);
-
     class PixelShaderRenderer
     {
         public PixelShaderRenderer() { }
 
+        public TimeSpan Duration => m_impl.Duration;
+
         private IReadOnlyList<ShaderSourceHelper> Sources => m_shaderSources;
 
 #nullable enable
-        public async Task SetSourceBitmap(int index,RenderTargetBitmap renderTargetBitmap, CanvasDevice? canvasDevice, Rect? clip = null)
+        public async Task SetSourceBitmap(int index, RenderTargetBitmap renderTargetBitmap, CanvasDevice? canvasDevice, Rect? clip = null)
         {
             var source = Sources[index];
 
@@ -88,7 +87,7 @@ namespace WinUIGallery.Shaders
         public void InitializeForShader<TPixelShader>()
             where TPixelShader : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<TPixelShader>
         {
-            m_impl = new PixelShaderRenderImpl(typeof(TPixelShader));
+            m_impl = PixelShaderRenderImpl.GetRenderImplForShader<TPixelShader>();
 
             var sourcesCount = m_impl.Sources.Count;
             m_shaderSources = new List<ShaderSourceHelper>(sourcesCount);
@@ -105,46 +104,51 @@ namespace WinUIGallery.Shaders
 
     class PixelShaderRenderImpl
     {
-        public PixelShaderRenderImpl(Type type)
+        public static PixelShaderRenderImpl GetRenderImplForShader<TPixelShader>()
         {
-            var drawDelegate = s_shaderDrawMap[type];
-            PixelShader = drawDelegate(out Action<ShaderDrawData> drawAction, out EffectSourceList sources);
-            DrawAction = drawAction;
-            Sources = sources;
+            var shaderFactory = s_shaderFactoryMap[typeof(TPixelShader)];
+            return shaderFactory();
         }
 
-        public ICanvasImage PixelShader { get; }
-        public Action<ShaderDrawData> DrawAction { get; }
-        public EffectSourceList Sources { get; }
+        private PixelShaderRenderImpl() { }
 
-        private delegate ICanvasImage ShaderDrawDelegate(out Action<ShaderDrawData> drawFunc, out EffectSourceList sources);
+        public required ICanvasImage PixelShader { get; set; }
+        public required Action<ShaderDrawData> DrawAction { get; set; }
+        public required EffectSourceList Sources { get; set; }
+        public required TimeSpan Duration { get; set; }
 
-        private static readonly Dictionary<Type, ShaderDrawDelegate> s_shaderDrawMap = new()
+        private delegate PixelShaderRenderImpl ShaderEffectFactory();
+
+        private static readonly Dictionary<Type, ShaderEffectFactory> s_shaderFactoryMap = new()
         {
-            { typeof(RippleFade), DrawRippleFade },
-            { typeof(TwirlDismiss), DrawTwirlDismiss },
-            { typeof(Wipe), DrawWipe },
+            { typeof(RippleFade), RippleFadeFactory },
+            { typeof(TwirlDismiss), TwirlDismissFactory },
+            { typeof(Wipe), WipeEffectFactory },
         };
 
-        private static PixelShaderEffect<RippleFade> DrawRippleFade(out Action<ShaderDrawData> drawFunc, out EffectSourceList sources)
+        private static PixelShaderRenderImpl RippleFadeFactory()
         {
             PixelShaderEffect<RippleFade> effect = new PixelShaderEffect<RippleFade>();
-            sources = effect.Sources;
 
-            drawFunc = (ShaderDrawData drawData) =>
+            var drawAction = (ShaderDrawData drawData) =>
             {
                 effect.ConstantBuffer = new RippleFade((float)drawData.Duration.TotalSeconds, drawData.CanvasSizeInt2);
             };
 
-            return effect;
+            return new PixelShaderRenderImpl()
+            {
+                PixelShader = effect,
+                Sources = effect.Sources,
+                Duration = TimeSpan.FromSeconds(1.5),
+                DrawAction = drawAction
+            };
         }
 
-        private static PixelShaderEffect<TwirlDismiss> DrawTwirlDismiss(out Action<ShaderDrawData> drawFunc, out EffectSourceList sources)
+        private static PixelShaderRenderImpl TwirlDismissFactory()
         {
             PixelShaderEffect<TwirlDismiss> effect = new PixelShaderEffect<TwirlDismiss>();
-            sources = effect.Sources;
 
-            drawFunc = (ShaderDrawData drawData) =>
+            var drawAction = (ShaderDrawData drawData) =>
             {
                 float scale = drawData.Dpi / 96.0f;
                 var originalSize = drawData.CanvasSizeInt2;
@@ -152,20 +156,31 @@ namespace WinUIGallery.Shaders
                 effect.ConstantBuffer = new TwirlDismiss((float)drawData.Duration.TotalSeconds, size);
             };
 
-            return effect;
+            return new PixelShaderRenderImpl()
+            {
+                PixelShader = effect,
+                Sources = effect.Sources,
+                Duration = TimeSpan.FromSeconds(1.2),
+                DrawAction = drawAction
+            };
         }
 
-        private static PixelShaderEffect<Wipe> DrawWipe(out Action<ShaderDrawData> drawFunc, out EffectSourceList sources)
+        private static PixelShaderRenderImpl WipeEffectFactory()
         {
             PixelShaderEffect<Wipe> effect = new PixelShaderEffect<Wipe>();
-            sources = effect.Sources;
 
-            drawFunc = (ShaderDrawData drawData) =>
+            var drawAction = (ShaderDrawData drawData) =>
             {
                 effect.ConstantBuffer = new Wipe((float)drawData.Duration.TotalSeconds, drawData.CanvasSizeInt2, drawData.WipeDirection);
             };
 
-            return effect;
+            return new PixelShaderRenderImpl()
+            {
+                PixelShader = effect,
+                Sources = effect.Sources,
+                Duration = TimeSpan.FromSeconds(2.0),
+                DrawAction = drawAction
+            };
         }
     }
 

--- a/WinUIGallery/Shaders/ShaderPanel.xaml.cs
+++ b/WinUIGallery/Shaders/ShaderPanel.xaml.cs
@@ -18,6 +18,9 @@ using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.UI.Xaml.Navigation;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
+using System.Diagnostics;
+using Windows.UI;
+using System.Numerics;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -35,6 +38,9 @@ namespace WinUIGallery.Shaders
         }
 
         public event EventHandler FirstRender;
+
+        // Variable to be passed through to the shader
+        public Vector2 WipeDirection { get; set; } = new Vector2(1,0);
 
         private PixelShaderRenderer Renderer { get; } = new();
 
@@ -68,7 +74,9 @@ namespace WinUIGallery.Shaders
                 CanvasDevice = CanvasDevice,
                 CanvasSize = sender.Size,
                 EventArgs = args,
-                Duration = DateTime.Now - startTime
+                Duration = DateTime.Now - startTime,
+                Dpi = CaptureHelper.GetDpi(this),
+                WipeDirection = WipeDirection
             };
 
             Renderer.Draw(drawData);

--- a/WinUIGallery/Shaders/ShaderPanel.xaml.cs
+++ b/WinUIGallery/Shaders/ShaderPanel.xaml.cs
@@ -38,9 +38,12 @@ namespace WinUIGallery.Shaders
         }
 
         public event EventHandler FirstRender;
+        public event EventHandler ShaderCompleted;
 
         // Variable to be passed through to the shader
         public Vector2 WipeDirection { get; set; } = new Vector2(1,0);
+
+        public TimeSpan Duration => Renderer.Duration;
 
         private PixelShaderRenderer Renderer { get; } = new();
 
@@ -50,7 +53,7 @@ namespace WinUIGallery.Shaders
 
         private CanvasDevice CanvasDevice { get; set; }
 
-        public async Task SetRenderTargetBitmapAsync(RenderTargetBitmap renderTargetBitmap, Rect? clip = null)
+        public async Task SetShaderInputAsync(RenderTargetBitmap renderTargetBitmap, Rect? clip = null)
         {
             // It's ok if CanvasDevice is null here, the function can handle it
             await Renderer.SetSourceBitmap(0, renderTargetBitmap, CanvasDevice, clip);
@@ -79,6 +82,13 @@ namespace WinUIGallery.Shaders
                 WipeDirection = WipeDirection
             };
 
+            bool lastDraw = false;
+            if (drawData.Duration > Renderer.Duration)
+            {
+                drawData.Duration = Renderer.Duration;
+                lastDraw = true;
+            }
+
             Renderer.Draw(drawData);
 
             if (!m_firstRender)
@@ -88,6 +98,12 @@ namespace WinUIGallery.Shaders
                     FirstRender(null, null);
                 }
                 m_firstRender = true;
+            }
+
+            if (lastDraw)
+            {
+                ShaderCompleted?.Invoke(null, null);
+                ShaderCompleted = null;
             }
         }
 

--- a/WinUIGallery/Shaders/ShaderSourceHelper.cs
+++ b/WinUIGallery/Shaders/ShaderSourceHelper.cs
@@ -25,6 +25,8 @@ namespace WinUIGallery.Shaders
             m_sourceIndex = index;
         }
 
+        public SizeInt32 BufferSize => m_bufferSize;
+
         public async Task SetPixelsFromTarget(RenderTargetBitmap bitmap, Rect? clip = null)
         {
             SizeInt32 bitmapSize = new SizeInt32(bitmap.PixelWidth, bitmap.PixelHeight);

--- a/WinUIGallery/Shaders/TwirlDismiss.cs
+++ b/WinUIGallery/Shaders/TwirlDismiss.cs
@@ -1,7 +1,5 @@
 using ComputeSharp;
 using ComputeSharp.D2D1;
-using System;
-using System.Numerics;
 
 namespace WinUIGallery.Shaders;
 
@@ -18,41 +16,95 @@ namespace WinUIGallery.Shaders;
 [D2DGeneratedPixelShaderDescriptor]
 internal readonly partial struct TwirlDismiss(float time, int2 resolution) : ID2D1PixelShader
 {
+    float2 projectPointOntoRect(float2 v, float2 rectSize)
+    {
+        float radiusScaleToEdge = Hlsl.Min(rectSize.X * 0.5f / Hlsl.Abs(v.X), resolution.Y * 0.5f / Hlsl.Abs(v.Y));
+        return v * radiusScaleToEdge;
+    }
+
+    float2 rotateVector(float2 v, float r)
+    {
+        float cos = Hlsl.Cos(r);
+        float sin = Hlsl.Sin(r);
+        return new(v.X * cos - v.Y * sin, v.X * sin + v.Y * cos);
+    }
+
     /// <inheritdoc/>
     public float4 Execute()
     {
+        // Pixel coordinate
         int2 xy = (int2)D2D.GetScenePosition().XY;
 
-        float2 xyOffset = xy - (float2)resolution * 0.5f;
-        float radius = Hlsl.Length(xyOffset);
-        float maxDist = Hlsl.Length((float2)resolution * 0.5f);
-        float percentOut = radius / maxDist;
-
+        // Time
         float duration = 1.0f;
         float f = time / duration;
-        float insideRadians = 20 * f * f;
-        float outsideRadians = insideRadians / 2.0f;
-        float size = Hlsl.Max(0.0f, 1.0f - (f * f));
+
+        // Calculate offset from center and initial radial coordinate
+        float2 xyOffset = xy - (float2)resolution * 0.5f;
         float radiansInitial = Hlsl.Atan2(xyOffset.Y, xyOffset.X);
-        float radiansDelta = percentOut * outsideRadians + (1 - percentOut) * insideRadians;
+        float initialRadius = Hlsl.Length(xyOffset);
+
+        // Inscribed circle inside rect
+        float inscribedCircleRadius = Hlsl.Min(resolution.X, resolution.Y) * 0.5f;
+
+        // Rotation for inside and outside edges
+        float insideRadians = 20 * f * f;
+        float outsideRadians = insideRadians / 20.0f;
+        // Measure of how far "out" the pixel is from center - 0 is center, 1 is perimeter of rect
+        float fracOutFromCenterRect = initialRadius / (Hlsl.Length(resolution) * 0.5f);
+        float radiansDelta = fracOutFromCenterRect * outsideRadians + (1 - fracOutFromCenterRect) * insideRadians;
         float radiansFinal = radiansInitial + radiansDelta;
+
+        // When rotating, some of the image might be clipped, so take the vector that would be
+        // clipped the most and shrink the image so it fits within the bounds.
+        float2 worstVector = (float2)resolution * 0.5f;
+        float2 worstVectorRotated = rotateVector(worstVector, radiansDelta);
+        float scaling = Hlsl.Min(1, Hlsl.Length(projectPointOntoRect(worstVectorRotated, resolution)) / Hlsl.Length(worstVectorRotated));
+        float maxSafeRadius = initialRadius / scaling;
+
+        // After a quarter turn, the image will be shrunk enough to fit inside the inscribed circle
+        if (radiansDelta >= 1.57f)
+        {
+            maxSafeRadius = inscribedCircleRadius;
+        }
 
         float cos = Hlsl.Cos(radiansFinal);
         float sin = Hlsl.Sin(radiansFinal);
+
+        // The pixel coordinate, rotated
+        float2 offsetRotatedUnscaled = new float2(cos, sin) * initialRadius;
+
+        // Project point onto the outside of the rectangle
+        float2 offsetRotatedProjectedOntoRect = projectPointOntoRect(offsetRotatedUnscaled, resolution);
+        float maxRadius = Hlsl.Length(offsetRotatedProjectedOntoRect);
+
+        // Another measure of how far "out" the pixel is from center
+        // 0 is center, 1 is the perimeter of the inscribed circle, 1+ is outside inscribed circle
+        float fracOutFromCenterPolar = initialRadius / inscribedCircleRadius;
+
+        // If the shader samples from a point at this radius, the rect will be morphed into a
+        // perfect circle, inscribed within the rect
+        float targetRadius = fracOutFromCenterPolar * maxRadius;
+
+        // Slowly morph from rect to circle over first quarter turn
+        float fracToQuarterTurn = Hlsl.Sin(Hlsl.Min(1.57f, radiansDelta));
+        float morphedRadius = (targetRadius * fracToQuarterTurn) + (maxSafeRadius * (1 - fracToQuarterTurn));
+        float finalRadius = morphedRadius;
+
+        // Shrink as the animation goes on
+        float delay = 0.2f;
+        float size = Hlsl.Clamp(1.0f - ((f - delay) * (f - delay)), 0.0f, 1.0f);
         if (size == 0)
         {
             return new(0, 0, 0, 0);
         }
-        float2 offsetRotated = new float2(cos, sin) * radius / size;
-        float2 offsetScene = offsetRotated + (float2)resolution * 0.5f;
+        finalRadius /= size;
 
-        float4 tex = D2D.SampleInputAtPosition(0, offsetScene);
+        // Calculate the final polar/scene coordinate and sample.
+        float2 offsetRotated = new float2(cos, sin) * finalRadius;
+        float2 sceneRotated = offsetRotated + (float2)resolution * 0.5f;
+        float4 tex = D2D.SampleInputAtPosition(0, sceneRotated);
 
-        if (tex.A < 0.5f)
-        {
-            return new(0, 0, 0, 0);
-        }
-
-        return new(tex.X, tex.Y, tex.Z, 1.0f);
+        return new(tex.X, tex.Y, tex.Z, tex.A);
     }
 }

--- a/WinUIGallery/Shaders/TwirlDismiss.cs
+++ b/WinUIGallery/Shaders/TwirlDismiss.cs
@@ -34,9 +34,8 @@ internal readonly partial struct TwirlDismiss(float time, int2 resolution) : ID2
         float outsideRadians = insideRadians / 2.0f;
         float size = Hlsl.Max(0.0f, 1.0f - (f * f));
         float radiansInitial = Hlsl.Atan2(xyOffset.Y, xyOffset.X);
-        float radiansDelta =  percentOut * outsideRadians + (1-percentOut) * insideRadians;
+        float radiansDelta = percentOut * outsideRadians + (1 - percentOut) * insideRadians;
         float radiansFinal = radiansInitial + radiansDelta;
-
 
         float cos = Hlsl.Cos(radiansFinal);
         float sin = Hlsl.Sin(radiansFinal);
@@ -45,14 +44,14 @@ internal readonly partial struct TwirlDismiss(float time, int2 resolution) : ID2
             return new(0, 0, 0, 0);
         }
         float2 offsetRotated = new float2(cos, sin) * radius / size;
-        float2 uvFinal = offsetRotated / resolution + new float2(0.5f, 0.5f);
+        float2 offsetScene = offsetRotated + (float2)resolution * 0.5f;
 
-        if (uvFinal.X < 0.0f || uvFinal.Y < 0.0f || uvFinal.X > 1.0f || uvFinal.Y > 1.0f)
+        float4 tex = D2D.SampleInputAtPosition(0, offsetScene);
+
+        if (tex.A < 0.5f)
         {
             return new(0, 0, 0, 0);
         }
-
-        float3 tex = D2D.SampleInput(0, uvFinal).RGB;
 
         return new(tex.X, tex.Y, tex.Z, 1.0f);
     }

--- a/WinUIGallery/Shaders/Wipe.cs
+++ b/WinUIGallery/Shaders/Wipe.cs
@@ -1,0 +1,66 @@
+using ComputeSharp;
+using ComputeSharp.D2D1;
+using System;
+using Windows.UI.ViewManagement.Core;
+
+namespace WinUIGallery.Shaders;
+
+/// <summary>
+/// A shader for creating a ripple and fade out effect.
+/// Ported from <see href="https://www.shadertoy.com/view/WtjyzR"/>.
+/// <para>Created by Geoffrey Trousdale.</para>
+/// </summary>
+/// <param name="time">The current time since the start of the application.</param>
+/// <param name="dispatchSize">The dispatch size for the current output.</param>
+[D2DInputCount(1)]
+[D2DRequiresScenePosition]
+[D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
+[D2DGeneratedPixelShaderDescriptor]
+internal readonly partial struct Wipe(float t, int2 resolution, float2 wipeDirection) : ID2D1PixelShader
+{
+    /// <inheritdoc/>
+    public float4 Execute()
+    {
+        // Constants
+        float delay = 0.25f;
+        float duration = 1.0f;
+        float borderWidth = 200.0f;
+
+        // Properties of the wipe
+        // Could be moved out of the shader as an optimization
+        float2 center = (float2)resolution * 0.5f;
+        float2 d = Hlsl.Normalize(wipeDirection);
+        float2 wipeStart = Hlsl.Clamp(center - (d * resolution), new float2(0, 0), resolution) - (d * borderWidth);
+        float2 wipeEnd = Hlsl.Clamp(center + (d * resolution), new float2(0, 0), resolution);
+        float2 wipeVector = wipeEnd - wipeStart;
+        float wipeLength = Hlsl.Length(wipeVector);
+
+        // Progress of the wipe
+        float f = Hlsl.Clamp((t-delay) / duration, 0.0f, 1.0f);
+        int2 xy = (int2)D2D.GetScenePosition().XY;
+        float borderMin = wipeLength * f;
+        float borderMax = borderMin + borderWidth;
+
+        float2 offsetFromWipeStart = xy - wipeStart;
+        float projectionAlongWipe = Hlsl.Dot(offsetFromWipeStart, d);
+        float c = projectionAlongWipe / wipeLength;
+
+        // Left side
+        if (projectionAlongWipe < borderMin)
+        {
+            return new(0, 0, 0, 0);
+        }
+
+        // Right side
+        float4 tex = D2D.SampleInputAtPosition(0, xy);
+        if (projectionAlongWipe > borderMax)
+        {
+            return new(tex.RGB, 1.0f);
+        }
+
+        // Blend in the middle
+        float blend = (projectionAlongWipe - borderMin) / borderWidth;
+
+        return tex * blend;
+    }
+}


### PR DESCRIPTION
This is a merge (+fixes) of feature/demo to feature/Ignote2024-BRK304-ABDemo so that the SceneGraph portion of is synced with the AB demo. This lets everything be on one branch.

Changes:
- Add wipe effect
- Make the type of the transition effect be selectable from the settings page
- Qaulity updates for ripple effect
- Change Twirl Dismiss effect to not clip and be more of a "Tornado"
- Change the ShaderPanel + ContentDialogPage to be demo ready
- Refactor of the ShaderPanelRenderer to be more straightforward and avoid compiler warnings