### PR TITLE
Fix more DPI Issues for Demo

### DIFF
--- a/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
@@ -196,6 +196,7 @@ namespace WinUIGallery
                 var shaderPanel = new ShaderPanel();
                 shaderPanel.Width = frame.RenderSize.Width;
                 shaderPanel.Height = frame.RenderSize.Height;
+                shaderPanel.AdjustForDpi(XamlRoot.RasterizationScale);
 
                 if (SettingsPage.computeSharpAnimationState == SettingsPage.ComputeSharpAnimationState.WIPE)
                 {

--- a/WinUIGallery/Shaders/CaptureHelper.cs
+++ b/WinUIGallery/Shaders/CaptureHelper.cs
@@ -23,11 +23,12 @@ namespace WinUIGallery.Shaders
         
         public static async Task CaptureTo(this UIElement uiElement, RenderTargetBitmap renderTarget)
         {
-            var root = GetRoot(uiElement);
+            //var root = GetRoot(uiElement);
 
-            var dpi = GetDpi(uiElement);
+            //var dpi = GetDpi(uiElement);
 
-            await renderTarget.RenderAsync(root, (int)(uiElement.RenderSize.Width * 96.0f / dpi), (int)(uiElement.RenderSize.Height * 96.0f / dpi));
+            //await renderTarget.RenderAsync(root, (int)(uiElement.RenderSize.Width * 96.0f / dpi), (int)(uiElement.RenderSize.Height * 96.0f / dpi));
+            await renderTarget.RenderAsync(uiElement);
         }
 
         public static async Task<Rect> CaptureTo(this ContentDialog dialog, RenderTargetBitmap renderTarget)
@@ -63,6 +64,11 @@ namespace WinUIGallery.Shaders
         public static float GetDpi(UIElement element)
         {
             var window = WindowHelper.GetWindowForElement(element);
+            if (window == null)
+            {
+                return 1.0f;
+            }
+
             var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(window);
             return Win32.GetDpiForWindow(hwnd);
         }

--- a/WinUIGallery/Shaders/IdentityShader.cs
+++ b/WinUIGallery/Shaders/IdentityShader.cs
@@ -1,0 +1,25 @@
+using ComputeSharp;
+using ComputeSharp.D2D1;
+using System;
+using Windows.UI.ViewManagement.Core;
+
+namespace WinUIGallery.Shaders;
+
+/// <summary>
+/// A shader that displays the given input with no changes.
+/// This is most useful as a debugging tool for looking at the inputs
+/// passed into other shaders.
+/// Ported from <see href="https://www.shadertoy.com/view/WtjyzR"/>.
+/// <para>Created by Geoffrey Trousdale.</para>
+/// </summary>
+[D2DInputCount(1)]
+[D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
+[D2DGeneratedPixelShaderDescriptor]
+internal readonly partial struct IdentityShader() : ID2D1PixelShader
+{
+    /// <inheritdoc/>
+    public float4 Execute()
+    {
+        return D2D.GetInput(0);
+    }
+}

--- a/WinUIGallery/Shaders/PixelShaderRenderer.cs
+++ b/WinUIGallery/Shaders/PixelShaderRenderer.cs
@@ -43,7 +43,7 @@ namespace WinUIGallery.Shaders
         private IReadOnlyList<ShaderSourceHelper> Sources => m_shaderSources;
 
 #nullable enable
-        public async Task SetSourceBitmap(int index, RenderTargetBitmap renderTargetBitmap, CanvasDevice? canvasDevice, Rect? clip = null)
+        public async Task SetSourceBitmap(int index, RenderTargetBitmap renderTargetBitmap, CanvasDevice? canvasDevice, RectInt32? clip = null)
         {
             var source = Sources[index];
 
@@ -124,6 +124,7 @@ namespace WinUIGallery.Shaders
             { typeof(RippleFade), RippleFadeFactory },
             { typeof(TwirlDismiss), TwirlDismissFactory },
             { typeof(Wipe), WipeEffectFactory },
+            { typeof(IdentityShader), IdentityShaderFactory },
         };
 
         private static PixelShaderRenderImpl RippleFadeFactory()
@@ -179,6 +180,24 @@ namespace WinUIGallery.Shaders
                 PixelShader = effect,
                 Sources = effect.Sources,
                 Duration = TimeSpan.FromSeconds(2.0),
+                DrawAction = drawAction
+            };
+        }
+
+        private static PixelShaderRenderImpl IdentityShaderFactory()
+        {
+            PixelShaderEffect<IdentityShader> effect = new PixelShaderEffect<IdentityShader>();
+
+            var drawAction = (ShaderDrawData drawData) =>
+            {
+                effect.ConstantBuffer = new IdentityShader();
+            };
+
+            return new PixelShaderRenderImpl()
+            {
+                PixelShader = effect,
+                Sources = effect.Sources,
+                Duration = TimeSpan.FromSeconds(5.0), // extra long to help with debugging
                 DrawAction = drawAction
             };
         }

