### PR TITLE
Fix broken WinUI repo link

### DIFF
--- a/WinUIGallery/ItemPage.xaml.cs
+++ b/WinUIGallery/ItemPage.xaml.cs
@@ -9,23 +9,13 @@
 //*********************************************************
 using System;
 using System.Linq;
-using System.Numerics;
 using System.Reflection;
-using WinUIGallery.Data;
-using WinUIGallery.Helper;
-using Windows.Foundation;
-using Windows.Foundation.Metadata;
-using Windows.System;
-using Microsoft.UI.Composition;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Hosting;
-using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media.Animation;
 using Microsoft.UI.Xaml.Navigation;
+using WinUIGallery.Data;
 using WinUIGallery.DesktopWap.Controls;
-using WASDK = Microsoft.WindowsAppSDK;
+using WinUIGallery.Helper;
 
 namespace WinUIGallery
 {
@@ -34,7 +24,7 @@ namespace WinUIGallery
     /// </summary>
     public sealed partial class ItemPage : Page
     {
-        private static string WinUIBaseUrl = string.Format("https://github.com/microsoft/microsoft-ui-xaml/tree/winui3/release/{0}.{1}-stable/controls/dev", WASDK.Release.Major, WASDK.Release.Minor);
+        private static string WinUIBaseUrl = "https://github.com/microsoft/microsoft-ui-xaml/tree/main/src/controls/dev";
         private static string GalleryBaseUrl = "https://github.com/microsoft/WinUI-Gallery/tree/main/WinUIGallery/ControlPages/";
 
         public ControlInfoDataItem Item


### PR DESCRIPTION
A few weeks ago the WinUI source code moved to the `main` branch as it should be. Therefore, we no longer need to link to a specific branch/version number.

As a result, the source code links are working again!

Closes: #1681