### PR TITLE
Fix switching effects bug

### DIFF
--- a/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
@@ -197,6 +197,8 @@ namespace WinUIGallery
                 shaderPanel.Width = frame.RenderSize.Width;
                 shaderPanel.Height = frame.RenderSize.Height;
                 shaderPanel.AdjustForDpi(XamlRoot.RasterizationScale);
+                var overlayVisual = ElementCompositionPreview.GetElementVisual(overlayPanel);
+                overlayVisual.Opacity = 1.0f;
 
                 if (SettingsPage.computeSharpAnimationState == SettingsPage.ComputeSharpAnimationState.WIPE)
                 {
@@ -207,7 +209,6 @@ namespace WinUIGallery
                 else
                 {
                     shaderPanel.InitializeForShader<RippleFade>();
-                    var overlayVisual = ElementCompositionPreview.GetElementVisual(overlayPanel);
                     var compositor = overlayVisual.Compositor;
                     var opacityAnimation = compositor.CreateScalarKeyFrameAnimation();
                     opacityAnimation.InsertKeyFrame(0.0f, 1.0f);


### PR DESCRIPTION
Switching from the ripple effect to the wipe effect would cause the wipe effect to not appear, because part of the ripple effect is an opacity fade. This change fixes that to reset the opacity every time an effect is triggered.