--- a/WinUIGallery/Shaders/RippleFade.cs
+++ b/WinUIGallery/Shaders/RippleFade.cs
@@ -52,13 +52,14 @@ internal readonly partial struct RippleFade(float t, int2 resolution) : ID2D1Pix
         float2 uvGreen = (sampleOffset * 1.3f);
         float2 uvBlue = (sampleOffset * 1.6f);
 
-        uvRed = Hlsl.Clamp(xy+uvRed, new float2(1, 1), resolution - new float2(1,1));
-        uvGreen = Hlsl.Clamp(xy+uvGreen, new float2(1, 1), resolution - new float2(1, 1));
-        uvBlue = Hlsl.Clamp(xy+uvBlue, new float2(1, 1), resolution - new float2(1, 1));
+        uvRed = Hlsl.Clamp(xy+uvRed, new float2(0, 0), resolution - new float2(1,1));
+        uvGreen = Hlsl.Clamp(xy+uvGreen, new float2(0, 0), resolution - new float2(1, 1));
+        uvBlue = Hlsl.Clamp(xy+uvBlue, new float2(0, 0), resolution - new float2(1, 1));
 
-        float4 red = D2D.SampleInputAtPosition(0, uvRed);
-        float4 green = D2D.SampleInputAtPosition(0, uvGreen);
-        float4 blue = D2D.SampleInputAtPosition(0, uvBlue);
+        float2 halvesies = new float2(0.5f, 0.5f);
+        float4 red = D2D.SampleInputAtPosition(0, uvRed + halvesies);
+        float4 green = D2D.SampleInputAtPosition(0, uvGreen + halvesies);
+        float4 blue = D2D.SampleInputAtPosition(0, uvBlue + halvesies);
 
         return new float4(red.R, green.G, blue.B, 1);
     }

--- a/WinUIGallery/Shaders/ShaderPanel.xaml.cs
+++ b/WinUIGallery/Shaders/ShaderPanel.xaml.cs
@@ -136,12 +136,8 @@ namespace WinUIGallery.Shaders
 
         private void CanvasAnimatedControl_Loaded(object sender, RoutedEventArgs e)
         {
-            // Change the canvas to be in pixels
-            //canvasAnimatedControl.Width = Width * DpiScale;
-            //canvasAnimatedControl.Height = Height * DpiScale;
-            //canvasAnimatedControl.Scale = new Vector3((float)(1 / DpiScale), (float)(1 / DpiScale), 1.0f);
+            // Change the canvas to be in pixels - we've already undone the DPI scale in "AdjustForDpi" below.
             canvasAnimatedControl.DpiScale = 1.0f; // 1.0 after the scale and everything is applied
-            //canvasAnimatedControl.DpiScale = (float)DpiScale;
             canvasAnimatedControl.RasterizationScale = 1.0f;
 
             // Initialize and start the timer
@@ -170,7 +166,6 @@ namespace WinUIGallery.Shaders
             Width *= dpiScale;
             Height *= dpiScale;
             Scale = new Vector3((float)(1 / DpiScale), (float)(1 / DpiScale), 1.0f);
-            // RenderTransform = new ScaleTransform() { ScaleX = 1 / DpiScale, ScaleY = 1 / DpiScale };
         }
     }
 }

--- a/WinUIGallery/Shaders/ShaderPanel.xaml.cs
+++ b/WinUIGallery/Shaders/ShaderPanel.xaml.cs
@@ -21,6 +21,7 @@ using Windows.Foundation.Collections;
 using System.Diagnostics;
 using Windows.UI;
 using System.Numerics;
+using Windows.Graphics;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -45,6 +46,8 @@ namespace WinUIGallery.Shaders
 
         public TimeSpan Duration => Renderer.Duration;
 
+        public double DpiScale { get; private set; } = 1.0f;
+
         private PixelShaderRenderer Renderer { get; } = new();
 
         private bool m_firstRender = false;
@@ -55,8 +58,32 @@ namespace WinUIGallery.Shaders
 
         public async Task SetShaderInputAsync(RenderTargetBitmap renderTargetBitmap, Rect? clip = null)
         {
+            // Clip comes in as DIPs and we want it as pixels
+            RectInt32? pixelClip;
+            if (clip.HasValue)
+            {
+                RectInt32 scaledClip = new RectInt32();
+                scaledClip.X = (int)(clip.Value.X * DpiScale);
+                scaledClip.Y = (int)(clip.Value.Y * DpiScale);
+                scaledClip.Width = (int)(clip.Value.Width * DpiScale);
+                scaledClip.Height = (int)(clip.Value.Height * DpiScale);
+                pixelClip = scaledClip;
+
+                // Make our Win2D canvas match exactly the pixels we're drawing
+                canvasAnimatedControl.Width = scaledClip.Width;
+                canvasAnimatedControl.Height = scaledClip.Height;
+            }
+            else
+            {
+                pixelClip = null;
+
+                // Make our Win2D canvas match exactly the pixels we're drawing
+                canvasAnimatedControl.Width = renderTargetBitmap.PixelWidth;
+                canvasAnimatedControl.Height = renderTargetBitmap.PixelHeight;
+            }
+
             // It's ok if CanvasDevice is null here, the function can handle it
-            await Renderer.SetSourceBitmap(0, renderTargetBitmap, CanvasDevice, clip);
+            await Renderer.SetSourceBitmap(0, renderTargetBitmap, CanvasDevice, pixelClip);
         }
 
         public void InitializeForShader<T>()
