### PR TITLE
Fix: `Color > HighContrast` theme toggle highlight

### DIFF
--- a/WinUIGallery/ControlPages/DesignGuidance/ColorPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/ColorPage.xaml
@@ -6,7 +6,6 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:WinUIGallery.Controls"
-    xmlns:controls1="using:WinUIGallery.DesktopWap.Controls"
     xmlns:core="using:WinUIGallery"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -53,8 +52,6 @@
             <SelectorBarItem Text="Signal" />
             <SelectorBarItem Text="High Contrast" />
         </SelectorBar>
-        <controls1:SampleThemeListener Grid.Row="3">
-            <Frame x:Name="NavigationFrame" />
-        </controls1:SampleThemeListener>
+        <Frame x:Name="NavigationFrame" Grid.Row="3"/>
     </Grid>
 </Page>

--- a/WinUIGallery/Controls/DesignGuidance/ColorSections/BackgroundSection.xaml
+++ b/WinUIGallery/Controls/DesignGuidance/ColorSections/BackgroundSection.xaml
@@ -7,415 +7,417 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:designguidance="using:WinUIGallery.DesktopWap.Controls.DesignGuidance"
+    xmlns:wdc="using:WinUIGallery.DesktopWap.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
+    <wdc:SampleThemeListener>        
+        <StackPanel Spacing="{StaticResource ColorSectionSpacing}">
 
-    <StackPanel Spacing="{StaticResource ColorSectionSpacing}">
-
-        <!--  Card Background  -->
-        <designguidance:ColorPageExample
-            Title="Card Background"
-            Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
-            Description="Used to create 'cards' - content blocks that live on page and layer backgrounds.">
-            <Border
-                Width="60"
-                Height="30"
-                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                BorderThickness="1"
-                CornerRadius="{StaticResource ControlCornerRadius}" />
-        </designguidance:ColorPageExample>
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <designguidance:ColorTile
-                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                ColorBrushName="CardBackgroundFillColorDefaultBrush"
-                ColorExplanation="Default card color"
-                ColorName="Card Background / Default"
-                ColorValue="#FFFFFF (B3, 70%)" />
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
-                ColorBrushName="CardBackgroundFillColorSecondaryBrush"
-                ColorExplanation="Alternate card color: slightly darker"
-                ColorName="Card Background / Secondary"
-                ColorValue="#F6F6F6 (80, 50%)" />
-            <designguidance:ColorTile
-                Grid.Column="2"
-                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                ColorBrushName="CardBackgroundTertiaryBrush"
-                ColorExplanation="Default card hover and pressed color"
-                ColorName="Card Background / Tertiary"
-                ColorValue="#FFFFFF (FF, 30%)"
-                ShowSeparator="False"
-                ShowWarning="True" />
-        </Grid>
+            <!--  Card Background  -->
+            <designguidance:ColorPageExample
+                Title="Card Background"
+                Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
+                Description="Used to create 'cards' - content blocks that live on page and layer backgrounds.">
+                <Border
+                    Width="60"
+                    Height="30"
+                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="{StaticResource ControlCornerRadius}" />
+            </designguidance:ColorPageExample>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <designguidance:ColorTile
+                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    ColorBrushName="CardBackgroundFillColorDefaultBrush"
+                    ColorExplanation="Default card color"
+                    ColorName="Card Background / Default"
+                    ColorValue="#FFFFFF (B3, 70%)" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
+                    ColorBrushName="CardBackgroundFillColorSecondaryBrush"
+                    ColorExplanation="Alternate card color: slightly darker"
+                    ColorName="Card Background / Secondary"
+                    ColorValue="#F6F6F6 (80, 50%)" />
+                <designguidance:ColorTile
+                    Grid.Column="2"
+                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    ColorBrushName="CardBackgroundTertiaryBrush"
+                    ColorExplanation="Default card hover and pressed color"
+                    ColorName="Card Background / Tertiary"
+                    ColorValue="#FFFFFF (FF, 30%)"
+                    ShowSeparator="False"
+                    ShowWarning="True" />
+            </Grid>
 
 
-        <!--  Smoke Background  -->
-        <designguidance:ColorPageExample
-            Title="Smoke Background"
-            Background="{ThemeResource SmokeFillColorDefaultBrush}"
-            Description="Used over windows and desktop to block them out as inaccessible.">
-            <Grid
-                Width="120"
-                Height="40"
-                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                BorderThickness="1"
-                CornerRadius="{StaticResource OverlayCornerRadius}" />
-        </designguidance:ColorPageExample>
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <designguidance:ColorTile
+            <!--  Smoke Background  -->
+            <designguidance:ColorPageExample
+                Title="Smoke Background"
                 Background="{ThemeResource SmokeFillColorDefaultBrush}"
-                ColorBrushName="SmokeFillColorDefaultBrush"
-                ColorExplanation="Dims the background behind dialogs"
-                ColorName="Smoke / Default"
-                ColorValue="#000000 (4D, 30%) " />
-        </Grid>
-
-
-        <!--  Layer  -->
-
-        <designguidance:ColorPageExample
-            Title="Layer"
-            Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
-            Description="Used on background colors of any material to create layering.">
-            <Grid
-                Width="120"
-                Height="40"
-                Background="{ThemeResource AcrylicBackgroundFillColorBaseBrush}"
-                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                BorderThickness="1"
-                CornerRadius="{StaticResource OverlayCornerRadius}">
+                Description="Used over windows and desktop to block them out as inaccessible.">
                 <Grid
-                    Width="90"
-                    HorizontalAlignment="Right"
+                    Width="120"
+                    Height="40"
+                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="{StaticResource OverlayCornerRadius}" />
+            </designguidance:ColorPageExample>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <designguidance:ColorTile
+                    Background="{ThemeResource SmokeFillColorDefaultBrush}"
+                    ColorBrushName="SmokeFillColorDefaultBrush"
+                    ColorExplanation="Dims the background behind dialogs"
+                    ColorName="Smoke / Default"
+                    ColorValue="#000000 (4D, 30%) " />
+            </Grid>
+
+
+            <!--  Layer  -->
+
+            <designguidance:ColorPageExample
+                Title="Layer"
+                Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
+                Description="Used on background colors of any material to create layering.">
+                <Grid
+                    Width="120"
+                    Height="40"
+                    Background="{ThemeResource AcrylicBackgroundFillColorBaseBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="{StaticResource OverlayCornerRadius}">
+                    <Grid
+                        Width="90"
+                        HorizontalAlignment="Right"
+                        Background="{ThemeResource LayerFillColorDefaultBrush}"
+                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                        BorderThickness="1,0,0,0" />
+                </Grid>
+            </designguidance:ColorPageExample>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <designguidance:ColorTile
                     Background="{ThemeResource LayerFillColorDefaultBrush}"
-                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                    BorderThickness="1,0,0,0" />
+                    ColorBrushName="LayerFillColorDefaultBrush"
+                    ColorExplanation="Content layer color"
+                    ColorName="Layer / Default"
+                    ColorValue="#FFFFFF (80, 50%)" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="{ThemeResource LayerFillColorAltBrush}"
+                    ColorBrushName="LayerFillColorAltBrush"
+                    ColorExplanation="Alternate content layer color"
+                    ColorName="Layer / Alt"
+                    ColorValue="#FFFFFF (FF, 100%)"
+                    ShowSeparator="False" />
             </Grid>
-        </designguidance:ColorPageExample>
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <designguidance:ColorTile
-                Background="{ThemeResource LayerFillColorDefaultBrush}"
-                ColorBrushName="LayerFillColorDefaultBrush"
-                ColorExplanation="Content layer color"
-                ColorName="Layer / Default"
-                ColorValue="#FFFFFF (80, 50%)" />
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="{ThemeResource LayerFillColorAltBrush}"
-                ColorBrushName="LayerFillColorAltBrush"
-                ColorExplanation="Alternate content layer color"
-                ColorName="Layer / Alt"
-                ColorValue="#FFFFFF (FF, 100%)"
-                ShowSeparator="False" />
-        </Grid>
 
-        <!--  Layer on Acrylic  -->
-        <designguidance:ColorPageExample
-            Title="Layer on Acrylic"
-            Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
-            Description="Used on background colors of any material to create layering.">
-            <Grid
-                Width="120"
-                Height="40"
-                Background="{ThemeResource AcrylicBackgroundFillColorBaseBrush}"
-                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                BorderThickness="1"
-                CornerRadius="{StaticResource OverlayCornerRadius}">
+            <!--  Layer on Acrylic  -->
+            <designguidance:ColorPageExample
+                Title="Layer on Acrylic"
+                Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
+                Description="Used on background colors of any material to create layering.">
                 <Grid
-                    Width="90"
-                    HorizontalAlignment="Right"
-                    Background="{ThemeResource LayerOnAcrylicFillColorDefaultBrush}"
+                    Width="120"
+                    Height="40"
+                    Background="{ThemeResource AcrylicBackgroundFillColorBaseBrush}"
                     BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                    BorderThickness="1,0,0,0" />
+                    BorderThickness="1"
+                    CornerRadius="{StaticResource OverlayCornerRadius}">
+                    <Grid
+                        Width="90"
+                        HorizontalAlignment="Right"
+                        Background="{ThemeResource LayerOnAcrylicFillColorDefaultBrush}"
+                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                        BorderThickness="1,0,0,0" />
+                </Grid>
+            </designguidance:ColorPageExample>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <designguidance:ColorTile
+                    Background="{ThemeResource LayerOnAcrylicFillColorDefaultBrush}"
+                    ColorBrushName="LayerOnAcrylicFillColorDefaultBrush"
+                    ColorExplanation="Content layer color on acrylic surfaces"
+                    ColorName="Layer On Acrylic / Default"
+                    ColorValue="#FFFFFF (40, 25%)"
+                    ShowSeparator="False" />
             </Grid>
-        </designguidance:ColorPageExample>
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <designguidance:ColorTile
-                Background="{ThemeResource LayerOnAcrylicFillColorDefaultBrush}"
-                ColorBrushName="LayerOnAcrylicFillColorDefaultBrush"
-                ColorExplanation="Content layer color on acrylic surfaces"
-                ColorName="Layer On Acrylic / Default"
-                ColorValue="#FFFFFF (40, 25%)"
-                ShowSeparator="False" />
-        </Grid>
 
-        <!--  Layer on Mica Base Alt  -->
-        <designguidance:ColorPageExample
-            Title="Layer on Mica Base Alt"
-            Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
-            Description="Used for fills on Tab control.">
-            <TabViewItem
-                Width="150"
-                Height="30"
-                BorderBrush="{ThemeResource ControlStrokeColorSecondaryBrush}"
-                BorderThickness="1"
-                Header="Text" />
-        </designguidance:ColorPageExample>
-
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-
-            <designguidance:ColorTile
-                Background="{ThemeResource LayerOnMicaBaseAltFillColorDefaultBrush}"
-                ColorBrushName="LayerOnMicaBaseAltFillColorDefaultBrush"
-                ColorExplanation="Active Tab Rest, Content layer"
-                ColorName="Layer On Mica Base Alt / Default"
-                ColorValue="#FFFFFF (B3, 70%)"
-                Foreground="{ThemeResource TextFillColorPrimary}" />
-
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="{ThemeResource LayerOnMicaBaseAltFillColorTertiaryBrush}"
-                ColorBrushName="LayerOnMicaBaseAltFillColorTertiaryBrush"
-                ColorExplanation="Active Tab Drag"
-                ColorName="Layer On Mica Base Alt / Tertiary"
-                ColorValue="#F9F9F9 (FF, 100%)"
-                Foreground="{ThemeResource TextFillColorPrimary}" />
-
-        </Grid>
-
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <designguidance:ColorTile
-                Background="{ThemeResource LayerOnMicaBaseAltFillColorTransparentBrush}"
-                ColorBrushName="LayerOnMicaBaseAltFillColorTransparentBrush"
-                ColorExplanation="Inactive Tab Rest"
-                ColorName="Layer On Mica Base Alt / Transparent"
-                ColorValue="Transparent"
-                Foreground="{ThemeResource TextFillColorPrimary}"
-                ShowSeparator="False" />
-
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="{ThemeResource LayerOnMicaBaseAltFillColorSecondaryBrush}"
-                ColorBrushName="LayerOnMicaBaseAltFillColorSecondaryBrush"
-                ColorExplanation="Inactive Tab Hover"
-                ColorName="Layer On Mica Base Alt / Secondary"
-                ColorValue="#000000 (0A, 3.73%)"
-                Foreground="{ThemeResource TextFillColorPrimary}"
-                ShowSeparator="False" />
-        </Grid>
-
-        <!--  Solid background  -->
-        <designguidance:ColorPageExample
-            Title="Solid Background"
-            Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
-            Description="Solid background colors to place layers, cards or controls on.">
-            <Border
-                Width="120"
-                Height="40"
-                Background="{ThemeResource GalleryBackgroundBrush}"
-                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                BorderThickness="1"
-                CornerRadius="{StaticResource ControlCornerRadius}" />
-        </designguidance:ColorPageExample>
-
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-
-            <designguidance:ColorTile
-                Background="{ThemeResource SolidBackgroundFillColorBaseBrush}"
-                ColorBrushName="SolidBackgroundFillColorBaseBrush"
-                ColorExplanation="Used for the bottom most layer of an experience."
-                ColorName="Solid Background / Base"
-                ColorValue="#F3F3F (FF, 100%)"
-                Foreground="{ThemeResource TextFillColorPrimary}" />
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="{ThemeResource SolidBackgroundFillColorBaseAltBrush}"
-                ColorBrushName="SolidBackgroundFillColorBaseAltBrush"
-                ColorExplanation="Used for the bottom most layer of an experience."
-                ColorName="Solid Background / Base Alt"
-                ColorValue="#DADADA (FF, 100%)"
-                Foreground="{ThemeResource TextFillColorPrimary}" />
-            <designguidance:ColorTile
-                Grid.Column="2"
-                Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}"
-                ColorBrushName="SolidBackgroundFillColorSecondaryBrush"
-                ColorExplanation="Alternate base color for those who need a darker background color."
-                ColorName="Solid Background / Secondary"
-                ColorValue="#EEEEEE (FF, 100%)"
-                Foreground="{ThemeResource TextFillColorPrimary}" />
-            <designguidance:ColorTile
-                Grid.Column="3"
-                Background="{ThemeResource SolidBackgroundFillColorTertiaryBrush}"
-                ColorBrushName="SolidBackgroundFillColorTertiaryBrush"
-                ColorExplanation="Content layer color"
-                ColorName="Solid Background / Tertiary"
-                ColorValue="#F9F9F9 (FF, 100%)"
-                Foreground="{ThemeResource TextFillColorPrimary}"
-                ShowSeparator="False" />
-        </Grid>
-
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-
-            <designguidance:ColorTile
+            <!--  Layer on Mica Base Alt  -->
+            <designguidance:ColorPageExample
+                Title="Layer on Mica Base Alt"
                 Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
-                ColorBrushName="SolidBackgroundFillColorQuarternaryBrush"
-                ColorExplanation="Alt content layer color."
-                ColorName="Solid Background / Quarternary"
-                ColorValue="#FFFFFF (FF, 100%)"
-                Foreground="{ThemeResource TextFillColorPrimary}" />
-            <designguidance:ColorTile
-                Grid.Column="1"
+                Description="Used for fills on Tab control.">
+                <TabViewItem
+                    Width="150"
+                    Height="30"
+                    BorderBrush="{ThemeResource ControlStrokeColorSecondaryBrush}"
+                    BorderThickness="1"
+                    Header="Text" />
+            </designguidance:ColorPageExample>
+
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <designguidance:ColorTile
+                    Background="{ThemeResource LayerOnMicaBaseAltFillColorDefaultBrush}"
+                    ColorBrushName="LayerOnMicaBaseAltFillColorDefaultBrush"
+                    ColorExplanation="Active Tab Rest, Content layer"
+                    ColorName="Layer On Mica Base Alt / Default"
+                    ColorValue="#FFFFFF (B3, 70%)"
+                    Foreground="{ThemeResource TextFillColorPrimary}" />
+
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="{ThemeResource LayerOnMicaBaseAltFillColorTertiaryBrush}"
+                    ColorBrushName="LayerOnMicaBaseAltFillColorTertiaryBrush"
+                    ColorExplanation="Active Tab Drag"
+                    ColorName="Layer On Mica Base Alt / Tertiary"
+                    ColorValue="#F9F9F9 (FF, 100%)"
+                    Foreground="{ThemeResource TextFillColorPrimary}" />
+
+            </Grid>
+
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <designguidance:ColorTile
+                    Background="{ThemeResource LayerOnMicaBaseAltFillColorTransparentBrush}"
+                    ColorBrushName="LayerOnMicaBaseAltFillColorTransparentBrush"
+                    ColorExplanation="Inactive Tab Rest"
+                    ColorName="Layer On Mica Base Alt / Transparent"
+                    ColorValue="Transparent"
+                    Foreground="{ThemeResource TextFillColorPrimary}"
+                    ShowSeparator="False" />
+
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="{ThemeResource LayerOnMicaBaseAltFillColorSecondaryBrush}"
+                    ColorBrushName="LayerOnMicaBaseAltFillColorSecondaryBrush"
+                    ColorExplanation="Inactive Tab Hover"
+                    ColorName="Layer On Mica Base Alt / Secondary"
+                    ColorValue="#000000 (0A, 3.73%)"
+                    Foreground="{ThemeResource TextFillColorPrimary}"
+                    ShowSeparator="False" />
+            </Grid>
+
+            <!--  Solid background  -->
+            <designguidance:ColorPageExample
+                Title="Solid Background"
                 Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
