### PR TITLE
Resolve `Iconography Page` issue, improve `Control Example` behavior and `ScrollViewPage` Example

### DIFF
--- a/WinUIGallery/ControlPages/ScrollViewPage.xaml
+++ b/WinUIGallery/ControlPages/ScrollViewPage.xaml
@@ -209,6 +209,7 @@
                     <NumberBox x:Name="nbAnimationDuration"
                         Grid.Row="1" Grid.Column="1"
                         Minimum="1000"
+                        Value="1500"
                         Maximum="5000"
                         SpinButtonPlacementMode="Inline"
                         SmallChange="500"

--- a/WinUIGallery/ControlPages/ScrollViewPage.xaml
+++ b/WinUIGallery/ControlPages/ScrollViewPage.xaml
@@ -209,7 +209,6 @@
                     <NumberBox x:Name="nbAnimationDuration"
                         Grid.Row="1" Grid.Column="1"
                         Minimum="1000"
-                        Value="1500"
                         Maximum="5000"
                         SpinButtonPlacementMode="Inline"
                         SmallChange="500"

--- a/WinUIGallery/ControlPages/ScrollViewPage.xaml.cs
+++ b/WinUIGallery/ControlPages/ScrollViewPage.xaml.cs
@@ -20,7 +20,7 @@ namespace WinUIGallery.ControlPages
 {
     public sealed partial class ScrollViewPage : Page
     {
-        private double prvAnimationDuration;
+        private double prvAnimationDuration = 1500;
 
         public ScrollViewPage()
         {
@@ -48,6 +48,7 @@ namespace WinUIGallery.ControlPages
             };
             nbZoomFactor.NumberFormatter = formatter;
 
+            nbAnimationDuration.Value = prvAnimationDuration;
             Example3.CSharp = Example3.CSharp.Replace("nbAnimationDuration.Value", nbAnimationDuration.Value.ToString());
             prvAnimationDuration = nbAnimationDuration.Value;
 

--- a/WinUIGallery/ControlPages/ScrollViewPage.xaml.cs
+++ b/WinUIGallery/ControlPages/ScrollViewPage.xaml.cs
@@ -11,6 +11,7 @@ using Microsoft.UI.Composition;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Numerics;
 using Windows.Globalization.NumberFormatting;
@@ -20,7 +21,8 @@ namespace WinUIGallery.ControlPages
 {
     public sealed partial class ScrollViewPage : Page
     {
-        private double prvAnimationDuration = 1500;
+        // Cache for storing Example3 C# sample code content
+        private readonly Dictionary<string, string> _example3CodeCache = new();
 
         public ScrollViewPage()
         {
@@ -47,10 +49,6 @@ namespace WinUIGallery.ControlPages
                 NumberRounder = rounder
             };
             nbZoomFactor.NumberFormatter = formatter;
-
-            nbAnimationDuration.Value = prvAnimationDuration;
-            Example3.CSharp = Example3.CSharp.Replace("nbAnimationDuration.Value", nbAnimationDuration.Value.ToString());
-            prvAnimationDuration = nbAnimationDuration.Value;
 
             this.Loaded -= ScrollViewPage_Loaded;
         }
@@ -267,40 +265,55 @@ namespace WinUIGallery.ControlPages
 
         private void cmbVerticalAnimation_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (sender is ComboBox combo)
-            {
-                switch (combo.SelectedIndex)
-                {
-                    case 0:
-                        Example3.CSharp = ReadSampleCodeFileContent("ScrollViewSample3_DefaultAnimation_cs");
-                        break;
-                    case 1:
-                        Example3.CSharp = ReadSampleCodeFileContent("ScrollViewSample3_AccordionAnimation_cs");
-                        break;
-                    case 2:
-                        Example3.CSharp = ReadSampleCodeFileContent("ScrollViewSample3_TeleportationAnimation_cs");
-                        break;
-                }
-        
-                if (nbAnimationDuration != null)
-                {
-                    Example3.CSharp = Example3.CSharp.Replace("nbAnimationDuration.Value", nbAnimationDuration.Value.ToString());
-                }
-        
-                Example3.UpdateLayout();
-            }
+            UpdateExample3Content();
         }
 
         private void nbAnimationDuration_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
         {
-            Example3.CSharp = Example3.CSharp.Replace(prvAnimationDuration.ToString(),nbAnimationDuration.Value.ToString());
-            prvAnimationDuration = nbAnimationDuration.Value;
+            UpdateExample3Content();
         }
 
-        private string ReadSampleCodeFileContent(string sampleCodeFileName)
+        private void UpdateExample3Content()
         {
-            StorageFolder folder = Windows.ApplicationModel.Package.Current.InstalledLocation;
-            return File.ReadAllText($"{folder.Path}\\ControlPagesSampleCode\\ScrollView\\{sampleCodeFileName}.txt");
+            string sampleCodeFileName = null;
+
+            switch (cmbVerticalAnimation.SelectedIndex)
+            {
+                case 0:
+                    sampleCodeFileName = "ScrollViewSample3_DefaultAnimation_cs";
+                    break;
+                case 1:
+                    sampleCodeFileName = "ScrollViewSample3_AccordionAnimation_cs";
+                    break;
+                case 2:
+                    sampleCodeFileName = "ScrollViewSample3_TeleportationAnimation_cs";
+                    break;
+                default:
+                    sampleCodeFileName = null;
+                    break;
+            }
+
+            if (sampleCodeFileName != null)
+            {
+                Example3.CSharp = GetExample3CodeContent(sampleCodeFileName);
+
+                if (nbAnimationDuration != null)
+                {
+                    Example3.CSharp = Example3.CSharp.Replace("nbAnimationDuration.Value", nbAnimationDuration.Value.ToString());
+                }
+            }
+        }
+
+        // Method to get sample code content (with caching)
+        private string GetExample3CodeContent(string sampleCodeFileName)
+        {
+            if (!_example3CodeCache.TryGetValue(sampleCodeFileName, out var content))
+            {
+                var folder = Windows.ApplicationModel.Package.Current.InstalledLocation;
+                content = File.ReadAllText($"{folder.Path}\\ControlPagesSampleCode\\ScrollView\\{sampleCodeFileName}.txt");
+                _example3CodeCache[sampleCodeFileName] = content; // Cache the content
+            }
+            return content;
         }
     }
 }

