### PR TITLE
[SceneGraph LKG] Disable check to skip animation if an animation is already in progress

### DIFF
--- a/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
@@ -194,12 +194,12 @@ namespace WinUIGallery
             else
             {
 #if !AB_BUILD
-                if (overlayPanel.ChildCount > 0)
-                {
-                    // We already have a transition effect in progress. Navigate, but don't start a new effect.
-                    NavigateHelper(pageType, targetPageArguments, navigationTransitionInfo);
-                    return;
-                }
+                //if (overlayPanel.ChildCount > 0)
+                //{
+                //    // We already have a transition effect in progress. Navigate, but don't start a new effect.
+                //    NavigateHelper(pageType, targetPageArguments, navigationTransitionInfo);
+                //    return;
+                //}
 
                 // overlayPanel.ClearOverlays();
                 var overlayVisual = ElementCompositionPreview.GetElementVisual(overlayPanel);


### PR DESCRIPTION
Disable check to skip animation if an animation is already in progress.

We can re-enable this if we want it, but for now we'll restart the animation if a click happens again too fast.