-                ColorBrushName="SolidBackgroundFillColorQuinaryBrush"
-                ColorExplanation="Used for solid default card colors"
-                ColorName="Solid Background / Quinary"
-                ColorValue="#FDFDFD (FF, 100%)"
-                Foreground="{ThemeResource TextFillColorPrimary}"
-                ShowWarning="True" />
-            <designguidance:ColorTile
-                Grid.Column="2"
+                Description="Solid background colors to place layers, cards or controls on.">
+                <Border
+                    Width="120"
+                    Height="40"
+                    Background="{ThemeResource GalleryBackgroundBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="{StaticResource ControlCornerRadius}" />
+            </designguidance:ColorPageExample>
+
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <designguidance:ColorTile
+                    Background="{ThemeResource SolidBackgroundFillColorBaseBrush}"
+                    ColorBrushName="SolidBackgroundFillColorBaseBrush"
+                    ColorExplanation="Used for the bottom most layer of an experience."
+                    ColorName="Solid Background / Base"
+                    ColorValue="#F3F3F (FF, 100%)"
+                    Foreground="{ThemeResource TextFillColorPrimary}" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="{ThemeResource SolidBackgroundFillColorBaseAltBrush}"
+                    ColorBrushName="SolidBackgroundFillColorBaseAltBrush"
+                    ColorExplanation="Used for the bottom most layer of an experience."
+                    ColorName="Solid Background / Base Alt"
+                    ColorValue="#DADADA (FF, 100%)"
+                    Foreground="{ThemeResource TextFillColorPrimary}" />
+                <designguidance:ColorTile
+                    Grid.Column="2"
+                    Background="{ThemeResource SolidBackgroundFillColorSecondaryBrush}"
+                    ColorBrushName="SolidBackgroundFillColorSecondaryBrush"
+                    ColorExplanation="Alternate base color for those who need a darker background color."
+                    ColorName="Solid Background / Secondary"
+                    ColorValue="#EEEEEE (FF, 100%)"
+                    Foreground="{ThemeResource TextFillColorPrimary}" />
+                <designguidance:ColorTile
+                    Grid.Column="3"
+                    Background="{ThemeResource SolidBackgroundFillColorTertiaryBrush}"
+                    ColorBrushName="SolidBackgroundFillColorTertiaryBrush"
+                    ColorExplanation="Content layer color"
+                    ColorName="Solid Background / Tertiary"
+                    ColorValue="#F9F9F9 (FF, 100%)"
+                    Foreground="{ThemeResource TextFillColorPrimary}"
+                    ShowSeparator="False" />
+            </Grid>
+
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <designguidance:ColorTile
+                    Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
+                    ColorBrushName="SolidBackgroundFillColorQuarternaryBrush"
+                    ColorExplanation="Alt content layer color."
+                    ColorName="Solid Background / Quarternary"
+                    ColorValue="#FFFFFF (FF, 100%)"
+                    Foreground="{ThemeResource TextFillColorPrimary}" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
+                    ColorBrushName="SolidBackgroundFillColorQuinaryBrush"
+                    ColorExplanation="Used for solid default card colors"
+                    ColorName="Solid Background / Quinary"
+                    ColorValue="#FDFDFD (FF, 100%)"
+                    Foreground="{ThemeResource TextFillColorPrimary}"
+                    ShowWarning="True" />
+                <designguidance:ColorTile
+                    Grid.Column="2"
+                    Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
+                    ColorBrushName="SolidBackgroundFillColorSenaryBrush"
+                    ColorExplanation="Used for solid default card color"
+                    ColorName="Solid Background / Senary"
+                    ColorValue="#FFFFFF (FF, 100%)"
+                    Foreground="{ThemeResource TextFillColorPrimary}"
+                    ShowSeparator="False"
+                    ShowWarning="True" />
+            </Grid>
+
+
+            <!--  Mica background  -->
+            <designguidance:ColorPageExample
+                Title="Mica Background"
                 Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
-                ColorBrushName="SolidBackgroundFillColorSenaryBrush"
-                ColorExplanation="Used for solid default card color"
-                ColorName="Solid Background / Senary"
-                ColorValue="#FFFFFF (FF, 100%)"
-                Foreground="{ThemeResource TextFillColorPrimary}"
-                ShowSeparator="False"
-                ShowWarning="True" />
-        </Grid>
+                Description="Mica background colors to place layers, cards, or controls on.">
+                <Grid
+                    Width="120"
+                    Height="40"
+                    Background="{ThemeResource AcrylicBackgroundFillColorBaseBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="{StaticResource OverlayCornerRadius}" />
+            </designguidance:ColorPageExample>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <designguidance:ColorTile
+                    Background="{ThemeResource LayerOnAcrylicFillColorDefaultBrush}"
+                    ColorBrushName="MicaBackgroundFillColorBaseBrush"
+                    ColorExplanation="Used for the bottom most layer of an experience."
+                    ColorName="Mica Background / Base"
+                    ShowWarning="True" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="{ThemeResource LayerOnAcrylicFillColorDefaultBrush}"
+                    ColorBrushName="MicaBackgroundFillColorBaseAltBrush"
+                    ColorExplanation="Default tab band background color."
+                    ColorName="Mica Background / Base Alt"
+                    ShowSeparator="False"
+                    ShowWarning="True" />
+            </Grid>
 
+            <!--  Acrylic background  -->
+            <designguidance:ColorPageExample
+                Title="Acrylic Background"
+                Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
+                Description="Acrylic background colors to place layers, cards, or controls on.">
+                <Grid
+                    Width="120"
+                    Height="40"
+                    Background="{ThemeResource AcrylicBackgroundFillColorBaseBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="{StaticResource OverlayCornerRadius}" />
+            </designguidance:ColorPageExample>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <designguidance:ColorTile
+                    Background="{ThemeResource AcrylicBackgroundFillColorBaseBrush}"
+                    ColorBrushName="AcrylicBackgroundFillColorBaseBrush"
+                    ColorExplanation="Used for the bottom most layer of an acrylic surface only when the surface will use layers."
+                    ColorName="Acrylic Background / Base"
+                    ColorValue="#F3F3F3 (FF, 100%), 0% Tint Opacity, 90% Luminosity Opacity Fallback: #EEEEEE (FF, 100%)"
+                    ShowSeparator="True" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="{ThemeResource AcrylicBackgroundFillColorDefaultBrush}"
+                    ColorBrushName="AcrylicBackgroundFillColorDefaultBrush"
+                    ColorExplanation="Default acrylic recipe used for control flyouts and surfaces that live with in the context of an app."
+                    ColorName="Acrylic Background / Default"
+                    ColorValue="#FCFCFC (FF, 100%), 0% Tint Opacity, 85% Luminosity Opacity Fallback: #F9F9F9 (FF, 100%)"
+                    ShowSeparator="False" />
+            </Grid>
 
-        <!--  Mica background  -->
-        <designguidance:ColorPageExample
-            Title="Mica Background"
-            Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
-            Description="Mica background colors to place layers, cards, or controls on.">
-            <Grid
-                Width="120"
-                Height="40"
-                Background="{ThemeResource AcrylicBackgroundFillColorBaseBrush}"
-                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                BorderThickness="1"
-                CornerRadius="{StaticResource OverlayCornerRadius}" />
-        </designguidance:ColorPageExample>
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <designguidance:ColorTile
-                Background="{ThemeResource LayerOnAcrylicFillColorDefaultBrush}"
-                ColorBrushName="MicaBackgroundFillColorBaseBrush"
-                ColorExplanation="Used for the bottom most layer of an experience."
-                ColorName="Mica Background / Base"
-                ShowWarning="True" />
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="{ThemeResource LayerOnAcrylicFillColorDefaultBrush}"
-                ColorBrushName="MicaBackgroundFillColorBaseAltBrush"
-                ColorExplanation="Default tab band background color."
-                ColorName="Mica Background / Base Alt"
-                ShowSeparator="False"
-                ShowWarning="True" />
-        </Grid>
+            <!--  Accent Acrylic background  -->
+            <designguidance:ColorPageExample
+                Title="Accent Acrylic Background"
+                Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
+                Description="Acrylic background colors to place layers, cards, or controls on.">
+                <Grid
+                    Width="120"
+                    Height="40"
+                    Background="{ThemeResource AccentAcrylicBackgroundFillColorBaseBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="{StaticResource OverlayCornerRadius}" />
+            </designguidance:ColorPageExample>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <designguidance:ColorTile
+                    Background="{ThemeResource AccentAcrylicBackgroundFillColorBaseBrush}"
+                    ColorBrushName="AccentAcrylicBackgroundFillColorBaseBrush"
+                    ColorExplanation="Used for the bottom most layer of an acrylic surface only when the surface will use layers."
+                    ColorName="Accent Acrylic Background / Base"
+                    ColorValue="Light 3, 80% Tint Opacity, 80% Luminosity Opacity Fallback: Light 3"
+                    ShowSeparator="True" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="{ThemeResource AccentAcrylicBackgroundFillColorDefaultBrush}"
+                    ColorBrushName="AccentAcrylicBackgroundFillColorDefaultBrush"
+                    ColorExplanation="Default acrylic recipe used for control flyouts and surfaces that live with in the context of an app."
+                    ColorName="Accent Acrylic Background / Default"
+                    ColorValue="Light 3, 80% Tint Opacity, 90% Luminosity Opacity Fallback: Light 3"
+                    ShowSeparator="False" />
+            </Grid>
 
-        <!--  Acrylic background  -->
-        <designguidance:ColorPageExample
-            Title="Acrylic Background"
-            Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
-            Description="Acrylic background colors to place layers, cards, or controls on.">
-            <Grid
-                Width="120"
-                Height="40"
-                Background="{ThemeResource AcrylicBackgroundFillColorBaseBrush}"
-                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                BorderThickness="1"
-                CornerRadius="{StaticResource OverlayCornerRadius}" />
-        </designguidance:ColorPageExample>
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <designguidance:ColorTile
-                Background="{ThemeResource AcrylicBackgroundFillColorBaseBrush}"
-                ColorBrushName="AcrylicBackgroundFillColorBaseBrush"
-                ColorExplanation="Used for the bottom most layer of an acrylic surface only when the surface will use layers."
-                ColorName="Acrylic Background / Base"
-                ColorValue="#F3F3F3 (FF, 100%), 0% Tint Opacity, 90% Luminosity Opacity Fallback: #EEEEEE (FF, 100%)"
-                ShowSeparator="True" />
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="{ThemeResource AcrylicBackgroundFillColorDefaultBrush}"
-                ColorBrushName="AcrylicBackgroundFillColorDefaultBrush"
-                ColorExplanation="Default acrylic recipe used for control flyouts and surfaces that live with in the context of an app."
-                ColorName="Acrylic Background / Default"
-                ColorValue="#FCFCFC (FF, 100%), 0% Tint Opacity, 85% Luminosity Opacity Fallback: #F9F9F9 (FF, 100%)"
-                ShowSeparator="False" />
-        </Grid>
-
-        <!--  Accent Acrylic background  -->
-        <designguidance:ColorPageExample
-            Title="Accent Acrylic Background"
-            Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
-            Description="Acrylic background colors to place layers, cards, or controls on.">
-            <Grid
-                Width="120"
-                Height="40"
-                Background="{ThemeResource AccentAcrylicBackgroundFillColorBaseBrush}"
-                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                BorderThickness="1"
-                CornerRadius="{StaticResource OverlayCornerRadius}" />
-        </designguidance:ColorPageExample>
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <designguidance:ColorTile
-                Background="{ThemeResource AccentAcrylicBackgroundFillColorBaseBrush}"
-                ColorBrushName="AccentAcrylicBackgroundFillColorBaseBrush"
-                ColorExplanation="Used for the bottom most layer of an acrylic surface only when the surface will use layers."
-                ColorName="Accent Acrylic Background / Base"
-                ColorValue="Light 3, 80% Tint Opacity, 80% Luminosity Opacity Fallback: Light 3"
-                ShowSeparator="True" />
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="{ThemeResource AccentAcrylicBackgroundFillColorDefaultBrush}"
-                ColorBrushName="AccentAcrylicBackgroundFillColorDefaultBrush"
-                ColorExplanation="Default acrylic recipe used for control flyouts and surfaces that live with in the context of an app."
-                ColorName="Accent Acrylic Background / Default"
-                ColorValue="Light 3, 80% Tint Opacity, 90% Luminosity Opacity Fallback: Light 3"
-                ShowSeparator="False" />
-        </Grid>
-
-    </StackPanel>
+        </StackPanel>
+    </wdc:SampleThemeListener>
 </Page>

--- a/WinUIGallery/Controls/DesignGuidance/ColorSections/FillSection.xaml
+++ b/WinUIGallery/Controls/DesignGuidance/ColorSections/FillSection.xaml
@@ -7,397 +7,400 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:designguidance="using:WinUIGallery.DesktopWap.Controls.DesignGuidance"
+    xmlns:wdc="using:WinUIGallery.DesktopWap.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <StackPanel Spacing="{StaticResource ColorSectionSpacing}">
+    <wdc:SampleThemeListener>
+        <StackPanel Spacing="{StaticResource ColorSectionSpacing}">
 