--- a/WinUIGallery/Controls/ControlExample.xaml
+++ b/WinUIGallery/Controls/ControlExample.xaml
@@ -172,24 +172,28 @@
 
                     <!-- using animations:Implicit... with Grid.Row causes Grid.Row to have no effect, Therefore, the Grid.Row is applied in the grid  -->
                     <Grid x:DefaultBindMode="OneWay" Grid.Row="1">
-                        <controls:SampleCodePresenter
-                            x:Name="XamlPresenter"
-                            Visibility="Collapsed"
-                            Code="{x:Bind Xaml}"
-                            SampleType="XAML"
-                            CodeSourceFile="{x:Bind XamlSource}"
-                            Substitutions="{x:Bind Substitutions}"
-                            animations:Implicit.HideAnimations="{StaticResource HideTransitions}"
-                            animations:Implicit.ShowAnimations="{StaticResource ShowTransitions}"/>
-                        <controls:SampleCodePresenter
-                            x:Name="CSharpPresenter"
-                            Visibility="Collapsed"
-                            Code="{x:Bind CSharp}"
-                            SampleType="CSharp"
-                            CodeSourceFile="{x:Bind CSharpSource}"
-                            Substitutions="{x:Bind Substitutions}"
-                            animations:Implicit.HideAnimations="{StaticResource HideTransitions}"
-                            animations:Implicit.ShowAnimations="{StaticResource ShowTransitions}"/>
+                        <ContentPresenter x:Name="XamlContentPresenter"
+                                          Visibility="Collapsed">
+                            <controls:SampleCodePresenter
+                                x:Name="XamlPresenter"
+                                Code="{x:Bind Xaml}"
+                                SampleType="XAML"
+                                CodeSourceFile="{x:Bind XamlSource}"
+                                Substitutions="{x:Bind Substitutions}"
+                                animations:Implicit.HideAnimations="{StaticResource HideTransitions}"
+                                animations:Implicit.ShowAnimations="{StaticResource ShowTransitions}" />
+                        </ContentPresenter>
+                        <ContentPresenter x:Name="CSharpContentPresenter"
+                                          Visibility="Collapsed">
+                            <controls:SampleCodePresenter
+                                x:Name="CSharpPresenter"
+                                Code="{x:Bind CSharp}"
+                                SampleType="CSharp"
+                                CodeSourceFile="{x:Bind CSharpSource}"
+                                Substitutions="{x:Bind Substitutions}"
+                                animations:Implicit.HideAnimations="{StaticResource HideTransitions}"
+                                animations:Implicit.ShowAnimations="{StaticResource ShowTransitions}" />
+                        </ContentPresenter>
                     </Grid>
                 </Grid>
             </muxc:Expander>

