### PR TITLE
[SceneGraph LKG] Fix rapid clicking behavior + code cleanup

### DIFF
--- a/WinUIGallery/ControlPages/ContentDialogPage.xaml.cs
+++ b/WinUIGallery/ControlPages/ContentDialogPage.xaml.cs
@@ -72,14 +72,14 @@ namespace WinUIGallery.ControlPages
                 var deferral = args.GetDeferral();
 
                 // A dialog is actually a full window sized element because it darkens the window
-                // underneath it. Get the "real" dialog content that we think of as the dialog.
-                var realDialog = sender.GetDialogContent();
+                // underneath it. Get the "real" dialog box inside of it.
+                var dialogBox = sender.GetDialogBox();
 
-                var dialogToWindowTransform = realDialog.TransformToVisual(sender);
+                var dialogToWindowTransform = dialogBox.TransformToVisual(sender);
                 var dialogOffset = dialogToWindowTransform.TransformPoint(new Point(0, 0));
 
                 // Capture the dialog to our bitmap.
-                m_canvasRenderTarget = await realDialog.CaptureTo2(null);
+                m_canvasRenderTarget = await CaptureHelper.CaptureElementAsync(dialogBox);
 
                 // Calculate offset from Window root to the overlay panel
                 var transform = XamlRoot.Content.TransformToVisual(overlayPanel);

--- a/WinUIGallery/ControlPages/ContentDialogPage.xaml.cs
+++ b/WinUIGallery/ControlPages/ContentDialogPage.xaml.cs
@@ -75,30 +75,26 @@ namespace WinUIGallery.ControlPages
                 // underneath it. Get the "real" dialog box inside of it.
                 var dialogBox = sender.GetDialogBox();
 
-                var dialogToWindowTransform = dialogBox.TransformToVisual(sender);
-                var dialogOffset = dialogToWindowTransform.TransformPoint(new Point(0, 0));
-
                 // Capture the dialog to our bitmap.
                 m_canvasRenderTarget = await CaptureHelper.CaptureElementAsync(dialogBox);
-
-                // Calculate offset from Window root to the overlay panel
-                var transform = XamlRoot.Content.TransformToVisual(overlayPanel);
-                var overlayOffset = transform.TransformPoint(new Point(0, 0));
 
                 // Create our shader panel which will run "TwirlDismiss" on the dialog capture.
                 var dialogShaderPanel = new ShaderPanel();
                 dialogShaderPanel.InitializeForShader<TwirlDismiss>();
                 dialogShaderPanel.Width = m_canvasRenderTarget.Size.Width;
                 dialogShaderPanel.Height = m_canvasRenderTarget.Size.Height;
-                dialogShaderPanel.Translation = new Vector3(
-                    (float)overlayOffset.X,
-                    (float)overlayOffset.Y,
-                    0);
 
-                dialogShaderPanel.SetShaderInputAsync(m_canvasRenderTarget);
+                dialogShaderPanel.SetShaderInput(m_canvasRenderTarget);
 
-                // Display the shader panel by adding it as an overlay.
-                overlayPanel.AddOverlay(dialogShaderPanel, dialogOffset);
+                // Calculate the offset of the dialog box from our overlays.
+                var dialogToWindowTransform = dialogBox.TransformToVisual(sender);
+                var windowToOverlayTransform = XamlRoot.Content.TransformToVisual(overlayPanel);
+                var offsetFromWindow = dialogToWindowTransform.TransformPoint(new Point(0, 0));
+                var offsetFromOverlay = windowToOverlayTransform.TransformPoint(offsetFromWindow);
+
+                // Display the shader panel by adding it as an overlay in the same position as the
+                // dialog box.
+                overlayPanel.AddOverlay(dialogShaderPanel, offsetFromOverlay);
 
                 // Close the dialog once the shader starts running, and remove the shader panel when
                 // it's done.

--- a/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
@@ -271,7 +271,7 @@ namespace WinUIGallery
                 Point offset = transform.TransformPoint(new Point(0, 0));
                 Rect clip = new Rect(offset.X, offset.Y, shaderPanel.Width, shaderPanel.Height);
 
-                shaderPanel.SetShaderInputAsync(m_fullBitmap);
+                shaderPanel.SetShaderInput(m_fullBitmap);
 
                 overlayPanel.AddOverlay(shaderPanel, offset);
                 shaderPanel.ShaderCompleted += (s, e) => overlayPanel.ClearOverlay(shaderPanel);

--- a/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
@@ -236,7 +236,7 @@ namespace WinUIGallery
                 m_isCapturePending = true;
                 // Cover the UI with the VisualSurface before capturing, because we will scale the UI to capture at high DPI
                 ElementCompositionPreview.SetElementChildVisual(rootFrameInFront, spriteVisual);