-        <!--  Control Fill  -->
-        <designguidance:ColorPageExample
-            Title="Control Fill"
-            Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
-            Description="Fill used for standard controls">
-            <Button Content="Text" />
-        </designguidance:ColorPageExample>
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <designguidance:ColorTile
-                Background="{ThemeResource ControlFillColorDefaultBrush}"
-                ColorBrushName="ControlFillColorDefaultBrush"
-                ColorExplanation="Rest"
-                ColorName="Control / Default"
-                ColorValue="#FFFFFF (B3, 70%)" />
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="{ThemeResource ControlFillColorSecondaryBrush}"
-                ColorBrushName="ControlFillColorSecondaryBrush"
-                ColorExplanation="Hover"
-                ColorName="Control / Secondary"
-                ColorValue="#F9F9F9 (50, 50%)" />
-            <designguidance:ColorTile
-                Grid.Column="2"
-                Background="{ThemeResource ControlFillColorTertiaryBrush}"
-                ColorBrushName="ControlFillColorTertiaryBrush"
-                ColorExplanation="Pressed"
-                ColorName="Control / Tertiary"
-                ColorValue="#F9F9F9 (4D, 30%)" />
-            <designguidance:ColorTile
-                Grid.Column="3"
-                Background="{ThemeResource ControlFillColorTertiaryBrush}"
-                ColorBrushName="ControlFillColorQuarternaryBrush"
-                ColorExplanation="Rest (Pill Button control)"
-                ColorName="Control / Quartenary"
-                ColorValue="#F9F9F9 (C2, 30%)"
-                ShowSeparator="False"
-                ShowWarning="True" />
-        </Grid>
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <designguidance:ColorTile
-                Grid.Column="0"
-                Background="{ThemeResource ControlFillColorDisabledBrush}"
-                ColorBrushName="ControlFillColorDisabledBrush"
-                ColorExplanation="Disabled"
-                ColorName="Control / Disabled"
-                ColorValue="#F3F3F3 (FD, 30%)" />
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="{ThemeResource ControlFillColorTransparentBrush}"
-                ColorBrushName="ControlFillColorTransparentBrush"
-                ColorExplanation="Rest"
-                ColorName="Control / Transparent"
-                ColorValue="#FFFFFF (00, 0%)" />
-            <designguidance:ColorTile
-                Grid.Column="2"
-                Background="{ThemeResource ControlFillColorInputActiveBrush}"
-                ColorBrushName="ControlFillColorInputActiveBrush"
-                ColorExplanation="Active/focused text input fields"
-                ColorName="Control / Input Active"
-                ColorValue="#FFFFFF (FF, 100%)"
-                ShowSeparator="False" />
-        </Grid>
-
-
-        <!--  Control Alt Fill  -->
-        <designguidance:ColorPageExample
-            Title="Control Alt Fill"
-            Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
-            Description="Fill used for the 'off' states of toggle controls">
-            <ToggleSwitch OffContent="" OnContent="" />
-        </designguidance:ColorPageExample>
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <designguidance:ColorTile
-                Background="{ThemeResource ControlAltFillColorTransparentBrush}"
-                ColorBrushName="ControlAltFillColorTransparentBrush"
-                ColorName="Control Alt / Transparent"
-                ColorValue="#FFFFFF (00, 0%)" />
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="{ThemeResource ControlAltFillColorSecondaryBrush}"
-                ColorBrushName="ControlAltFillColorSecondaryBrush"
-                ColorExplanation="Rest"
-                ColorName="Control Alt / Secondary"
-                ColorValue="#000000 (06, 2.41%)" />
-            <designguidance:ColorTile
-                Grid.Column="2"
-                Background="{ThemeResource ControlAltFillColorTertiaryBrush}"
-                ColorBrushName="ControlAltFillColorTertiaryBrush"
-                ColorExplanation="Hover"
-                ColorName="Control Alt / Tertiary"
-                ColorValue="#000000 (0F, 5.78%)"
-                ShowSeparator="False" />
-        </Grid>
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <designguidance:ColorTile
-                Background="{ThemeResource ControlAltFillColorQuarternaryBrush}"
-                ColorBrushName="ControlAltFillColorQuarternaryBrush"
-                ColorExplanation="Pressed"
-                ColorName="Control Alt / Quarternary"
-                ColorValue="#000000 (12, 6.58%)" />
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="{ThemeResource ControlAltFillColorDisabledBrush}"
-                ColorBrushName="ControlAltFillColorDisabledBrush"
-                ColorExplanation="Disabled"
-                ColorName="Control Alt / Disabled"
-                ColorValue="#FFFFFF (00, 0%)"
-                ShowSeparator="False" />
-        </Grid>
-
-        <!--  Neutral Solid  -->
-        <designguidance:ColorPageExample
-            Title="Neutral Solid"
-            Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
-            Description="Fills used for Sliders thumb control to cover the track beneath it.">
-            <Slider
-                MinWidth="240"
-                Maximum="100"
-                Value="40" />
-        </designguidance:ColorPageExample>
-
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-
-            <designguidance:ColorTile
-                Background="{ThemeResource ControlSolidFillColorDefaultBrush}"
-                ColorBrushName="ControlSolidFillColorDefaultBrush"
-                ColorExplanation="Rest"
-                ColorName="Control Solid / Default"
-                ColorValue="#FFFFFF (FF, 100%)"
-                ShowSeparator="False" />
-        </Grid>
-
-        <!--  Neutral Strong  -->
-        <designguidance:ColorPageExample
-            Title="Neutral Strong"
-            Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
-            Description="Used for controls that must meet contrast ratio requirements of 3:1.">
-            <ScrollBar
-                Width="200"
-                Height="20"
-                IndicatorMode="MouseIndicator"
-                Orientation="Horizontal"
-                Visibility="Visible" />
-        </designguidance:ColorPageExample>
-
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-
-            <designguidance:ColorTile
-                Background="{ThemeResource ControlStrongFillColorDefaultBrush}"
-                ColorBrushName="ControlStrongFillColorDefaultBrush"
-                ColorExplanation="Rest or hover"
-                ColorName="Control Strong / Default"
-                ColorValue="#000000 (72, 44.58%)"
-                Foreground="{ThemeResource TextFillColorInverseBrush}"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Column="2"
-                Background="{ThemeResource ControlStrongFillColorDisabledBrush}"
-                ColorBrushName="ControlStrongFillColorDisabledBrush"
-                ColorExplanation="Disabled only (not accessible)"
-                ColorName="Control Strong / Disabled"
-                ColorValue="#FFFFFF (51, 31.73%)"
-                Foreground="{ThemeResource TextFillColorInverseBrush}"
-                ShowSeparator="False" />
-        </Grid>
-
-
-        <!--  Subtle fill  -->
-        <designguidance:ColorPageExample
-            Title="Subtle Fill"
-            Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
-            Description="Used for list items and fills that are transparent at rest and appear upon interaction.">
-            <StackPanel Orientation="Vertical">
-                <Grid Padding="8">
-                    <TextBlock Text="Rest" />
-                </Grid>
-                <Grid
-                    MinWidth="120"
-                    Padding="12"
-                    Background="{ThemeResource SubtleFillColorSecondaryBrush}"
-                    CornerRadius="{StaticResource ControlCornerRadius}">
-                    <TextBlock Text="Hover" />
-                </Grid>
-
-            </StackPanel>
-        </designguidance:ColorPageExample>
-
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-
-            <designguidance:ColorTile
-                Background="{ThemeResource SubtleFillColorTransparentBrush}"
-                ColorBrushName="SubtleFillColorTransparentBrush"
-                ColorExplanation="Rest"
-                ColorName="Subtle / Transparent "
-                ColorValue="#000000 (00, 0%)"
-                Foreground="{ThemeResource TextFillColorPrimary}" />
-
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="{ThemeResource SubtleFillColorSecondaryBrush}"
-                ColorBrushName="SubtleFillColorSecondaryBrush"
-                ColorExplanation="Hover"
-                ColorName="Subtle / Secondary"
-                ColorValue="#000000, (09,3.73%)"
-                Foreground="{ThemeResource TextFillColorPrimary}" />
-            <designguidance:ColorTile
-                Grid.Column="2"
-                Background="{ThemeResource SubtleFillColorTertiaryBrush}"
-                ColorBrushName="SubtleFillColorTertiaryBrush"
-                ColorExplanation="Pressed"
-                ColorName="Subtle / Tertiary "
-                ColorValue=" #000000 (06, 2.41%)"
-                Foreground="{ThemeResource TextFillColorPrimary}" />
-            <designguidance:ColorTile
-                Grid.Column="3"
-                Background="{ThemeResource SubtleFillColorDisabledBrush}"
-                ColorBrushName="SubtleFillColorDisabledBrush"
-                ColorExplanation="Disabled only (not accessible)"
-                ColorName="Subtle / Disabled"
-                ColorValue="#000000 (00, 0%)"
-                Foreground="{ThemeResource TextFillColorPrimary}"
-                ShowSeparator="False" />
-        </Grid>
-
-
-        <!--  Control On Image Fill  -->
-        <designguidance:ColorPageExample
-            Title="Control On Image Fill"
-            Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
-            Description="Used for controls living on top of imagery.">
-            <Grid CornerRadius="{StaticResource ControlCornerRadius}">
-                <Image MaxHeight="150" Source="/Assets/SampleMedia/valley.jpg" />
-                <Border
-                    Width="20"
-                    Height="20"
-                    Margin="8"
-                    HorizontalAlignment="Right"
-                    VerticalAlignment="Top"
-                    Background="{ThemeResource ControlOnImageFillColorDefaultBrush}"
-                    BorderBrush="{ThemeResource ControlStrongStrokeColorDefaultBrush}"
-                    BorderThickness="1"
-                    CornerRadius="{StaticResource ControlCornerRadius}" />
+            <!--  Control Fill  -->
+            <designguidance:ColorPageExample
+                Title="Control Fill"
+                Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
+                Description="Fill used for standard controls">
+                <Button Content="Text" />
+            </designguidance:ColorPageExample>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <designguidance:ColorTile
+                    Background="{ThemeResource ControlFillColorDefaultBrush}"
+                    ColorBrushName="ControlFillColorDefaultBrush"
+                    ColorExplanation="Rest"
+                    ColorName="Control / Default"
+                    ColorValue="#FFFFFF (B3, 70%)" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="{ThemeResource ControlFillColorSecondaryBrush}"
+                    ColorBrushName="ControlFillColorSecondaryBrush"
+                    ColorExplanation="Hover"
+                    ColorName="Control / Secondary"
+                    ColorValue="#F9F9F9 (50, 50%)" />
+                <designguidance:ColorTile
+                    Grid.Column="2"
+                    Background="{ThemeResource ControlFillColorTertiaryBrush}"
+                    ColorBrushName="ControlFillColorTertiaryBrush"
+                    ColorExplanation="Pressed"
+                    ColorName="Control / Tertiary"
+                    ColorValue="#F9F9F9 (4D, 30%)" />
+                <designguidance:ColorTile
+                    Grid.Column="3"
+                    Background="{ThemeResource ControlFillColorTertiaryBrush}"
+                    ColorBrushName="ControlFillColorQuarternaryBrush"
+                    ColorExplanation="Rest (Pill Button control)"
+                    ColorName="Control / Quartenary"
+                    ColorValue="#F9F9F9 (C2, 30%)"
+                    ShowSeparator="False"
+                    ShowWarning="True" />
             </Grid>
-        </designguidance:ColorPageExample>
-
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-
-            <designguidance:ColorTile
-                Background="{ThemeResource ControlOnImageFillColorDefaultBrush}"
-                ColorBrushName="ControlOnImageFillColorDefaultBrush"
-                ColorExplanation="Rest"
-                ColorName="Control On Image Fill Default"
-                ColorValue="#FFFFFF (C9, 79%)"
-                Foreground="{ThemeResource TextFillColorPrimary}" />
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="{ThemeResource ControlOnImageFillColorSecondaryBrush}"
-                ColorBrushName="ControlOnImageFillColorSecondaryBrush"
-                ColorExplanation="Hover"
-                ColorName="Control On Image Fill Secondary"
-                ColorValue="#F3F3F3 (FF, 100%)"
-                Foreground="{ThemeResource TextFillColorPrimary}" />
-            <designguidance:ColorTile
-                Grid.Column="2"
-                Background="{ThemeResource ControlOnImageFillColorTertiaryBrush}"
-                ColorBrushName="ControlOnImageFillColorTertiaryBrush"
-                ColorExplanation="Pressed"
-                ColorName="Control On Image Fill Tertiary"
-                ColorValue="#EBEBEB (FF, 100%)"
-                Foreground="{ThemeResource TextFillColorPrimary}" />
-            <designguidance:ColorTile
-                Grid.Column="3"
-                Background="{ThemeResource ControlOnImageFillColorDisabledBrush}"
-                ColorBrushName="ControlOnImageFillColorDisabledBrush"
-                ColorExplanation="Disabled only (not accessible)"
-                ColorName="Control On Image Fill Disabled"
-                ColorValue="#FFFFFF (00, 0%)"
-                Foreground="{ThemeResource TextFillColorPrimary}"
-                ShowSeparator="False" />
-        </Grid>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <designguidance:ColorTile
+                    Grid.Column="0"
+                    Background="{ThemeResource ControlFillColorDisabledBrush}"
+                    ColorBrushName="ControlFillColorDisabledBrush"
+                    ColorExplanation="Disabled"
+                    ColorName="Control / Disabled"
+                    ColorValue="#F3F3F3 (FD, 30%)" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="{ThemeResource ControlFillColorTransparentBrush}"
+                    ColorBrushName="ControlFillColorTransparentBrush"
+                    ColorExplanation="Rest"
+                    ColorName="Control / Transparent"
+                    ColorValue="#FFFFFF (00, 0%)" />
+                <designguidance:ColorTile
+                    Grid.Column="2"
+                    Background="{ThemeResource ControlFillColorInputActiveBrush}"
+                    ColorBrushName="ControlFillColorInputActiveBrush"
+                    ColorExplanation="Active/focused text input fields"
+                    ColorName="Control / Input Active"
+                    ColorValue="#FFFFFF (FF, 100%)"
+                    ShowSeparator="False" />
+            </Grid>
 
 
-        <!--  Accent fill  -->
-        <designguidance:ColorPageExample
-            Title="Accent Fill"
-            Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
-            Description="Used for accent fills on controls">
-            <StackPanel>
-                <Button Content="Text" Style="{StaticResource AccentButtonStyle}" />
-            </StackPanel>
-        </designguidance:ColorPageExample>
+            <!--  Control Alt Fill  -->
+            <designguidance:ColorPageExample
+                Title="Control Alt Fill"
+                Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
+                Description="Fill used for the 'off' states of toggle controls">
+                <ToggleSwitch OffContent="" OnContent="" />
+            </designguidance:ColorPageExample>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <designguidance:ColorTile
+                    Background="{ThemeResource ControlAltFillColorTransparentBrush}"
+                    ColorBrushName="ControlAltFillColorTransparentBrush"
+                    ColorName="Control Alt / Transparent"
+                    ColorValue="#FFFFFF (00, 0%)" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="{ThemeResource ControlAltFillColorSecondaryBrush}"
+                    ColorBrushName="ControlAltFillColorSecondaryBrush"
+                    ColorExplanation="Rest"
+                    ColorName="Control Alt / Secondary"
+                    ColorValue="#000000 (06, 2.41%)" />
+                <designguidance:ColorTile
+                    Grid.Column="2"
+                    Background="{ThemeResource ControlAltFillColorTertiaryBrush}"
+                    ColorBrushName="ControlAltFillColorTertiaryBrush"
+                    ColorExplanation="Hover"
+                    ColorName="Control Alt / Tertiary"
+                    ColorValue="#000000 (0F, 5.78%)"
+                    ShowSeparator="False" />
+            </Grid>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <designguidance:ColorTile
+                    Background="{ThemeResource ControlAltFillColorQuarternaryBrush}"
+                    ColorBrushName="ControlAltFillColorQuarternaryBrush"
+                    ColorExplanation="Pressed"
+                    ColorName="Control Alt / Quarternary"
+                    ColorValue="#000000 (12, 6.58%)" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="{ThemeResource ControlAltFillColorDisabledBrush}"
+                    ColorBrushName="ControlAltFillColorDisabledBrush"
+                    ColorExplanation="Disabled"
+                    ColorName="Control Alt / Disabled"
+                    ColorValue="#FFFFFF (00, 0%)"
+                    ShowSeparator="False" />
+            </Grid>
 
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <designguidance:ColorTile
-                Background="{ThemeResource AccentFillColorDefaultBrush}"
-                ColorBrushName="AccentFillColorDefaultBrush"
-                ColorExplanation="Rest"
-                ColorName="Accent / Default"
-                ColorValue="Dark 1 (100%)"
-                Foreground="{ThemeResource TextOnAccentFillColorDefaultBrush}"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="{ThemeResource AccentFillColorSecondaryBrush}"
-                ColorBrushName="AccentFillColorSecondaryBrush"
-                ColorExplanation="Hover"
-                ColorName="Accent / Secondary"
-                ColorValue="Dark 1 (90%)"
-                Foreground="{ThemeResource TextOnAccentFillColorDefaultBrush}"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Column="2"
-                Background="{ThemeResource AccentFillColorTertiaryBrush}"
-                ColorBrushName="AccentFillColorTertiaryBrush"
-                ColorExplanation="Pressed"
-                ColorName="Accent / Tertiary"
-                ColorValue="Dark 1 (80%)"
-                Foreground="{ThemeResource TextOnAccentFillColorDefaultBrush}"
-                ShowSeparator="False" />
-        </Grid>
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <designguidance:ColorTile
-                Background="{ThemeResource AccentFillColorDisabledBrush}"
-                ColorBrushName="AccentFillColorDisabledBrush"
-                ColorExplanation="Disabled"
-                ColorName="Accent / Disabled"
-                ColorValue="#000000 (37, 21.09%)"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="{ThemeResource AccentFillColorSelectedTextBackgroundBrush}"
-                ColorBrushName="AccentFillColorSelectedTextBackgroundBrush"
-                ColorExplanation="Highighted/selected text background"
-                ColorName="Accent / Selected Text Background"
-                ColorValue="Accent Base"
-                Foreground="{ThemeResource TextOnAccentFillColorDefaultBrush}"
-                ShowSeparator="False" />
-        </Grid>
+            <!--  Neutral Solid  -->
+            <designguidance:ColorPageExample
+                Title="Neutral Solid"
+                Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
+                Description="Fills used for Sliders thumb control to cover the track beneath it.">
+                <Slider
+                    MinWidth="240"
+                    Maximum="100"
+                    Value="40" />
+            </designguidance:ColorPageExample>
 