--- a/WinUIGallery/Controls/ControlExample.xaml.cs
+++ b/WinUIGallery/Controls/ControlExample.xaml.cs
@@ -243,13 +243,13 @@ namespace WinUIGallery
             {
                 if (selectedItem.Tag.ToString().Equals("Xaml", StringComparison.OrdinalIgnoreCase))
                 {
-                    XamlPresenter.Visibility = Visibility.Visible;
-                    CSharpPresenter.Visibility = Visibility.Collapsed;
+                    XamlContentPresenter.Visibility = Visibility.Visible;
+                    CSharpContentPresenter.Visibility = Visibility.Collapsed;
                 }
                 else if (selectedItem.Tag.ToString().Equals("CSharp", StringComparison.OrdinalIgnoreCase))
                 {
-                    CSharpPresenter.Visibility = Visibility.Visible;
-                    XamlPresenter.Visibility = Visibility.Collapsed;
+                    CSharpContentPresenter.Visibility = Visibility.Visible;
+                    XamlContentPresenter.Visibility = Visibility.Collapsed;
                 }
             }
         }

--- a/WinUIGallery/Controls/SampleCodePresenter.xaml.cs
+++ b/WinUIGallery/Controls/SampleCodePresenter.xaml.cs
@@ -87,6 +87,10 @@ namespace WinUIGallery.Controls
             {
                 Visibility = Visibility.Collapsed;
             }
+            else
+            {
+                Visibility = Visibility.Visible;
+            }
         }
 
         private void SampleCodePresenter_Loaded(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Description  
This PR reverts changes introduced in #1616 to the `ReevaluateVisibility` method in the `SampleCodePresenter` class. The modifications in #1616 caused unintended side effects, including the issue observed on the icons page. Reverting these changes resolves the problem and restores expected behavior.  

Additionally, this PR includes:  
- **Fix for overlapping issue with `SampleCodePresenter`:** Updates `ControlExample` to use `ContentPresenter` for visibility management, ensuring no overlapping when C# code changed.  
- **Ensure correct C# code sample updates when animation duration changes.**

## Motivation and Context  
Fixing the issue on the icons page caused by unintended side effects of changes in #1616, ensuring proper visibility management for code presenters without affecting other functionality. Additional fixes address overlapping issues and dynamic sample updates to enhance usability.  

## How Has This Been Tested?  
Manually tested:  
- Verified that reverting #1616 changes to the `ReevaluateVisibility` method.  
- Confirmed that overlapping of code presenters is resolved.  
- Ensured the animation duration is correctly updated in the displayed C# code in the ScrollView example.

## Screenshots (if appropriate):  
- **Before reverting:**  
![image](https://github.com/user-attachments/assets/07104df3-0bec-426c-b514-8ee821436557)  
- **After reverting:**  
![image](https://github.com/user-attachments/assets/774f966e-3caf-4c95-870c-1f81ce5e99d4)  

- **Before resolving overlapping issue:**  
![image](https://github.com/user-attachments/assets/3bab318f-fc61-4edc-a840-0853be93db6b)
- **After resolving overlapping issue:**  
![image](https://github.com/user-attachments/assets/a34937dc-bd02-455c-819c-f0a41729d39f)

## Types of changes  
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->  
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [x] Breaking change (fix or feature that would cause existing functionality to change)  