### PR TITLE
Separate XAML and C# code in TitleBar customization example

### DIFF
--- a/WinUIGallery/ControlPages/TitleBarPage.xaml
+++ b/WinUIGallery/ControlPages/TitleBarPage.xaml
@@ -143,7 +143,14 @@
                     </StackPanel>
                 </StackPanel>
             </local:ControlExample.Example>
-
+            <local:ControlExample.Xaml>
+                <x:String xml:space="preserve">
+&lt;!--UIElement set as titlebar--&gt;
+&lt;Border x:Name="AppTitleBar" Grid.Column="1" VerticalAlignment="Top"&gt;
+    &lt;TextBlock x:Name="AppTitle" Text="{StaticResource AppTitleName}" VerticalAlignment="Top" Margin="0,8,0,0" /&gt;
+&lt;/Border&gt;
+            </x:String>
+            </local:ControlExample.Xaml>
         </local:ControlExample>
         <local:ControlExample HeaderText="Titlebar Customizations : Interactive controls in Titlebar (non client) area"
                               CSharpSource="Window\TitleBar\TitleBarSample3.txt">

--- a/WinUIGallery/ControlPagesSampleCode/Window/TitleBar/TitleBarSample1.txt
+++ b/WinUIGallery/ControlPagesSampleCode/Window/TitleBar/TitleBarSample1.txt
@@ -1,9 +1,4 @@
-﻿// UIElement set as titlebar
-<Border x:Name="AppTitleBar" Grid.Column="1" VerticalAlignment="Top">
-    <TextBlock x:Name="AppTitle" Text="{StaticResource AppTitleName}" VerticalAlignment="Top" Margin="0,8,0,0" />
-</Border>
-
-// C# code to set AppTitleBar uielement as titlebar
+﻿// C# code to set AppTitleBar uielement as titlebar
 Window window = App.MainWindow;
 window.ExtendsContentIntoTitleBar = true;  // enable custom titlebar
 window.SetTitleBar(AppTitleBar);      // set user ui element as titlebar


### PR DESCRIPTION
## Description
This pull request Updates the TitleBar customization example by separating the XAML and C# code into distinct Code Presenters, main changes are:
- Adjusted the control example to include separate XAML code in `TitleBarPage.xaml`.
- Updated C# code in `TitleBarSample1.txt` to align with the new implementation.

## Motivation and Context
This simple change enhances readability and avoids confusion.

## How Has This Been Tested?
**Manually tested**

## Screenshots (if appropriate):
Before changes:
![image](https://github.com/user-attachments/assets/da60b99b-b336-4e57-9e93-2cf30aa947ee)

After Changes:
![image](https://github.com/user-attachments/assets/8e921db9-3d2b-45ec-a5b9-9a9595debc92)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