-    </StackPanel>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <designguidance:ColorTile
+                    Background="{ThemeResource ControlSolidFillColorDefaultBrush}"
+                    ColorBrushName="ControlSolidFillColorDefaultBrush"
+                    ColorExplanation="Rest"
+                    ColorName="Control Solid / Default"
+                    ColorValue="#FFFFFF (FF, 100%)"
+                    ShowSeparator="False" />
+            </Grid>
+
+            <!--  Neutral Strong  -->
+            <designguidance:ColorPageExample
+                Title="Neutral Strong"
+                Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
+                Description="Used for controls that must meet contrast ratio requirements of 3:1.">
+                <ScrollBar
+                    Width="200"
+                    Height="20"
+                    IndicatorMode="MouseIndicator"
+                    Orientation="Horizontal"
+                    Visibility="Visible" />
+            </designguidance:ColorPageExample>
+
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <designguidance:ColorTile
+                    Background="{ThemeResource ControlStrongFillColorDefaultBrush}"
+                    ColorBrushName="ControlStrongFillColorDefaultBrush"
+                    ColorExplanation="Rest or hover"
+                    ColorName="Control Strong / Default"
+                    ColorValue="#000000 (72, 44.58%)"
+                    Foreground="{ThemeResource TextFillColorInverseBrush}"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Column="2"
+                    Background="{ThemeResource ControlStrongFillColorDisabledBrush}"
+                    ColorBrushName="ControlStrongFillColorDisabledBrush"
+                    ColorExplanation="Disabled only (not accessible)"
+                    ColorName="Control Strong / Disabled"
+                    ColorValue="#FFFFFF (51, 31.73%)"
+                    Foreground="{ThemeResource TextFillColorInverseBrush}"
+                    ShowSeparator="False" />
+            </Grid>
+
+
+            <!--  Subtle fill  -->
+            <designguidance:ColorPageExample
+                Title="Subtle Fill"
+                Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
+                Description="Used for list items and fills that are transparent at rest and appear upon interaction.">
+                <StackPanel Orientation="Vertical">
+                    <Grid Padding="8">
+                        <TextBlock Text="Rest" />
+                    </Grid>
+                    <Grid
+                        MinWidth="120"
+                        Padding="12"
+                        Background="{ThemeResource SubtleFillColorSecondaryBrush}"
+                        CornerRadius="{StaticResource ControlCornerRadius}">
+                        <TextBlock Text="Hover" />
+                    </Grid>
+
+                </StackPanel>
+            </designguidance:ColorPageExample>
+
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <designguidance:ColorTile
+                    Background="{ThemeResource SubtleFillColorTransparentBrush}"
+                    ColorBrushName="SubtleFillColorTransparentBrush"
+                    ColorExplanation="Rest"
+                    ColorName="Subtle / Transparent "
+                    ColorValue="#000000 (00, 0%)"
+                    Foreground="{ThemeResource TextFillColorPrimary}" />
+
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="{ThemeResource SubtleFillColorSecondaryBrush}"
+                    ColorBrushName="SubtleFillColorSecondaryBrush"
+                    ColorExplanation="Hover"
+                    ColorName="Subtle / Secondary"
+                    ColorValue="#000000, (09,3.73%)"
+                    Foreground="{ThemeResource TextFillColorPrimary}" />
+                <designguidance:ColorTile
+                    Grid.Column="2"
+                    Background="{ThemeResource SubtleFillColorTertiaryBrush}"
+                    ColorBrushName="SubtleFillColorTertiaryBrush"
+                    ColorExplanation="Pressed"
+                    ColorName="Subtle / Tertiary "
+                    ColorValue=" #000000 (06, 2.41%)"
+                    Foreground="{ThemeResource TextFillColorPrimary}" />
+                <designguidance:ColorTile
+                    Grid.Column="3"
+                    Background="{ThemeResource SubtleFillColorDisabledBrush}"
+                    ColorBrushName="SubtleFillColorDisabledBrush"
+                    ColorExplanation="Disabled only (not accessible)"
+                    ColorName="Subtle / Disabled"
+                    ColorValue="#000000 (00, 0%)"
+                    Foreground="{ThemeResource TextFillColorPrimary}"
+                    ShowSeparator="False" />
+            </Grid>
+
+
+            <!--  Control On Image Fill  -->
+            <designguidance:ColorPageExample
+                Title="Control On Image Fill"
+                Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
+                Description="Used for controls living on top of imagery.">
+                <Grid CornerRadius="{StaticResource ControlCornerRadius}">
+                    <Image MaxHeight="150" Source="/Assets/SampleMedia/valley.jpg" />
+                    <Border
+                        Width="20"
+                        Height="20"
+                        Margin="8"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Top"
+                        Background="{ThemeResource ControlOnImageFillColorDefaultBrush}"
+                        BorderBrush="{ThemeResource ControlStrongStrokeColorDefaultBrush}"
+                        BorderThickness="1"
+                        CornerRadius="{StaticResource ControlCornerRadius}" />
+                </Grid>
+            </designguidance:ColorPageExample>
+
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <designguidance:ColorTile
+                    Background="{ThemeResource ControlOnImageFillColorDefaultBrush}"
+                    ColorBrushName="ControlOnImageFillColorDefaultBrush"
+                    ColorExplanation="Rest"
+                    ColorName="Control On Image Fill Default"
+                    ColorValue="#FFFFFF (C9, 79%)"
+                    Foreground="{ThemeResource TextFillColorPrimary}" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="{ThemeResource ControlOnImageFillColorSecondaryBrush}"
+                    ColorBrushName="ControlOnImageFillColorSecondaryBrush"
+                    ColorExplanation="Hover"
+                    ColorName="Control On Image Fill Secondary"
+                    ColorValue="#F3F3F3 (FF, 100%)"
+                    Foreground="{ThemeResource TextFillColorPrimary}" />
+                <designguidance:ColorTile
+                    Grid.Column="2"
+                    Background="{ThemeResource ControlOnImageFillColorTertiaryBrush}"
+                    ColorBrushName="ControlOnImageFillColorTertiaryBrush"
+                    ColorExplanation="Pressed"
+                    ColorName="Control On Image Fill Tertiary"
+                    ColorValue="#EBEBEB (FF, 100%)"
+                    Foreground="{ThemeResource TextFillColorPrimary}" />
+                <designguidance:ColorTile
+                    Grid.Column="3"
+                    Background="{ThemeResource ControlOnImageFillColorDisabledBrush}"
+                    ColorBrushName="ControlOnImageFillColorDisabledBrush"
+                    ColorExplanation="Disabled only (not accessible)"
+                    ColorName="Control On Image Fill Disabled"
+                    ColorValue="#FFFFFF (00, 0%)"
+                    Foreground="{ThemeResource TextFillColorPrimary}"
+                    ShowSeparator="False" />
+            </Grid>
+
+
+            <!--  Accent fill  -->
+            <designguidance:ColorPageExample
+                Title="Accent Fill"
+                Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
+                Description="Used for accent fills on controls">
+                <StackPanel>
+                    <Button Content="Text" Style="{StaticResource AccentButtonStyle}" />
+                </StackPanel>
+            </designguidance:ColorPageExample>
+
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <designguidance:ColorTile
+                    Background="{ThemeResource AccentFillColorDefaultBrush}"
+                    ColorBrushName="AccentFillColorDefaultBrush"
+                    ColorExplanation="Rest"
+                    ColorName="Accent / Default"
+                    ColorValue="Dark 1 (100%)"
+                    Foreground="{ThemeResource TextOnAccentFillColorDefaultBrush}"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="{ThemeResource AccentFillColorSecondaryBrush}"
+                    ColorBrushName="AccentFillColorSecondaryBrush"
+                    ColorExplanation="Hover"
+                    ColorName="Accent / Secondary"
+                    ColorValue="Dark 1 (90%)"
+                    Foreground="{ThemeResource TextOnAccentFillColorDefaultBrush}"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Column="2"
+                    Background="{ThemeResource AccentFillColorTertiaryBrush}"
+                    ColorBrushName="AccentFillColorTertiaryBrush"
+                    ColorExplanation="Pressed"
+                    ColorName="Accent / Tertiary"
+                    ColorValue="Dark 1 (80%)"
+                    Foreground="{ThemeResource TextOnAccentFillColorDefaultBrush}"
+                    ShowSeparator="False" />
+            </Grid>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <designguidance:ColorTile
+                    Background="{ThemeResource AccentFillColorDisabledBrush}"
+                    ColorBrushName="AccentFillColorDisabledBrush"
+                    ColorExplanation="Disabled"
+                    ColorName="Accent / Disabled"
+                    ColorValue="#000000 (37, 21.09%)"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="{ThemeResource AccentFillColorSelectedTextBackgroundBrush}"
+                    ColorBrushName="AccentFillColorSelectedTextBackgroundBrush"
+                    ColorExplanation="Highighted/selected text background"
+                    ColorName="Accent / Selected Text Background"
+                    ColorValue="Accent Base"
+                    Foreground="{ThemeResource TextOnAccentFillColorDefaultBrush}"
+                    ShowSeparator="False" />
+            </Grid>
+
+        </StackPanel>
+    </wdc:SampleThemeListener>
 </Page>

--- a/WinUIGallery/Controls/DesignGuidance/ColorSections/HighContrastSection.xaml
+++ b/WinUIGallery/Controls/DesignGuidance/ColorSections/HighContrastSection.xaml
@@ -7,6 +7,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:designguidance="using:WinUIGallery.DesktopWap.Controls.DesignGuidance"
+    xmlns:wdc="using:WinUIGallery.DesktopWap.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
@@ -18,379 +19,387 @@
             Margin="0,12,0,0"
             Style="{StaticResource SubtitleTextBlockStyle}"
             Text="Aquatic" />
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <Grid.RowDefinitions>
-                <RowDefinition />
-                <RowDefinition />
-            </Grid.RowDefinitions>
-            <designguidance:ColorTile
-                Background="#FFFFFF"
-                ColorBrushName="SystemColorWindowTextColor"
-                ColorExplanation="Foreground / Text color for Headings, body copy, lists, placeholder text, app and window borders, any UI that can't be interacted with."
-                ColorName="Window Text Color"
-                ColorValue="#FFFFFF"
-                Foreground="#202020"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Row="1"
-                Background="#202020"
-                ColorBrushName="SystemColorWindowColor"
-                ColorExplanation="Background of pages, panes, popups, and windows."
-                ColorName="Window Color"
-                ColorValue="#202020"
-                Foreground="#FFFFFF"
-                ShowSeparator="False" />
+        <wdc:SampleThemeListener>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition />
+                    <RowDefinition />
+                </Grid.RowDefinitions>
+                <designguidance:ColorTile
+                    Background="#FFFFFF"
+                    ColorBrushName="SystemColorWindowTextColor"
+                    ColorExplanation="Foreground / Text color for Headings, body copy, lists, placeholder text, app and window borders, any UI that can't be interacted with."
+                    ColorName="Window Text Color"
+                    ColorValue="#FFFFFF"
+                    Foreground="#202020"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Row="1"
+                    Background="#202020"
+                    ColorBrushName="SystemColorWindowColor"
+                    ColorExplanation="Background of pages, panes, popups, and windows."
+                    ColorName="Window Color"
+                    ColorValue="#202020"
+                    Foreground="#FFFFFF"
+                    ShowSeparator="False" />
 
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="#263B50"
-                ColorBrushName="SystemColorHighlightTextColor"
-                ColorExplanation="Foreground color for text or UI that is selected, interacted with (hover, pressed), or in progress."
-                ColorName="Highlight Text Color"
-                ColorValue="#263B50"
-                Foreground="#8EE3F0"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Row="1"
-                Grid.Column="1"
-                Background="#8EE3F0"
-                ColorBrushName="SystemColorHighlightColor"
-                ColorExplanation="Background or accent color for UI that is selected, interacted with (hover, pressed), or in progress."
-                ColorName="Highlight Color"
-                ColorValue="#8EE3F0"
-                Foreground="#263B50"
-                ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="#263B50"
+                    ColorBrushName="SystemColorHighlightTextColor"
+                    ColorExplanation="Foreground color for text or UI that is selected, interacted with (hover, pressed), or in progress."
+                    ColorName="Highlight Text Color"
+                    ColorValue="#263B50"
+                    Foreground="#8EE3F0"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Row="1"
+                    Grid.Column="1"
+                    Background="#8EE3F0"
+                    ColorBrushName="SystemColorHighlightColor"
+                    ColorExplanation="Background or accent color for UI that is selected, interacted with (hover, pressed), or in progress."
+                    ColorName="Highlight Color"
+                    ColorValue="#8EE3F0"
+                    Foreground="#263B50"
+                    ShowSeparator="False" />
 
-            <designguidance:ColorTile
-                Grid.Column="2"
-                Background="#FFFFFF"
-                ColorBrushName="SystemColorButtonTextColor"
-                ColorExplanation="Foreground color for buttons and any UI that can be interacted with."
-                ColorName="Button Text Color"
-                ColorValue="#FFFFFF"
-                Foreground="#202020"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Row="1"
-                Grid.Column="2"
-                Background="#202020"
-                ColorBrushName="SystemColorButtonFaceColor"
-                ColorExplanation="Background color for buttons and any UI that can be interacted with."
-                ColorName="Button Face Color"
-                ColorValue="#202020"
-                Foreground="#FFFFFF"
-                ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Column="2"
+                    Background="#FFFFFF"
+                    ColorBrushName="SystemColorButtonTextColor"
+                    ColorExplanation="Foreground color for buttons and any UI that can be interacted with."
+                    ColorName="Button Text Color"
+                    ColorValue="#FFFFFF"
+                    Foreground="#202020"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Row="1"
+                    Grid.Column="2"
+                    Background="#202020"
+                    ColorBrushName="SystemColorButtonFaceColor"
+                    ColorExplanation="Background color for buttons and any UI that can be interacted with."
+                    ColorName="Button Face Color"
+                    ColorValue="#202020"
+                    Foreground="#FFFFFF"
+                    ShowSeparator="False" />
 
