### PR TITLE
Refactor `SampleCodePresenter` to adjust code presenter visibility handling

### DIFF
--- a/WinUIGallery/Controls/SampleCodePresenter.xaml.cs
+++ b/WinUIGallery/Controls/SampleCodePresenter.xaml.cs
@@ -91,7 +91,6 @@ namespace WinUIGallery.Controls
 
         private void SampleCodePresenter_Loaded(object sender, RoutedEventArgs e)
         {
-            ReevaluateVisibility();
             VisualStateManager.GoToState(this, GetSampleLanguageVisualState(), false);
             if (Substitutions != null)
             {


### PR DESCRIPTION
## Description
Refactored `SampleCodePresenter` to improve code presenter visibility handling and align its behavior with broader application usage patterns, the only change is:
- Updated the `SampleCodePresenter_Loaded` method in `SampleCodePresenter.xaml.cs` to enhance visibility handling for `CodePresenter` by removing logic to collapse code presenter visibility by default.

## Motivation and Context
- The previous implementation collapsed the visibility of `CodePresenter` in scenarios where it was not explicitly needed. This conflicted with scenarios like the `Iconography Page`, where an empty `CodePresenter` is defined and modified dynamically later.
- The responsibility for managing visibility when switching between code presenters (e.g., XAML and C#) already exists in the `ControlExample.HandlePresenterVisibility` method, making redundant visibility management unnecessary within `SampleCodePresenter` in most cases.
- To prevent issues in cases requiring default-loaded `CodePresenter`, its visibility is now set to Visible by default, and changes are applied only when truly needed.

## How Has This Been Tested?
**Manual Testing:**
- Verified CodePresenter visibility remains consistent across pages requiring dynamic updates.
- Tested transitions between XAML and C# in scenarios where `HandlePresenterVisibility()` manages visibility logic.

## Screenshots:
**- Before:** Code presenters collapsed unnecessarily where they defined empty to be modified dynamically later.
![image](https://github.com/user-attachments/assets/07104df3-0bec-426c-b514-8ee821436557)

**- After:** Proper handling of empty code presenters and visibility.
![image](https://github.com/user-attachments/assets/774f966e-3caf-4c95-870c-1f81ce5e99d4)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