@@ -109,6 +136,14 @@ namespace WinUIGallery.Shaders
 
         private void CanvasAnimatedControl_Loaded(object sender, RoutedEventArgs e)
         {
+            // Change the canvas to be in pixels
+            //canvasAnimatedControl.Width = Width * DpiScale;
+            //canvasAnimatedControl.Height = Height * DpiScale;
+            //canvasAnimatedControl.Scale = new Vector3((float)(1 / DpiScale), (float)(1 / DpiScale), 1.0f);
+            canvasAnimatedControl.DpiScale = 1.0f; // 1.0 after the scale and everything is applied
+            //canvasAnimatedControl.DpiScale = (float)DpiScale;
+            canvasAnimatedControl.RasterizationScale = 1.0f;
+
             // Initialize and start the timer
             timer = new DispatcherTimer
             {
@@ -127,6 +162,15 @@ namespace WinUIGallery.Shaders
         private void canvasAnimatedControl_Unloaded(object sender, RoutedEventArgs e)
         {
             timer.Stop();
+        }
+
+        internal void AdjustForDpi(double dpiScale)
+        {
+            DpiScale = dpiScale;
+            Width *= dpiScale;
+            Height *= dpiScale;
+            Scale = new Vector3((float)(1 / DpiScale), (float)(1 / DpiScale), 1.0f);
+            // RenderTransform = new ScaleTransform() { ScaleX = 1 / DpiScale, ScaleY = 1 / DpiScale };
         }
     }
 }

--- a/WinUIGallery/Shaders/ShaderSourceHelper.cs
+++ b/WinUIGallery/Shaders/ShaderSourceHelper.cs
@@ -27,7 +27,7 @@ namespace WinUIGallery.Shaders
 
         public SizeInt32 BufferSize => m_bufferSize;
 
-        public async Task SetPixelsFromTarget(RenderTargetBitmap bitmap, Rect? clip = null)
+        public async Task SetPixelsFromTarget(RenderTargetBitmap bitmap, RectInt32? clip = null)
         {
             SizeInt32 bitmapSize = new SizeInt32(bitmap.PixelWidth, bitmap.PixelHeight);
             var pixelBuffer = await bitmap.GetPixelsAsync();
@@ -75,14 +75,14 @@ namespace WinUIGallery.Shaders
             m_dirty = false;
         }
 
-        private IBuffer ClipBuffer(IBuffer buffer, SizeInt32 bufferSize, Rect clip, out SizeInt32 newBufferSize)
+        private IBuffer ClipBuffer(IBuffer buffer, SizeInt32 bufferSize, RectInt32 clip, out SizeInt32 newBufferSize)
         {
             byte[] pixels = buffer.ToArray();
             int stride = bufferSize.Width * 4; // Assuming 4 bytes per pixel (BGRA)
 
             // Extract the cropped pixels
-            int cropX = (int)clip.X;
-            int cropY = (int)clip.Y;
+            int cropX = clip.X;
+            int cropY = clip.Y;
             int cropWidth = Math.Min((int)clip.Width, bufferSize.Width - cropX);
             int cropHeight = Math.Min((int)clip.Height, bufferSize.Height - cropY);
             byte[] croppedPixels = new byte[cropWidth * cropHeight * 4];

--- a/WinUIGallery/Shaders/Wipe.cs
+++ b/WinUIGallery/Shaders/Wipe.cs
@@ -52,7 +52,7 @@ internal readonly partial struct Wipe(float t, int2 resolution, float2 wipeDirec
         }
 
         // Right side
-        float4 tex = D2D.SampleInputAtPosition(0, xy);
+        float4 tex = D2D.SampleInputAtPosition(0, xy + new float2(0.5f,0.5f));
         if (projectionAlongWipe > borderMax)
         {
             return new(tex.RGB, 1.0f);


### PR DESCRIPTION
- Added an `IdentityShader` for debugging purposes
- Fixed pixel sampling positions to be pixel centered
- Correctly get back into pixel space in the ShaderPanel
- Transform our clip into pixel space too
- 100% DPI now looks perfectly crisp. Other DPIs still have issues.