-            <designguidance:ColorTile
-                Grid.Column="3"
-                Background="#75E9FC"
-                ColorBrushName="SystemColorHotlightColor"
-                ColorExplanation="Foreground / Text color for hyperlink text."
-                ColorName="Hotlight Color"
-                ColorValue="#75E9FC"
-                Foreground="#202020"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Row="1"
-                Grid.Column="3"
-                Background="#A6A6A6"
-                ColorBrushName="SystemColorGreyTextColor"
-                ColorExplanation="Foreground / Text color for Inactive (disabled) UI."
-                ColorName="Grey Text Color / Disabled"
-                ColorValue="#A6A6A6"
-                Foreground="#FFFFFF"
-                ShowSeparator="False" />
-        </Grid>
-
+                <designguidance:ColorTile
+                    Grid.Column="3"
+                    Background="#75E9FC"
+                    ColorBrushName="SystemColorHotlightColor"
+                    ColorExplanation="Foreground / Text color for hyperlink text."
+                    ColorName="Hotlight Color"
+                    ColorValue="#75E9FC"
+                    Foreground="#202020"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Row="1"
+                    Grid.Column="3"
+                    Background="#A6A6A6"
+                    ColorBrushName="SystemColorGreyTextColor"
+                    ColorExplanation="Foreground / Text color for Inactive (disabled) UI."
+                    ColorName="Grey Text Color / Disabled"
+                    ColorValue="#A6A6A6"
+                    Foreground="#FFFFFF"
+                    ShowSeparator="False" />
+            </Grid>
+        </wdc:SampleThemeListener>
+        
         <!--  Desert  -->
         <TextBlock
             Margin="0,24,0,0"
             Style="{StaticResource SubtitleTextBlockStyle}"
             Text="Desert" />
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <Grid.RowDefinitions>
-                <RowDefinition />
-                <RowDefinition />
-            </Grid.RowDefinitions>
-            <designguidance:ColorTile
-                Background="#3D3D3D"
-                ColorBrushName="SystemColorWindowTextColor"
-                ColorExplanation="Foreground / Text color for Headings, body copy, lists, placeholder text, app and window borders, any UI that can't be interacted with."
-                ColorName="Window Text Color"
-                ColorValue="#3D3D3D"
-                Foreground="#FFFAEF"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Row="1"
-                Background="#FFFAEF"
-                ColorBrushName="SystemColorWindowColor"
-                ColorExplanation="Background of pages, panes, popups, and windows."
-                ColorName="Window Color"
-                ColorValue="#FFFAEF"
-                Foreground="#3D3D3D"
-                ShowSeparator="False" />
+        <wdc:SampleThemeListener>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition />
+                    <RowDefinition />
+                </Grid.RowDefinitions>
+                <designguidance:ColorTile
+                    Background="#3D3D3D"
+                    ColorBrushName="SystemColorWindowTextColor"
+                    ColorExplanation="Foreground / Text color for Headings, body copy, lists, placeholder text, app and window borders, any UI that can't be interacted with."
+                    ColorName="Window Text Color"
+                    ColorValue="#3D3D3D"
+                    Foreground="#FFFAEF"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Row="1"
+                    Background="#FFFAEF"
+                    ColorBrushName="SystemColorWindowColor"
+                    ColorExplanation="Background of pages, panes, popups, and windows."
+                    ColorName="Window Color"
+                    ColorValue="#FFFAEF"
+                    Foreground="#3D3D3D"
+                    ShowSeparator="False" />
 
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="#FFF5E3"
-                ColorBrushName="SystemColorHighlightTextColor"
-                ColorExplanation="Foreground color for text or UI that is selected, interacted with (hover, pressed), or in progress."
-                ColorName="Highlight Text Color"
-                ColorValue="#FFF5E3"
-                Foreground="#903909"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Row="1"
-                Grid.Column="1"
-                Background="#903909"
-                ColorBrushName="SystemColorHighlightColor"
-                ColorExplanation="Background or accent color for UI that is selected, interacted with (hover, pressed), or in progress."
-                ColorName="Highlight Color"
-                ColorValue="#903909"
-                Foreground="#FFF5E3"
-                ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="#FFF5E3"
+                    ColorBrushName="SystemColorHighlightTextColor"
+                    ColorExplanation="Foreground color for text or UI that is selected, interacted with (hover, pressed), or in progress."
+                    ColorName="Highlight Text Color"
+                    ColorValue="#FFF5E3"
+                    Foreground="#903909"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Row="1"
+                    Grid.Column="1"
+                    Background="#903909"
+                    ColorBrushName="SystemColorHighlightColor"
+                    ColorExplanation="Background or accent color for UI that is selected, interacted with (hover, pressed), or in progress."
+                    ColorName="Highlight Color"
+                    ColorValue="#903909"
+                    Foreground="#FFF5E3"
+                    ShowSeparator="False" />
 
-            <designguidance:ColorTile
-                Grid.Column="2"
-                Background="#202020"
-                ColorBrushName="SystemColorButtonTextColor"
-                ColorExplanation="Foreground color for buttons and any UI that can be interacted with."
-                ColorName="Button Text Color"
-                ColorValue="#202020"
-                Foreground="#FFFAEF"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Row="1"
-                Grid.Column="2"
-                Background="#FFFAEF"
-                ColorBrushName="SystemColorButtonFaceColor"
-                ColorExplanation="Background color for buttons and any UI that can be interacted with."
-                ColorName="Button Face Color"
-                ColorValue="#FFFAEF"
-                Foreground="#202020"
-                ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Column="2"
+                    Background="#202020"
+                    ColorBrushName="SystemColorButtonTextColor"
+                    ColorExplanation="Foreground color for buttons and any UI that can be interacted with."
+                    ColorName="Button Text Color"
+                    ColorValue="#202020"
+                    Foreground="#FFFAEF"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Row="1"
+                    Grid.Column="2"
+                    Background="#FFFAEF"
+                    ColorBrushName="SystemColorButtonFaceColor"
+                    ColorExplanation="Background color for buttons and any UI that can be interacted with."
+                    ColorName="Button Face Color"
+                    ColorValue="#FFFAEF"
+                    Foreground="#202020"
+                    ShowSeparator="False" />
 
-            <designguidance:ColorTile
-                Grid.Column="3"
-                Background="#1C5E75"
-                ColorBrushName="SystemColorHotlightColor"
-                ColorExplanation="Foreground / Text color for hyperlink text."
-                ColorName="Hotlight Color"
-                ColorValue="#1C5E75"
-                Foreground="#FFFAEF"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Row="1"
-                Grid.Column="3"
-                Background="#676767"
-                ColorBrushName="SystemColorGreyTextColor"
-                ColorExplanation="Foreground / Text color for Inactive (disabled) UI."
-                ColorName="Grey Text Color / Disabled"
-                ColorValue="#676767"
-                Foreground="#FFFAEF"
-                ShowSeparator="False" />
-        </Grid>
-
+                <designguidance:ColorTile
+                    Grid.Column="3"
+                    Background="#1C5E75"
+                    ColorBrushName="SystemColorHotlightColor"
+                    ColorExplanation="Foreground / Text color for hyperlink text."
+                    ColorName="Hotlight Color"
+                    ColorValue="#1C5E75"
+                    Foreground="#FFFAEF"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Row="1"
+                    Grid.Column="3"
+                    Background="#676767"
+                    ColorBrushName="SystemColorGreyTextColor"
+                    ColorExplanation="Foreground / Text color for Inactive (disabled) UI."
+                    ColorName="Grey Text Color / Disabled"
+                    ColorValue="#676767"
+                    Foreground="#FFFAEF"
+                    ShowSeparator="False" />
+            </Grid>
+        </wdc:SampleThemeListener>
+        
         <!--  Dusk  -->
         <TextBlock
             Margin="0,24,0,0"
             Style="{StaticResource SubtitleTextBlockStyle}"
             Text="Dusk" />
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <Grid.RowDefinitions>
-                <RowDefinition />
-                <RowDefinition />
-            </Grid.RowDefinitions>
-            <designguidance:ColorTile
-                Background="#FFFFFF"
-                ColorBrushName="SystemColorWindowTextColor"
-                ColorExplanation="Foreground / Text color for Headings, body copy, lists, placeholder text, app and window borders, any UI that can't be interacted with."
-                ColorName="Window Text Color"
-                ColorValue="#FFFFFF"
-                Foreground="#2D3236"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Row="1"
-                Background="#2D3236"
-                ColorBrushName="SystemColorWindowColor"
-                ColorExplanation="Background of pages, panes, popups, and windows."
-                ColorName="Window Color"
-                ColorValue="#2D3236"
-                Foreground="#FFFFFF"
-                ShowSeparator="False" />
+        <wdc:SampleThemeListener>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition />
+                    <RowDefinition />
+                </Grid.RowDefinitions>
+                <designguidance:ColorTile
+                    Background="#FFFFFF"
+                    ColorBrushName="SystemColorWindowTextColor"
+                    ColorExplanation="Foreground / Text color for Headings, body copy, lists, placeholder text, app and window borders, any UI that can't be interacted with."
+                    ColorName="Window Text Color"
+                    ColorValue="#FFFFFF"
+                    Foreground="#2D3236"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Row="1"
+                    Background="#2D3236"
+                    ColorBrushName="SystemColorWindowColor"
+                    ColorExplanation="Background of pages, panes, popups, and windows."
+                    ColorName="Window Color"
+                    ColorValue="#2D3236"
+                    Foreground="#FFFFFF"
+                    ShowSeparator="False" />
 
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="#212D3B"
-                ColorBrushName="SystemColorHighlightTextColor"
-                ColorExplanation="Foreground color for text or UI that is selected, interacted with (hover, pressed), or in progress."
-                ColorName="Highlight Text Color"
-                ColorValue="#212D3B"
-                Foreground="#ABCFF2"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Row="1"
-                Grid.Column="1"
-                Background="#ABCFF2"
-                ColorBrushName="SystemColorHighlightColor"
-                ColorExplanation="Background or accent color for UI that is selected, interacted with (hover, pressed), or in progress."
-                ColorName="Highlight Color"
-                ColorValue="#ABCFF2"
-                Foreground="#212D3B"
-                ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="#212D3B"
+                    ColorBrushName="SystemColorHighlightTextColor"
+                    ColorExplanation="Foreground color for text or UI that is selected, interacted with (hover, pressed), or in progress."
+                    ColorName="Highlight Text Color"
+                    ColorValue="#212D3B"
+                    Foreground="#ABCFF2"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Row="1"
+                    Grid.Column="1"
+                    Background="#ABCFF2"
+                    ColorBrushName="SystemColorHighlightColor"
+                    ColorExplanation="Background or accent color for UI that is selected, interacted with (hover, pressed), or in progress."
+                    ColorName="Highlight Color"
+                    ColorValue="#ABCFF2"
+                    Foreground="#212D3B"
+                    ShowSeparator="False" />
 
-            <designguidance:ColorTile
-                Grid.Column="2"
-                Background="#B6F6F0"
-                ColorBrushName="SystemColorButtonTextColor"
-                ColorExplanation="Foreground color for buttons and any UI that can be interacted with."
-                ColorName="Button Text Color"
-                ColorValue="#B6F6F0"
-                Foreground="#2D3236"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Row="1"
-                Grid.Column="2"
-                Background="#2D3236"
-                ColorBrushName="SystemColorButtonFaceColor"
-                ColorExplanation="Background color for buttons and any UI that can be interacted with."
-                ColorName="Button Face Color"
-                ColorValue="#2D3236"
-                Foreground="#B6F6F0"
-                ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Column="2"
+                    Background="#B6F6F0"
+                    ColorBrushName="SystemColorButtonTextColor"
+                    ColorExplanation="Foreground color for buttons and any UI that can be interacted with."
+                    ColorName="Button Text Color"
+                    ColorValue="#B6F6F0"
+                    Foreground="#2D3236"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Row="1"
+                    Grid.Column="2"
+                    Background="#2D3236"
+                    ColorBrushName="SystemColorButtonFaceColor"
+                    ColorExplanation="Background color for buttons and any UI that can be interacted with."
+                    ColorName="Button Face Color"
+                    ColorValue="#2D3236"
+                    Foreground="#B6F6F0"
+                    ShowSeparator="False" />
 
-            <designguidance:ColorTile
-                Grid.Column="3"
-                Background="#70EBDE"
-                ColorBrushName="SystemColorHotlightColor"
-                ColorExplanation="Foreground / Text color for hyperlink text."
-                ColorName="Hotlight Color"
-                ColorValue="#70EBDE"
-                Foreground="#202020"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Row="1"
-                Grid.Column="3"
-                Background="#A6A6A6"
-                ColorBrushName="SystemColorGreyTextColor"
-                ColorExplanation="Foreground / Text color for Inactive (disabled) UI."
-                ColorName="Grey Text Color / Disabled"
-                ColorValue="#A6A6A6"
-                Foreground="#FFFFFF"
-                ShowSeparator="False" />
-        </Grid>
-
+                <designguidance:ColorTile
+                    Grid.Column="3"
+                    Background="#70EBDE"
+                    ColorBrushName="SystemColorHotlightColor"
+                    ColorExplanation="Foreground / Text color for hyperlink text."
+                    ColorName="Hotlight Color"
+                    ColorValue="#70EBDE"
+                    Foreground="#202020"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Row="1"
+                    Grid.Column="3"
+                    Background="#A6A6A6"
+                    ColorBrushName="SystemColorGreyTextColor"
+                    ColorExplanation="Foreground / Text color for Inactive (disabled) UI."
+                    ColorName="Grey Text Color / Disabled"
+                    ColorValue="#A6A6A6"
+                    Foreground="#FFFFFF"
+                    ShowSeparator="False" />
+            </Grid>
+        </wdc:SampleThemeListener>
+        
         <!--  Night Sky  -->
         <TextBlock
             Margin="0,24,0,0"
             Style="{StaticResource SubtitleTextBlockStyle}"
             Text="Night Sky" />
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <Grid.RowDefinitions>
-                <RowDefinition />
-                <RowDefinition />
-            </Grid.RowDefinitions>
-            <designguidance:ColorTile
-                Background="#FFFFFF"
-                ColorBrushName="SystemColorWindowTextColor"
-                ColorExplanation="Foreground / Text color for Headings, body copy, lists, placeholder text, app and window borders, any UI that can't be interacted with."
-                ColorName="Window Text Color"
-                ColorValue="#FFFFFF"
-                Foreground="#000000"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Row="1"
-                Background="#000000"
-                ColorBrushName="SystemColorWindowColor"
-                ColorExplanation="Background of pages, panes, popups, and windows."
-                ColorName="Window Color"
-                ColorValue="#000000"
-                Foreground="#FFFFFF"
-                ShowSeparator="False" />
+        <wdc:SampleThemeListener>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition />
+                    <RowDefinition />
+                </Grid.RowDefinitions>
+                <designguidance:ColorTile
+                    Background="#FFFFFF"
+                    ColorBrushName="SystemColorWindowTextColor"
+                    ColorExplanation="Foreground / Text color for Headings, body copy, lists, placeholder text, app and window borders, any UI that can't be interacted with."
+                    ColorName="Window Text Color"
+                    ColorValue="#FFFFFF"
+                    Foreground="#000000"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Row="1"
+                    Background="#000000"
+                    ColorBrushName="SystemColorWindowColor"
+                    ColorExplanation="Background of pages, panes, popups, and windows."
+                    ColorName="Window Color"
+                    ColorValue="#000000"
+                    Foreground="#FFFFFF"
+                    ShowSeparator="False" />
 
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="#2B2B2B"
-                ColorBrushName="SystemColorHighlightTextColor"
-                ColorExplanation="Foreground color for text or UI that is selected, interacted with (hover, pressed), or in progress."
-                ColorName="Highlight Text Color"
-                ColorValue="#2B2B2B"
-                Foreground="#D6B4FD"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Row="1"
-                Grid.Column="1"
-                Background="#D6B4FD"
-                ColorBrushName="SystemColorHighlightColor"
-                ColorExplanation="Background or accent color for UI that is selected, interacted with (hover, pressed), or in progress."
-                ColorName="Highlight Color"
-                ColorValue="#D6B4FD"
-                Foreground="#2B2B2B"
-                ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="#2B2B2B"
+                    ColorBrushName="SystemColorHighlightTextColor"
+                    ColorExplanation="Foreground color for text or UI that is selected, interacted with (hover, pressed), or in progress."
+                    ColorName="Highlight Text Color"
+                    ColorValue="#2B2B2B"
+                    Foreground="#D6B4FD"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Row="1"
+                    Grid.Column="1"
+                    Background="#D6B4FD"
+                    ColorBrushName="SystemColorHighlightColor"
+                    ColorExplanation="Background or accent color for UI that is selected, interacted with (hover, pressed), or in progress."
+                    ColorName="Highlight Color"
+                    ColorValue="#D6B4FD"
+                    Foreground="#2B2B2B"
+                    ShowSeparator="False" />
 
-            <designguidance:ColorTile
-                Grid.Column="2"
-                Background="#FFEE32"
-                ColorBrushName="SystemColorButtonTextColor"
-                ColorExplanation="Foreground color for buttons and any UI that can be interacted with."
-                ColorName="Button Text Color"
-                ColorValue="#FFEE32"
-                Foreground="#000000"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Row="1"
-                Grid.Column="2"
-                Background="#000000"
-                ColorBrushName="SystemColorButtonFaceColor"
-                ColorExplanation="Background color for buttons and any UI that can be interacted with."
-                ColorName="Button Face Color"
-                ColorValue="#000000"
-                Foreground="#FFEE32"
-                ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Column="2"
+                    Background="#FFEE32"
+                    ColorBrushName="SystemColorButtonTextColor"
+                    ColorExplanation="Foreground color for buttons and any UI that can be interacted with."
+                    ColorName="Button Text Color"
+                    ColorValue="#FFEE32"
+                    Foreground="#000000"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Row="1"
+                    Grid.Column="2"
+                    Background="#000000"
+                    ColorBrushName="SystemColorButtonFaceColor"
+                    ColorExplanation="Background color for buttons and any UI that can be interacted with."
+                    ColorName="Button Face Color"
+                    ColorValue="#000000"
+                    Foreground="#FFEE32"
+                    ShowSeparator="False" />
 