-                m_fullBitmap = await rootFrameParent.CaptureTo2(rootFrame);
+                m_fullBitmap = await CaptureHelper.CaptureElementAsync(rootFrameParent, rootFrame);
                 ElementCompositionPreview.SetElementChildVisual(rootFrameInFront, null);
                 m_isCapturePending = false;
 

--- a/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
+++ b/WinUIGallery/Navigation/NavigationRootPage.xaml.cs
@@ -185,6 +185,11 @@ namespace WinUIGallery
             object targetPageArguments = null,
             Microsoft.UI.Xaml.Media.Animation.NavigationTransitionInfo navigationTransitionInfo = null)
         {
+            if (m_blockNavigate)
+            {
+                return;
+            }
+
             // Don't do the animation for the first navigation
             if (m_firstNavigation || SettingsPage.computeSharpAnimationState == SettingsPage.ComputeSharpAnimationState.NONE)
             {
@@ -281,6 +286,7 @@ namespace WinUIGallery
 
         private bool m_firstNavigation = true;
         private bool m_isCapturePending = false;
+        private bool m_blockNavigate = false;
         private CanvasRenderTarget m_fullBitmap;
         private DateTime m_lastNavigationTime = DateTime.Now;
 
@@ -296,9 +302,14 @@ namespace WinUIGallery
                         {
                             if ((string)item.Tag == id)
                             {
+                                // Setting SelectedItem normally calls "Navigate". That's unintended here.
+                                m_blockNavigate = true;
+
                                 group.IsExpanded = true;
                                 NavigationView.SelectedItem = item;
                                 item.IsSelected = true;
+
+                                m_blockNavigate = false;
                                 return;
                             }
                             else if (item.MenuItems.Count > 0)
@@ -309,10 +320,15 @@ namespace WinUIGallery
                                     {
                                         if ((string)innerItem.Tag == id)
                                         {
+                                            // Setting SelectedItem normally calls "Navigate". That's unintended here.
+                                            m_blockNavigate = true;
+
                                             group.IsExpanded = true;
                                             item.IsExpanded = true;
                                             NavigationView.SelectedItem = innerItem;
                                             innerItem.IsSelected = true;
+
+                                            m_blockNavigate = false;
                                             return;
                                         }
                                     }

--- a/WinUIGallery/Shaders/CaptureHelper.cs
+++ b/WinUIGallery/Shaders/CaptureHelper.cs
@@ -25,53 +25,7 @@ namespace WinUIGallery.Shaders
 {
     internal static class CaptureHelper
     {
-        public static async Task CaptureTo(this Window window, RenderTargetBitmap renderTarget)
-        {
-            var root = GetRoot(window.Content);
-            await renderTarget.RenderAsync(root);
-        }
-        
-        public static async Task CaptureTo(this UIElement uiElement, RenderTargetBitmap renderTarget)
-        {
-            //var root = GetRoot(uiElement);
-
-            //var dpi = GetDpi(uiElement);
-
-            //await renderTarget.RenderAsync(root, (int)(uiElement.RenderSize.Width * 96.0f / dpi), (int)(uiElement.RenderSize.Height * 96.0f / dpi));
-            await renderTarget.RenderAsync(uiElement);
-        }
-
-        public static async Task<Rect> CaptureTo(this ContentDialog dialog, RenderTargetBitmap renderTarget)
-        {
-            // The dialog is actually a full window element because it darkens the screen
-            // when it appears. Drill in a bit to get to the actual element that contains
-            // what we think of as the "dialog".
-            var child1 = VisualTreeHelper.GetChild(dialog, 0);
-            var child2 = VisualTreeHelper.GetChild(child1, 0);
-            var child3 = VisualTreeHelper.GetChild(child2, 0);
-
-            var dialogContent = child3 as Border;
-            var dpi = GetDpi(dialog) / 96.0f;
-
-            // Get transform from dialog content to the window wide dialog.
-            // This will let us position things later.
-            var transform = dialogContent.TransformToVisual(dialog);
-            Rect originalBounds = new()
-            {
-                X = 0,
-                Y = 0,
-                Width = dialogContent.RenderSize.Width,
-                Height = dialogContent.RenderSize.Height
-            };
-
-            var transformedBounds = transform.TransformBounds(originalBounds);
-
-            await renderTarget.RenderAsync(dialogContent, (int)(transformedBounds.Width / dpi), (int)(transformedBounds.Height / dpi));
-
-            return transformedBounds;
-        }
-
-        public static async Task<CanvasRenderTarget> CaptureTo2(this UIElement element, UIElement scaleElement)
+        public static async Task<CanvasRenderTarget> CaptureElementAsync(UIElement element, UIElement scaleElement = null)
         {
             Visual backingVisual = ElementCompositionPreview.GetElementVisual(element);
             var compositor = backingVisual.Compositor;
@@ -133,7 +87,7 @@ namespace WinUIGallery.Shaders
             return bitmap;
         }
 
-        public static Border GetDialogContent(this ContentDialog dialog)
+        public static Border GetDialogBox(this ContentDialog dialog)
         {
             // The dialog is actually a full window element because it darkens the screen
             // when it appears. Drill in a bit to get to the actual element that contains
@@ -142,8 +96,8 @@ namespace WinUIGallery.Shaders
             var child2 = VisualTreeHelper.GetChild(child1, 0);
             var child3 = VisualTreeHelper.GetChild(child2, 0);
 
-            var dialogContent = child3 as Border;
-            return dialogContent;
+            var dialogBox = child3 as Border;
+            return dialogBox;
         }
 
         public static float GetDpi(UIElement element)
@@ -151,61 +105,13 @@ namespace WinUIGallery.Shaders
             var window = WindowHelper.GetWindowForElement(element);
             if (window == null)
             {
+                // In the short time between the window closing and the process exiting, the window
+                // could be null. Just return a default value here, we're about to exit anyways.
                 return 1.0f;
             }
 
             var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(window);
             return Win32.GetDpiForWindow(hwnd);
-        }
-
-        public static async Task SaveAsBitmapAsync(this RenderTargetBitmap bitmap, Window referenceWindow)
-        {
-            FileSavePicker savePicker = new FileSavePicker();
-            savePicker.SuggestedStartLocation = PickerLocationId.PicturesLibrary;
-            savePicker.FileTypeChoices.Add("Bitmap", new List<string>() { ".bmp" });
-            savePicker.SuggestedFileName = "image";
-
-            var windowNative = WinRT.Interop.WindowNative.GetWindowHandle(referenceWindow);
-            WinRT.Interop.InitializeWithWindow.Initialize(savePicker, windowNative);
-
-            var outputFile = await savePicker.PickSaveFileAsync();
-
-            if (outputFile == null)
-            {
-                return;
-            }
-
-            using (var stream = await outputFile.OpenAsync(Windows.Storage.FileAccessMode.ReadWrite))
-            {
-                BitmapEncoder encoder = await BitmapEncoder.CreateAsync(BitmapEncoder.BmpEncoderId, stream);
-
-                uint width = (uint)bitmap.PixelWidth;
-                uint height = (uint)bitmap.PixelHeight;
-
-                encoder.BitmapTransform.ScaledWidth = width;
-                encoder.BitmapTransform.ScaledHeight = height;
-                encoder.BitmapTransform.InterpolationMode = BitmapInterpolationMode.NearestNeighbor;
-
-                var buffer = await bitmap.GetPixelsAsync();
-
-                var softwareBitmap = SoftwareBitmap.CreateCopyFromBuffer(buffer, BitmapPixelFormat.Bgra8, bitmap.PixelWidth, bitmap.PixelHeight);
-                encoder.SetSoftwareBitmap(softwareBitmap);
-
-                await encoder.FlushAsync();
-            }
-        }
-
-        private static UIElement GetRoot(UIElement element)
-        {
-            UIElement root = element;
-            UIElement parent = VisualTreeHelper.GetParent(root) as UIElement;
-            while (parent != null)
-            {
-                root = parent;
-                parent = VisualTreeHelper.GetParent(root) as UIElement;
-            }
-
-            return root;
         }
     }
 }

--- a/WinUIGallery/Shaders/ShaderPanel.xaml.cs
+++ b/WinUIGallery/Shaders/ShaderPanel.xaml.cs
@@ -86,12 +86,8 @@ namespace WinUIGallery.Shaders
             Renderer.SetSourceBitmap(0, renderTargetBitmap, CanvasDevice, pixelClip);
         }
 
-        public void SetShaderInputAsync(CanvasRenderTarget renderTargetBitmap)
+        public void SetShaderInput(CanvasRenderTarget renderTargetBitmap)
         {
-            // Make our Win2D canvas match exactly the pixels we're drawing
-            //canvasAnimatedControl.Width = renderTargetBitmap.Size.Width;
-            //canvasAnimatedControl.Height = renderTargetBitmap.Size.Height;
-
             // It's ok if CanvasDevice is null here, the function can handle it
             Renderer.SetSourceBitmap(0, renderTargetBitmap, CanvasDevice, null);
         }


### PR DESCRIPTION
This includes:
- Makes what happens if multiple pages are quickly clicked be more reasonable
  - The average case should not hit this
  - If clicking very quickly between two pages, we still play an animation but it targets the last clicked page
  - If clicking before the previous animation is *quite* finished it will still queue up another animation now
- Fixes some crashes and other issues if clicking rapidly (like getting stuck scaled up)
- Deletes a lot of dead code
- Cleans up some logic and naming in the DialogContentPage so that it's nicer to show off