-            <designguidance:ColorTile
-                Grid.Column="3"
-                Background="#8080FF"
-                ColorBrushName="SystemColorHotlightColor"
-                ColorExplanation="Foreground / Text color for hyperlink text."
-                ColorName="Hotlight Color"
-                ColorValue="#8080FF"
-                Foreground="#FFFFFF"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Row="1"
-                Grid.Column="3"
-                Background="#A6A6A6"
-                ColorBrushName="SystemColorGreyTextColor"
-                ColorExplanation="Foreground / Text color for Inactive (disabled) UI."
-                ColorName="Grey Text Color / Disabled"
-                ColorValue="#A6A6A6"
-                Foreground="#000000"
-                ShowSeparator="False" />
-        </Grid>
+                <designguidance:ColorTile
+                    Grid.Column="3"
+                    Background="#8080FF"
+                    ColorBrushName="SystemColorHotlightColor"
+                    ColorExplanation="Foreground / Text color for hyperlink text."
+                    ColorName="Hotlight Color"
+                    ColorValue="#8080FF"
+                    Foreground="#FFFFFF"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Row="1"
+                    Grid.Column="3"
+                    Background="#A6A6A6"
+                    ColorBrushName="SystemColorGreyTextColor"
+                    ColorExplanation="Foreground / Text color for Inactive (disabled) UI."
+                    ColorName="Grey Text Color / Disabled"
+                    ColorValue="#A6A6A6"
+                    Foreground="#000000"
+                    ShowSeparator="False" />
+            </Grid>
+        </wdc:SampleThemeListener>
     </StackPanel>
 </Page>

--- a/WinUIGallery/Controls/DesignGuidance/ColorSections/SignalSection.xaml
+++ b/WinUIGallery/Controls/DesignGuidance/ColorSections/SignalSection.xaml
@@ -7,166 +7,168 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:designguidance="using:WinUIGallery.DesktopWap.Controls.DesignGuidance"
+    xmlns:wdc="using:WinUIGallery.DesktopWap.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
+    <wdc:SampleThemeListener>
+        <StackPanel Spacing="{StaticResource ColorSectionSpacing}">
+            <!--  System  -->
+            <designguidance:ColorPageExample
+                Title="System"
+                Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
+                Description="Used for accent fills on controls">
+                <InfoBar
+                    Title="Title"
+                    IsClosable="False"
+                    IsOpen="True"
+                    Message="This is body text. Windows 11 is faster and more intuitive."
+                    Severity="Error" />
+            </designguidance:ColorPageExample>
 
-    <StackPanel Spacing="{StaticResource ColorSectionSpacing}">
-        <!--  System  -->
-        <designguidance:ColorPageExample
-            Title="System"
-            Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
-            Description="Used for accent fills on controls">
-            <InfoBar
-                Title="Title"
-                IsClosable="False"
-                IsOpen="True"
-                Message="This is body text. Windows 11 is faster and more intuitive."
-                Severity="Error" />
-        </designguidance:ColorPageExample>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
 
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
+                <designguidance:ColorTile
+                    Background="{ThemeResource SystemFillColorSuccessBrush}"
+                    ColorBrushName="SystemFillColorSuccessBrush"
+                    ColorExplanation="Badge"
+                    ColorName="System / Success"
+                    ColorValue="#6CCB5F, 100%"
+                    Foreground="{ThemeResource TextFillColorInverseBrush}"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="{ThemeResource SystemFillColorCautionBrush}"
+                    ColorBrushName="SystemFillColorCautionBrush"
+                    ColorExplanation="Badge"
+                    ColorName="System / Caution"
+                    ColorValue="FCE100, 100%"
+                    Foreground="{ThemeResource TextFillColorInverseBrush}"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Column="2"
+                    Background="{ThemeResource SystemFillColorCriticalBrush}"
+                    ColorBrushName="SystemFillColorCriticalBrush"
+                    ColorExplanation="Badge"
+                    ColorName="System / Critical"
+                    ColorValue="#FF99A4, 100%"
+                    Foreground="{ThemeResource TextFillColorInverseBrush}"
+                    ShowSeparator="False" />
+            </Grid>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
 
-            <designguidance:ColorTile
-                Background="{ThemeResource SystemFillColorSuccessBrush}"
-                ColorBrushName="SystemFillColorSuccessBrush"
-                ColorExplanation="Badge"
-                ColorName="System / Success"
-                ColorValue="#6CCB5F, 100%"
-                Foreground="{ThemeResource TextFillColorInverseBrush}"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="{ThemeResource SystemFillColorCautionBrush}"
-                ColorBrushName="SystemFillColorCautionBrush"
-                ColorExplanation="Badge"
-                ColorName="System / Caution"
-                ColorValue="FCE100, 100%"
-                Foreground="{ThemeResource TextFillColorInverseBrush}"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Column="2"
-                Background="{ThemeResource SystemFillColorCriticalBrush}"
-                ColorBrushName="SystemFillColorCriticalBrush"
-                ColorExplanation="Badge"
-                ColorName="System / Critical"
-                ColorValue="#FF99A4, 100%"
-                Foreground="{ThemeResource TextFillColorInverseBrush}"
-                ShowSeparator="False" />
-        </Grid>
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
+                <designguidance:ColorTile
+                    Grid.Column="0"
+                    Background="{ThemeResource SystemFillColorSuccessBackgroundBrush}"
+                    ColorBrushName="SystemFillColorSuccessBackgroundBrush"
+                    ColorExplanation="Infobar Background"
+                    ColorName="System / Success Background"
+                    ColorValue="#393D1B, 100%"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="{ThemeResource SystemFillColorCautionBackgroundBrush}"
+                    ColorBrushName="SystemFillColorCautionBackgroundBrush"
+                    ColorExplanation="Infobar Background"
+                    ColorName="System / Caution Background"
+                    ColorValue="#433519, 100%"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Column="2"
+                    Background="{ThemeResource SystemFillColorCriticalBackgroundBrush}"
+                    ColorBrushName="SystemFillColorCriticalBackgroundBrush"
+                    ColorExplanation="Infobar Background"
+                    ColorName="System / Critical Background"
+                    ColorValue="#442726, 100%"
+                    ShowSeparator="False" />
 
-            <designguidance:ColorTile
-                Grid.Column="0"
-                Background="{ThemeResource SystemFillColorSuccessBackgroundBrush}"
-                ColorBrushName="SystemFillColorSuccessBackgroundBrush"
-                ColorExplanation="Infobar Background"
-                ColorName="System / Success Background"
-                ColorValue="#393D1B, 100%"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="{ThemeResource SystemFillColorCautionBackgroundBrush}"
-                ColorBrushName="SystemFillColorCautionBackgroundBrush"
-                ColorExplanation="Infobar Background"
-                ColorName="System / Caution Background"
-                ColorValue="#433519, 100%"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Column="2"
-                Background="{ThemeResource SystemFillColorCriticalBackgroundBrush}"
-                ColorBrushName="SystemFillColorCriticalBackgroundBrush"
-                ColorExplanation="Infobar Background"
-                ColorName="System / Critical Background"
-                ColorValue="#442726, 100%"
-                ShowSeparator="False" />
+            </Grid>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <designguidance:ColorTile
+                    Background="{ThemeResource SystemFillColorAttentionBrush}"
+                    ColorBrushName="SystemFillColorAttentionBrush"
+                    ColorExplanation="Badge"
+                    ColorName="System / Attention"
+                    ColorValue="#60CDFF (100%)"
+                    Foreground="{ThemeResource TextFillColorInverseBrush}"
+                    ShowSeparator="False" />
 
-        </Grid>
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <designguidance:ColorTile
-                Background="{ThemeResource SystemFillColorAttentionBrush}"
-                ColorBrushName="SystemFillColorAttentionBrush"
-                ColorExplanation="Badge"
-                ColorName="System / Attention"
-                ColorValue="#60CDFF (100%)"
-                Foreground="{ThemeResource TextFillColorInverseBrush}"
-                ShowSeparator="False" />
-
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="{ThemeResource SystemFillColorNeutralBrush}"
-                ColorBrushName="SystemFillColorNeutralBrush"
-                ColorExplanation="Badge"
-                ColorName="System / Neutral"
-                ColorValue="#FFFFFF (8B, 54,42%)"
-                Foreground="{ThemeResource TextFillColorInverseBrush}" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="{ThemeResource SystemFillColorNeutralBrush}"
+                    ColorBrushName="SystemFillColorNeutralBrush"
+                    ColorExplanation="Badge"
+                    ColorName="System / Neutral"
+                    ColorValue="#FFFFFF (8B, 54,42%)"
+                    Foreground="{ThemeResource TextFillColorInverseBrush}" />
 
 
-            <designguidance:ColorTile
-                Grid.Column="2"
-                Background="{ThemeResource SystemFillColorSolidNeutralBrush}"
-                ColorBrushName="SystemFillColorSolidNeutralBrush"
-                ColorExplanation="Neutral badges over content"
-                ColorName="System / Solid Neutral"
-                ColorValue="#9D9D9D"
-                Foreground="{ThemeResource TextFillColorInverseBrush}"
-                ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Column="2"
+                    Background="{ThemeResource SystemFillColorSolidNeutralBrush}"
+                    ColorBrushName="SystemFillColorSolidNeutralBrush"
+                    ColorExplanation="Neutral badges over content"
+                    ColorName="System / Solid Neutral"
+                    ColorValue="#9D9D9D"
+                    Foreground="{ThemeResource TextFillColorInverseBrush}"
+                    ShowSeparator="False" />
 
-        </Grid>
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <designguidance:ColorTile
-                Background="{ThemeResource SystemFillColorAttentionBackgroundBrush}"
-                ColorBrushName="SystemFillColorAttentionBackgroundBrush"
-                ColorExplanation="Infobar Background"
-                ColorName="System / Attention Background"
-                ColorValue="#FFFFFF (0B, 3.26%)" />
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="{ThemeResource SystemFillColorNeutralBackgroundBrush}"
-                ColorBrushName="SystemFillColorNeutralBackgroundBrush"
-                ColorExplanation="Infobar Background"
-                ColorName="System / Neutral Background"
-                ColorValue="#FFFFFF (08, 3.26%)" />
-            <designguidance:ColorTile
-                Grid.Column="2"
-                Background="{ThemeResource SystemFillColorSolidNeutralBackgroundBrush}"
-                ColorBrushName="SystemFillColorSolidNeutralBackgroundBrush"
-                ColorExplanation="Neutral badges over content"
-                ColorName="System / Solid Neutral Background"
-                ColorValue="#2E2E2E" />
-        </Grid>
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <designguidance:ColorTile
-                Grid.Column="2"
-                Background="{ThemeResource SystemFillColorSolidAttentionBackgroundBrush}"
-                ColorBrushName="SystemFillColorSolidAttentionBackgroundBrush"
-                ColorName="System / Solid Attention Background"
-                ColorValue="#2E2E2E"
-                ShowSeparator="False" />
-        </Grid>
+            </Grid>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <designguidance:ColorTile
+                    Background="{ThemeResource SystemFillColorAttentionBackgroundBrush}"
+                    ColorBrushName="SystemFillColorAttentionBackgroundBrush"
+                    ColorExplanation="Infobar Background"
+                    ColorName="System / Attention Background"
+                    ColorValue="#FFFFFF (0B, 3.26%)" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="{ThemeResource SystemFillColorNeutralBackgroundBrush}"
+                    ColorBrushName="SystemFillColorNeutralBackgroundBrush"
+                    ColorExplanation="Infobar Background"
+                    ColorName="System / Neutral Background"
+                    ColorValue="#FFFFFF (08, 3.26%)" />
+                <designguidance:ColorTile
+                    Grid.Column="2"
+                    Background="{ThemeResource SystemFillColorSolidNeutralBackgroundBrush}"
+                    ColorBrushName="SystemFillColorSolidNeutralBackgroundBrush"
+                    ColorExplanation="Neutral badges over content"
+                    ColorName="System / Solid Neutral Background"
+                    ColorValue="#2E2E2E" />
+            </Grid>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <designguidance:ColorTile
+                    Grid.Column="2"
+                    Background="{ThemeResource SystemFillColorSolidAttentionBackgroundBrush}"
+                    ColorBrushName="SystemFillColorSolidAttentionBackgroundBrush"
+                    ColorName="System / Solid Attention Background"
+                    ColorValue="#2E2E2E"
+                    ShowSeparator="False" />
+            </Grid>
 
-    </StackPanel>
+        </StackPanel>
+    </wdc:SampleThemeListener>
 </Page>

--- a/WinUIGallery/Controls/DesignGuidance/ColorSections/StrokeSection.xaml
+++ b/WinUIGallery/Controls/DesignGuidance/ColorSections/StrokeSection.xaml
@@ -7,334 +7,336 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:designguidance="using:WinUIGallery.DesktopWap.Controls.DesignGuidance"
+    xmlns:wdc="using:WinUIGallery.DesktopWap.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
+    <wdc:SampleThemeListener>
+        <StackPanel Spacing="{StaticResource ColorSectionSpacing}">
 
-    <StackPanel Spacing="{StaticResource ColorSectionSpacing}">
-
-        <!--  Card Stroke  -->
-        <designguidance:ColorPageExample
-            Title="Card Stroke"
-            Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
-            Description="Used for card and layer colors.">
-            <Grid
-                Width="60"
-                Height="48"
-                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                CornerRadius="{StaticResource ControlCornerRadius}" />
-        </designguidance:ColorPageExample>
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <designguidance:ColorTile
-                Background="{ThemeResource CardStrokeColorDefaultBrush}"
-                ColorBrushName="CardStrokeColorDefaultBrush"
-                ColorExplanation="Card layer and strokes"
-                ColorName="Card Stroke / Default"
-                ColorValue="#000000 (0F, 6.78%)" />
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="{ThemeResource CardStrokeColorDefaultSolidBrush}"
-                ColorBrushName="CardStrokeColorDefaultSolidBrush"
-                ColorExplanation="Solid equivalent of Card Stroke / Default. Used in command bar for expanded states"
-                ColorName="Card Stroke / Default Solid"
-                ColorValue="#EBEBEB (FF, 100%)"
-                ShowSeparator="False" />
-        </Grid>
-
-        <!--  Control Elevation (gradient strokes)  -->
-        <designguidance:ColorPageExample
-            Title="Control Elevation (gradient strokes)"
-            Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
-            Description="Used for standard control strokes and stroke states.">
-            <Button Content="Text" />
-        </designguidance:ColorPageExample>
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <designguidance:ColorTile
-                Background="{ThemeResource ControlElevationBorderBrush}"
-                ColorBrushName="ControlElevationBorderBrush"
-                ColorExplanation="Rest"
-                ColorName="Control / Border"
-                ColorValue="Stop 1: Stroke/Control/Default Stop 2: Stroke/Control/Secondary" />
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="{ThemeResource CircleElevationBorderBrush}"
-                ColorBrushName="CircleElevationBorderBrush"
-                ColorExplanation="Rest"
-                ColorName="Circle / Border"
-                ColorValue="Stop 1: Stroke/Control/Default Stop 2: Stroke/Control/Secondary" />
-            <designguidance:ColorTile
-                Grid.Column="2"
-                Background="{ThemeResource TextControlElevationBorderBrush}"
-                ColorBrushName="TextControlElevationBorderBrush"
-                ColorExplanation="Rest"
-                ColorName="Text Control / Border"
-                ColorValue="Stop 1: Stroke/Control/Default Stop 2: Stroke/Control Strong/Default" />
-        </Grid>
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <designguidance:ColorTile
-                Grid.Column="0"
-                Background="{ThemeResource TextControlElevationBorderFocusedBrush}"
-                ColorBrushName="TextControlElevationBorderFocusedBrush"
-                ColorExplanation="Active text fields"
-                ColorName="Text Control / Border Focused"
-                ColorValue="Stop 1: Stroke/Control/Default Stop 2: Fill/Accent/Default" />
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="{ThemeResource AccentControlElevationBorderBrush}"
-                ColorBrushName="AccentControlElevationBorderBrush"
-                ColorExplanation="Rest"
-                ColorName="Accent Control / Border"
-                ColorValue="Stop 1: Stroke/Control/On Accent Default Stop 2: Stroke/Control/On Accent Secondary" />
-        </Grid>
-
-        <!--  Control Stroke  -->
-        <designguidance:ColorPageExample
-            Title="Control Stroke"
-            Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
-            Description="Used for gradient stops in elevation borders, and for control states.">
-            <Button Content="Text" />
-        </designguidance:ColorPageExample>
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <designguidance:ColorTile
-                Background="{ThemeResource ControlStrokeColorDefaultBrush}"
-                ColorBrushName="ControlStrokeColorDefaultBrush"
-                ColorExplanation="Used in Control Elevation Brushes. Pressed or Disabled"
-                ColorName="Control Stroke / Default"
-                ColorValue="#000000 (0F, 5.78%)" />
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="{ThemeResource ControlStrokeColorSecondaryBrush}"
-                ColorBrushName="ControlStrokeColorSecondaryBrush"
-                ColorExplanation="Used in Control Elevation Brushes"
-                ColorName="Control Stroke / Secondary"
-                ColorValue="#000000 (29, 16.22%)" />
-            <designguidance:ColorTile
-                Grid.Column="2"
-                Background="{ThemeResource ControlStrokeColorOnAccentDefaultBrush}"
-                ColorBrushName="ControlStrokeColorOnAccentDefaultBrush"
-                ColorExplanation="Used in Control Elevation Brushes. Pressed or Disabled"
-                ColorName="Control Stroke / On Accent Default"
-                ColorValue="#FFFFFF (14, 8%)" />
-            <designguidance:ColorTile
-                Grid.Column="3"
-                Background="{ThemeResource ControlStrokeColorOnAccentSecondaryBrush}"
-                ColorBrushName="ControlStrokeColorOnAccentSecondaryBrush"
-                ColorExplanation="Used in Control Elevation Brushes"
-                ColorName="Control Stroke / On Accent Secondary"
-                ColorValue="#000000 (66, 40%)"
-                ShowSeparator="False" />
-        </Grid>
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <designguidance:ColorTile
-                Grid.Column="0"
-                Background="{ThemeResource ControlStrokeColorOnAccentTertiaryBrush}"
-                ColorBrushName="ControlStrokeColorOnAccentTertiaryBrush"
-                ColorExplanation="Linework on Accent controls, ie: dividers"
-                ColorName="Control Stroke / On Accent Tertiary"
-                ColorValue="#000000 (37, 21.69%)" />
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="{ThemeResource ControlStrokeColorOnAccentDisabledBrush}"
-                ColorBrushName="ControlStrokeColorOnAccentDisabledBrush"
-                ColorExplanation="Disabled"
-                ColorName="Control Stroke / On Accent Disabled"
-                ColorValue="#000000 (0F, 5.78%)" />
-            <designguidance:ColorTile
-                Grid.Column="2"
-                Background="{ThemeResource ControlStrokeColorForStrongFillWhenOnImageBrush}"
-                ColorBrushName="ControlStrokeColorForStrongFillWhenOnImageBrush"
-                ColorExplanation="When used with a 'strong' fill color, ensures a 3:1 contrast on any background"
-                ColorName="Control Stroke / For Strong Fill When On Image"
-                ColorValue="#FFFFFF (59, 35%)"
-                ShowSeparator="False" />
-        </Grid>
-
-        <!--  Control Strong Stroke  -->
-        <designguidance:ColorPageExample
-            Title="Control Strong Stroke"
-            Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
-            Description="Used for control strokes that must meet contrast ratio requirements of 3:1.">
-            <ToggleSwitch
-                MinWidth="40"
-                MaxWidth="40"
-                OffContent=""
-                OnContent="" />
-        </designguidance:ColorPageExample>
-
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-
-            <designguidance:ColorTile
-                Background="{ThemeResource ControlStrongStrokeColorDefaultBrush}"
-                ColorBrushName="ControlStrongStrokeColorDefaultBrush"
-                ColorExplanation="3:1 control border"
-                ColorName="Control Strong Stroke / Default"
-                ColorValue="#000000 (72, 44.58%)"
-                Foreground="{ThemeResource TextFillColorInverseBrush}"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Column="2"
-                Background="{ThemeResource ControlStrongStrokeColorDisabledBrush}"
-                ColorBrushName="ControlStrongStrokeColorDisabledBrush"
-                ColorExplanation="Disabled"
-                ColorName="Control Strong Stroke / Disabled"
-                ColorValue="#FFFFFF (37, 21.69%)"
-                ShowSeparator="False" />
-        </Grid>
-
-
-        <!--  Surface Stroke  -->
-        <designguidance:ColorPageExample
-            Title="Surface Stroke"
-            Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
-            Description="Used for strokes on background surfaces, ie: flyouts, windows, dialogs.">
-            <Grid
-                Width="120"
-                Height="40"
-                Background="{ThemeResource AcrylicBackgroundFillColorBaseBrush}"
-                BorderBrush="{ThemeResource SurfaceStrokeColorDefaultBrush}"
-                BorderThickness="1"
-                CornerRadius="{StaticResource OverlayCornerRadius}" />
-        </designguidance:ColorPageExample>
-
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-
-            <designguidance:ColorTile
-                Background="{ThemeResource SurfaceStrokeColorDefaultBrush}"
-                ColorBrushName="SurfaceStrokeColorDefaultBrush"
-                ColorExplanation="Window and dialog borders, theme inverse"
-                ColorName="Surface Stroke / Default"
-                ColorValue="#757575 (66, 40%) Snapped Windows: #757575 (FF, 100%)"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Column="2"
-                Background="{ThemeResource SurfaceStrokeColorFlyoutBrush}"
-                ColorBrushName="SurfaceStrokeColorFlyoutBrush"
-                ColorExplanation="Control flyouts, always dark"
-                ColorName="Surface Stroke / Flyout"
-                ColorValue=""
-                ShowSeparator="False" />
-        </Grid>
-
-
-        <!--  Divider Stroke  -->
-        <designguidance:ColorPageExample
-            Title="Divider Stroke"
-            Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
-            Description="Used for divider and graphic lines.">
-            <Grid
-                Width="120"
-                Height="40"
-                Background="{ThemeResource AcrylicBackgroundFillColorBaseBrush}"
-                BorderBrush="{ThemeResource SurfaceStrokeColorDefaultBrush}"
-                BorderThickness="1"
-                CornerRadius="{StaticResource OverlayCornerRadius}">
-                <Border
-                    Width="1"
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Stretch"
-                    BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
-                    BorderThickness="1" />
-            </Grid>
-        </designguidance:ColorPageExample>
-
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-
-            <designguidance:ColorTile
-                Background="{ThemeResource DividerStrokeColorDefaultBrush}"
-                ColorBrushName="DividerStrokeColorDefaultBrush"
-                ColorExplanation="Content dividers"
-                ColorName="Divider Stroke / Default"
-                ColorValue="#0000000 (DF, 5.78%)"
-                Foreground="{ThemeResource TextFillColorPrimary}"
-                ShowSeparator="False" />
-        </Grid>
-
-        <!--  Focus Stroke  -->
-        <designguidance:ColorPageExample
-            Title="Focus Stroke"
-            Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
-            Description="Used for divider and graphic lines. Theme inverse; dark in light theme and light in dark theme.">
-            <Grid
-                BorderBrush="{ThemeResource FocusStrokeColorOuterBrush}"
-                BorderThickness="2"
-                CornerRadius="10">
+            <!--  Card Stroke  -->
+            <designguidance:ColorPageExample
+                Title="Card Stroke"
+                Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
+                Description="Used for card and layer colors.">
                 <Grid
-                    BorderBrush="{ThemeResource FocusStrokeColorInnerBrush}"
+                    Width="60"
+                    Height="48"
+                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    CornerRadius="{StaticResource ControlCornerRadius}" />
+            </designguidance:ColorPageExample>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <designguidance:ColorTile
+                    Background="{ThemeResource CardStrokeColorDefaultBrush}"
+                    ColorBrushName="CardStrokeColorDefaultBrush"
+                    ColorExplanation="Card layer and strokes"
+                    ColorName="Card Stroke / Default"
+                    ColorValue="#000000 (0F, 6.78%)" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="{ThemeResource CardStrokeColorDefaultSolidBrush}"
+                    ColorBrushName="CardStrokeColorDefaultSolidBrush"
+                    ColorExplanation="Solid equivalent of Card Stroke / Default. Used in command bar for expanded states"
+                    ColorName="Card Stroke / Default Solid"
+                    ColorValue="#EBEBEB (FF, 100%)"
+                    ShowSeparator="False" />
+            </Grid>
+
+            <!--  Control Elevation (gradient strokes)  -->
+            <designguidance:ColorPageExample
+                Title="Control Elevation (gradient strokes)"
+                Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
+                Description="Used for standard control strokes and stroke states.">
+                <Button Content="Text" />
+            </designguidance:ColorPageExample>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <designguidance:ColorTile
+                    Background="{ThemeResource ControlElevationBorderBrush}"
+                    ColorBrushName="ControlElevationBorderBrush"
+                    ColorExplanation="Rest"
+                    ColorName="Control / Border"
+                    ColorValue="Stop 1: Stroke/Control/Default Stop 2: Stroke/Control/Secondary" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="{ThemeResource CircleElevationBorderBrush}"
+                    ColorBrushName="CircleElevationBorderBrush"
+                    ColorExplanation="Rest"
+                    ColorName="Circle / Border"
+                    ColorValue="Stop 1: Stroke/Control/Default Stop 2: Stroke/Control/Secondary" />
+                <designguidance:ColorTile
+                    Grid.Column="2"
+                    Background="{ThemeResource TextControlElevationBorderBrush}"
+                    ColorBrushName="TextControlElevationBorderBrush"
+                    ColorExplanation="Rest"
+                    ColorName="Text Control / Border"
+                    ColorValue="Stop 1: Stroke/Control/Default Stop 2: Stroke/Control Strong/Default" />
+            </Grid>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <designguidance:ColorTile
+                    Grid.Column="0"
+                    Background="{ThemeResource TextControlElevationBorderFocusedBrush}"
+                    ColorBrushName="TextControlElevationBorderFocusedBrush"
+                    ColorExplanation="Active text fields"
+                    ColorName="Text Control / Border Focused"
+                    ColorValue="Stop 1: Stroke/Control/Default Stop 2: Fill/Accent/Default" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="{ThemeResource AccentControlElevationBorderBrush}"
+                    ColorBrushName="AccentControlElevationBorderBrush"
+                    ColorExplanation="Rest"
+                    ColorName="Accent Control / Border"
+                    ColorValue="Stop 1: Stroke/Control/On Accent Default Stop 2: Stroke/Control/On Accent Secondary" />
+            </Grid>
+
+            <!--  Control Stroke  -->
+            <designguidance:ColorPageExample
+                Title="Control Stroke"
+                Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
+                Description="Used for gradient stops in elevation borders, and for control states.">
+                <Button Content="Text" />
+            </designguidance:ColorPageExample>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <designguidance:ColorTile
+                    Background="{ThemeResource ControlStrokeColorDefaultBrush}"
+                    ColorBrushName="ControlStrokeColorDefaultBrush"
+                    ColorExplanation="Used in Control Elevation Brushes. Pressed or Disabled"
+                    ColorName="Control Stroke / Default"
+                    ColorValue="#000000 (0F, 5.78%)" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="{ThemeResource ControlStrokeColorSecondaryBrush}"
+                    ColorBrushName="ControlStrokeColorSecondaryBrush"
+                    ColorExplanation="Used in Control Elevation Brushes"
+                    ColorName="Control Stroke / Secondary"
+                    ColorValue="#000000 (29, 16.22%)" />
+                <designguidance:ColorTile
+                    Grid.Column="2"
+                    Background="{ThemeResource ControlStrokeColorOnAccentDefaultBrush}"
+                    ColorBrushName="ControlStrokeColorOnAccentDefaultBrush"
+                    ColorExplanation="Used in Control Elevation Brushes. Pressed or Disabled"
+                    ColorName="Control Stroke / On Accent Default"
+                    ColorValue="#FFFFFF (14, 8%)" />
+                <designguidance:ColorTile
+                    Grid.Column="3"
+                    Background="{ThemeResource ControlStrokeColorOnAccentSecondaryBrush}"
+                    ColorBrushName="ControlStrokeColorOnAccentSecondaryBrush"
+                    ColorExplanation="Used in Control Elevation Brushes"
+                    ColorName="Control Stroke / On Accent Secondary"
+                    ColorValue="#000000 (66, 40%)"
+                    ShowSeparator="False" />
+            </Grid>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <designguidance:ColorTile
+                    Grid.Column="0"
+                    Background="{ThemeResource ControlStrokeColorOnAccentTertiaryBrush}"
+                    ColorBrushName="ControlStrokeColorOnAccentTertiaryBrush"
+                    ColorExplanation="Linework on Accent controls, ie: dividers"
+                    ColorName="Control Stroke / On Accent Tertiary"
+                    ColorValue="#000000 (37, 21.69%)" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="{ThemeResource ControlStrokeColorOnAccentDisabledBrush}"
+                    ColorBrushName="ControlStrokeColorOnAccentDisabledBrush"
+                    ColorExplanation="Disabled"
+                    ColorName="Control Stroke / On Accent Disabled"
+                    ColorValue="#000000 (0F, 5.78%)" />
+                <designguidance:ColorTile
+                    Grid.Column="2"
+                    Background="{ThemeResource ControlStrokeColorForStrongFillWhenOnImageBrush}"
+                    ColorBrushName="ControlStrokeColorForStrongFillWhenOnImageBrush"
+                    ColorExplanation="When used with a 'strong' fill color, ensures a 3:1 contrast on any background"
+                    ColorName="Control Stroke / For Strong Fill When On Image"
+                    ColorValue="#FFFFFF (59, 35%)"
+                    ShowSeparator="False" />
+            </Grid>
+
+            <!--  Control Strong Stroke  -->
+            <designguidance:ColorPageExample
+                Title="Control Strong Stroke"
+                Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
+                Description="Used for control strokes that must meet contrast ratio requirements of 3:1.">
+                <ToggleSwitch
+                    MinWidth="40"
+                    MaxWidth="40"
+                    OffContent=""
+                    OnContent="" />
+            </designguidance:ColorPageExample>
+
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <designguidance:ColorTile
+                    Background="{ThemeResource ControlStrongStrokeColorDefaultBrush}"
+                    ColorBrushName="ControlStrongStrokeColorDefaultBrush"
+                    ColorExplanation="3:1 control border"
+                    ColorName="Control Strong Stroke / Default"
+                    ColorValue="#000000 (72, 44.58%)"
+                    Foreground="{ThemeResource TextFillColorInverseBrush}"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Column="2"
+                    Background="{ThemeResource ControlStrongStrokeColorDisabledBrush}"
+                    ColorBrushName="ControlStrongStrokeColorDisabledBrush"
+                    ColorExplanation="Disabled"
+                    ColorName="Control Strong Stroke / Disabled"
+                    ColorValue="#FFFFFF (37, 21.69%)"
+                    ShowSeparator="False" />
+            </Grid>
+
+
+            <!--  Surface Stroke  -->
+            <designguidance:ColorPageExample
+                Title="Surface Stroke"
+                Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
+                Description="Used for strokes on background surfaces, ie: flyouts, windows, dialogs.">
+                <Grid
+                    Width="120"
+                    Height="40"
+                    Background="{ThemeResource AcrylicBackgroundFillColorBaseBrush}"
+                    BorderBrush="{ThemeResource SurfaceStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="{StaticResource OverlayCornerRadius}" />
+            </designguidance:ColorPageExample>
+
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <designguidance:ColorTile
+                    Background="{ThemeResource SurfaceStrokeColorDefaultBrush}"
+                    ColorBrushName="SurfaceStrokeColorDefaultBrush"
+                    ColorExplanation="Window and dialog borders, theme inverse"
+                    ColorName="Surface Stroke / Default"
+                    ColorValue="#757575 (66, 40%) Snapped Windows: #757575 (FF, 100%)"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Column="2"
+                    Background="{ThemeResource SurfaceStrokeColorFlyoutBrush}"
+                    ColorBrushName="SurfaceStrokeColorFlyoutBrush"
+                    ColorExplanation="Control flyouts, always dark"
+                    ColorName="Surface Stroke / Flyout"
+                    ColorValue=""
+                    ShowSeparator="False" />
+            </Grid>
+
+
+            <!--  Divider Stroke  -->
+            <designguidance:ColorPageExample
+                Title="Divider Stroke"
+                Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
+                Description="Used for divider and graphic lines.">
+                <Grid
+                    Width="120"
+                    Height="40"
+                    Background="{ThemeResource AcrylicBackgroundFillColorBaseBrush}"
+                    BorderBrush="{ThemeResource SurfaceStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="{StaticResource OverlayCornerRadius}">
+                    <Border
+                        Width="1"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Stretch"
+                        BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
+                        BorderThickness="1" />
+                </Grid>
+            </designguidance:ColorPageExample>
+
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <designguidance:ColorTile
+                    Background="{ThemeResource DividerStrokeColorDefaultBrush}"
+                    ColorBrushName="DividerStrokeColorDefaultBrush"
+                    ColorExplanation="Content dividers"
+                    ColorName="Divider Stroke / Default"
+                    ColorValue="#0000000 (DF, 5.78%)"
+                    Foreground="{ThemeResource TextFillColorPrimary}"
+                    ShowSeparator="False" />
+            </Grid>
+
+            <!--  Focus Stroke  -->
+            <designguidance:ColorPageExample
+                Title="Focus Stroke"
+                Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
+                Description="Used for divider and graphic lines. Theme inverse; dark in light theme and light in dark theme.">
+                <Grid
+                    BorderBrush="{ThemeResource FocusStrokeColorOuterBrush}"
                     BorderThickness="2"
-                    CornerRadius="9">
+                    CornerRadius="10">
                     <Grid
-                        Width="120"
-                        Height="40"
-                        BorderBrush="{ThemeResource SurfaceStrokeColorDefaultBrush}"
-                        BorderThickness="1"
-                        CornerRadius="{StaticResource OverlayCornerRadius}">
-                        <TextBlock
-                            HorizontalAlignment="Center"
-                            VerticalAlignment="Center"
-                            Text="Text" />
+                        BorderBrush="{ThemeResource FocusStrokeColorInnerBrush}"
+                        BorderThickness="2"
+                        CornerRadius="9">
+                        <Grid
+                            Width="120"
+                            Height="40"
+                            BorderBrush="{ThemeResource SurfaceStrokeColorDefaultBrush}"
+                            BorderThickness="1"
+                            CornerRadius="{StaticResource OverlayCornerRadius}">
+                            <TextBlock
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                Text="Text" />
+                        </Grid>
                     </Grid>
                 </Grid>
+            </designguidance:ColorPageExample>
+
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <designguidance:ColorTile
+                    Background="{ThemeResource FocusStrokeColorOuterBrush}"
+                    ColorBrushName="FocusStrokeColorOuterBrush"
+                    ColorExplanation="Outer stroke color"
+                    ColorName="Focus / Outer"
+                    ColorValue="#000000 (E4, 89.56%)"
+                    Foreground="{ThemeResource TextFillColorInverseBrush}"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="{ThemeResource FocusStrokeColorInnerBrush}"
+                    ColorBrushName="FocusStrokeColorInnerBrush"
+                    ColorExplanation="Inner stroke color"
+                    ColorName="Focus / Inner"
+                    ColorValue="#FFFFFF (B3, 70%)"
+                    ShowSeparator="False" />
             </Grid>
-        </designguidance:ColorPageExample>
 
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-
-            <designguidance:ColorTile
-                Background="{ThemeResource FocusStrokeColorOuterBrush}"
-                ColorBrushName="FocusStrokeColorOuterBrush"
-                ColorExplanation="Outer stroke color"
-                ColorName="Focus / Outer"
-                ColorValue="#000000 (E4, 89.56%)"
-                Foreground="{ThemeResource TextFillColorInverseBrush}"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="{ThemeResource FocusStrokeColorInnerBrush}"
-                ColorBrushName="FocusStrokeColorInnerBrush"
-                ColorExplanation="Inner stroke color"
-                ColorName="Focus / Inner"
-                ColorValue="#FFFFFF (B3, 70%)"
-                ShowSeparator="False" />
-        </Grid>
-
-    </StackPanel>
+        </StackPanel>
+    </wdc:SampleThemeListener>
 </Page>

--- a/WinUIGallery/Controls/DesignGuidance/ColorSections/TextSection.xaml
+++ b/WinUIGallery/Controls/DesignGuidance/ColorSections/TextSection.xaml
@@ -7,182 +7,186 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:designguidance="using:WinUIGallery.DesktopWap.Controls.DesignGuidance"
+    xmlns:wdc="using:WinUIGallery.DesktopWap.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
     <!--  Colors section  -->
-    <StackPanel Spacing="{StaticResource ColorSectionSpacing}">
-        <!--  Text  -->
-        <designguidance:ColorPageExample
-            Title="Text"
-            Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
-            Description="For UI labels and static text">
-            <TextBlock
-                FontSize="42"
-                FontWeight="SemiBold"
-                Text="Aa" />
-        </designguidance:ColorPageExample>
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <designguidance:ColorTile
-                Background="{ThemeResource TextFillColorPrimaryBrush}"
-                ColorBrushName="TextFillColorPrimaryBrush"
-                ColorExplanation="Rest or Hover"
-                ColorName="Text / Primary"
-                ColorValue="#000000 (E4, 89.56%)"
-                Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="{ThemeResource TextFillColorSecondaryBrush}"
-                ColorBrushName="TextFillColorSecondaryBrush"
-                ColorExplanation="Rest or Hover"
-                ColorName="Text / Secondary"
-                ColorValue="#000000 (9E, 61.86%)"
-                Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Column="2"
-                Background="{ThemeResource TextFillColorTertiaryBrush}"
-                ColorBrushName="TextFillColorTertiaryBrush"
-                ColorExplanation="Pressed only (not accessible)"
-                ColorName="Text / Tertiary"
-                ColorValue="#000000 (72, 44.58%)"
-                Foreground="{ThemeResource TextFillColorPrimaryBrush}"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Column="3"
-                Background="{ThemeResource TextFillColorDisabledBrush}"
-                ColorBrushName="TextFillColorDisabledBrush"
-                ColorExplanation="Disabled only (not accessible)"
-                ColorName="Text / Disabled"
-                ColorValue="#000000 (5C, 36.14%)"
-                Foreground="{ThemeResource TextFillColorPrimaryBrush}"
-                ShowSeparator="False" />
-        </Grid>
+    <wdc:SampleThemeListener>
+        <StackPanel Spacing="{StaticResource ColorSectionSpacing}">
+            <!--  Text  -->
+            <designguidance:ColorPageExample
+                Title="Text"
+                Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
+                Description="For UI labels and static text">
+                <TextBlock
+                    FontSize="42"
+                    FontWeight="SemiBold"
+                    Text="Aa" />
+            </designguidance:ColorPageExample>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <designguidance:ColorTile
+                    Background="{ThemeResource TextFillColorPrimaryBrush}"
+                    ColorBrushName="TextFillColorPrimaryBrush"
+                    ColorExplanation="Rest or Hover"
+                    ColorName="Text / Primary"
+                    ColorValue="#000000 (E4, 89.56%)"
+                    Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="{ThemeResource TextFillColorSecondaryBrush}"
+                    ColorBrushName="TextFillColorSecondaryBrush"
+                    ColorExplanation="Rest or Hover"
+                    ColorName="Text / Secondary"
+                    ColorValue="#000000 (9E, 61.86%)"
+                    Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Column="2"
+                    Background="{ThemeResource TextFillColorTertiaryBrush}"
+                    ColorBrushName="TextFillColorTertiaryBrush"
+                    ColorExplanation="Pressed only (not accessible)"
+                    ColorName="Text / Tertiary"
+                    ColorValue="#000000 (72, 44.58%)"
+                    Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Column="3"
+                    Background="{ThemeResource TextFillColorDisabledBrush}"
+                    ColorBrushName="TextFillColorDisabledBrush"
+                    ColorExplanation="Disabled only (not accessible)"
+                    ColorName="Text / Disabled"
+                    ColorValue="#000000 (5C, 36.14%)"
+                    Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+                    ShowSeparator="False" />
+            </Grid>
 
 
-        <!--  Accent text  -->
-        <designguidance:ColorPageExample
-            Title="Accent Text"
-            Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
-            Description="Recommended for links">
-            <TextBlock
-                FontSize="42"
-                FontWeight="SemiBold"
-                Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
-                Text="Aa" />
-        </designguidance:ColorPageExample>
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
-            <designguidance:ColorTile
-                Background="{ThemeResource AccentTextFillColorPrimaryBrush}"
-                ColorBrushName="AccentTextFillColorPrimaryBrush"
-                ColorExplanation="Rest or Hover"
-                ColorName="Accent Text / Primary"
-                ColorValue="Dark 2"
-                Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Column="1"
-                Background="{ThemeResource AccentTextFillColorSecondaryBrush}"
-                ColorBrushName="AccentTextFillColorSecondaryBrush"
-                ColorExplanation="Rest or Hover"
-                ColorName="Accent Text / Secondary"
-                ColorValue="Dark 3"
-                Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Column="2"
-                Background="{ThemeResource AccentTextFillColorTertiaryBrush}"
-                ColorBrushName="AccentTextFillColorTertiaryBrush"
-                ColorExplanation="Pressed only (not accessible)"
-                ColorName="Accent Text / Tertiary"
-                ColorValue="Dark 1"
-                Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
-                ShowSeparator="False" />
-            <designguidance:ColorTile
-                Grid.Column="3"
-                Background="{ThemeResource AccentTextFillColorDisabledBrush}"
-                ColorBrushName="AccentTextFillColorDisabledBrush"
-                ColorExplanation="Disabled only (not accessible)"
-                ColorName="Accent Text / Disabled"
-                ColorValue="#000000 (5C, 36.14%)"
-                Foreground="{ThemeResource TextFillColorPrimaryBrush}"
-                ShowSeparator="False" />
-        </Grid>
+            <!--  Accent text  -->
+            <designguidance:ColorPageExample
+                Title="Accent Text"
+                Background="{ThemeResource SolidBackgroundFillColorQuarternaryBrush}"
+                Description="Recommended for links">
+                <TextBlock
+                    FontSize="42"
+                    FontWeight="SemiBold"
+                    Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
+                    Text="Aa" />
+            </designguidance:ColorPageExample>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <designguidance:ColorTile
+                    Background="{ThemeResource AccentTextFillColorPrimaryBrush}"
+                    ColorBrushName="AccentTextFillColorPrimaryBrush"
+                    ColorExplanation="Rest or Hover"
+                    ColorName="Accent Text / Primary"
+                    ColorValue="Dark 2"
+                    Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Column="1"
+                    Background="{ThemeResource AccentTextFillColorSecondaryBrush}"
+                    ColorBrushName="AccentTextFillColorSecondaryBrush"
+                    ColorExplanation="Rest or Hover"
+                    ColorName="Accent Text / Secondary"
+                    ColorValue="Dark 3"
+                    Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Column="2"
+                    Background="{ThemeResource AccentTextFillColorTertiaryBrush}"
+                    ColorBrushName="AccentTextFillColorTertiaryBrush"
+                    ColorExplanation="Pressed only (not accessible)"
+                    ColorName="Accent Text / Tertiary"
+                    ColorValue="Dark 1"
+                    Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
+                    ShowSeparator="False" />
+                <designguidance:ColorTile
+                    Grid.Column="3"
+                    Background="{ThemeResource AccentTextFillColorDisabledBrush}"
+                    ColorBrushName="AccentTextFillColorDisabledBrush"
+                    ColorExplanation="Disabled only (not accessible)"
+                    ColorName="Accent Text / Disabled"
+                    ColorValue="#000000 (5C, 36.14%)"
+                    Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+                    ShowSeparator="False" />
+            </Grid>
 
 
-        <!--  Text on accent  -->
-        <designguidance:ColorPageExample
-            Title="Text On Accent"
-            Background="{ThemeResource AccentFillColorDefaultBrush}"
-            Description="Used for text on accent colored controls or fills"
-            Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}">
-            <TextBlock
-                FontSize="42"
-                FontWeight="SemiBold"
-                Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
-                Text="Aa" />
-        </designguidance:ColorPageExample>
+            <!--  Text on accent  -->
+            <designguidance:ColorPageExample
+                Title="Text On Accent"
+                Background="{ThemeResource AccentFillColorDefaultBrush}"
+                Description="Used for text on accent colored controls or fills"
+                Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}">
+                <TextBlock
+                    FontSize="42"
+                    FontWeight="SemiBold"
+                    Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
+                    Text="Aa" />
+            </designguidance:ColorPageExample>
 
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
 
-            <designguidance:ColorTile
-                Background="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
-                ColorBrushName="TextOnAccentFillColorPrimaryBrush"
-                ColorExplanation="Rest or Hover"
-                ColorName="Text on Accent / Primary"
-                ColorValue="#FFFFFF (FF, 100%)"
-                Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
+                <designguidance:ColorTile
+                    Background="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
+                    ColorBrushName="TextOnAccentFillColorPrimaryBrush"
+                    ColorExplanation="Rest or Hover"
+                    ColorName="Text on Accent / Primary"
+                    ColorValue="#FFFFFF (FF, 100%)"
+                    Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
 
-            <designguidance:ColorTile
-                Grid.Column="2"
-                Background="{ThemeResource TextOnAccentFillColorSecondaryBrush}"
-                ColorBrushName="TextOnAccentFillColorSecondaryBrush"
-                ColorExplanation="Pressed only (not accessible)"
-                ColorName="Text on Accent / Secondary"
-                ColorValue="#FFFFFF (B3, 70%)"
-                Foreground="{ThemeResource TextFillColorPrimaryBrush}"
-                ShowSeparator="False" />
-        </Grid>
+                <designguidance:ColorTile
+                    Grid.Column="2"
+                    Background="{ThemeResource TextOnAccentFillColorSecondaryBrush}"
+                    ColorBrushName="TextOnAccentFillColorSecondaryBrush"
+                    ColorExplanation="Pressed only (not accessible)"
+                    ColorName="Text on Accent / Secondary"
+                    ColorValue="#FFFFFF (B3, 70%)"
+                    Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+                    ShowSeparator="False" />
+            </Grid>
 
-        <Grid Style="{StaticResource GalleryTileGridStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
+            <Grid Style="{StaticResource GalleryTileGridStyle}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
 
-            <designguidance:ColorTile
-                Background="{ThemeResource TextOnAccentFillColorDisabledBrush}"
-                ColorBrushName="TextOnAccentFillColorDisabledBrush"
-                ColorExplanation="Disabled only (not accessible)"
-                ColorName="Text on Accent / Disabled"
-                ColorValue="#FFFFFF (FF, 100%)"
-                Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
-            <designguidance:ColorTile
-                Grid.Column="2"
-                Background="{ThemeResource TextOnAccentFillColorSelectedTextBrush}"
-                ColorBrushName="TextOnAccentFillColorSelectedTextBrush"
-                ColorExplanation="For highlighted text in text entry experiences"
-                ColorName="Text on Accent / Selected Text"
-                ColorValue="#FFFFFF (FF, 100%)"
-                Foreground="Black"
-                ShowSeparator="False" />
-        </Grid>
-    </StackPanel>
+                <designguidance:ColorTile
+                    Background="{ThemeResource TextOnAccentFillColorDisabledBrush}"
+                    ColorBrushName="TextOnAccentFillColorDisabledBrush"
+                    ColorExplanation="Disabled only (not accessible)"
+                    ColorName="Text on Accent / Disabled"
+                    ColorValue="#FFFFFF (FF, 100%)"
+                    Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
+                <designguidance:ColorTile
+                    Grid.Column="2"
+                    Background="{ThemeResource TextOnAccentFillColorSelectedTextBrush}"
+                    ColorBrushName="TextOnAccentFillColorSelectedTextBrush"
+                    ColorExplanation="For highlighted text in text entry experiences"
+                    ColorName="Text on Accent / Selected Text"
+                    ColorValue="#FFFFFF (FF, 100%)"
+                    Foreground="Black"
+                    ShowSeparator="False" />
+            </Grid>
+        </StackPanel>
+    </wdc:SampleThemeListener>
+
 </Page>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The changes in this PR prevent the `SampleThemeListener` from applying theme changes to all child elements, including some textboxes, which do not need to be affected by the theme toggle. These changes address the issue of inconsistent text highlighting in the "High Contrast" section of the `ColorPage` by improving theme handling. The main changes are:
- Removed `<SampleThemeListener>` from `ColorPage`.
- Added `<SampleThemeListener>` to other "Color Sections" pages as needed for better modularity.



## Motivation and Context
Fixes #1671 

## How Has This Been Tested?
**Manually Tested** by toggling the theme in all sections of the `ColorPage` and observing the behavior.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
