### PR TITLE
Add Manual WebView2 Package Reference to Bypass Store Validation Error

### DIFF
--- a/WinUIGallery/WinUIGallery.csproj
+++ b/WinUIGallery/WinUIGallery.csproj
@@ -99,6 +99,9 @@
             just add versionless PackageReferences here.  They will be updated to their actual versions by either the Packages.props file
             in the WinUI repo, or the next ItemGroup below when standalone. -->
     <ItemGroup>
+        <!-- https://github.com/microsoft/WindowsAppSDK/issues/4836 -->
+        <!-- Explicitly added latest version of WebView2 as temporary workaround for Windows Store validation error. -->
+        <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2903.40" />
         <PackageReference Include="Microsoft.WindowsAppSDK" />
         <PackageReference Include="ColorCode.Core" />
         <PackageReference Include="Microsoft.Graphics.Win2D" />


### PR DESCRIPTION
## Description
Manually adding latest version of WebView2 package reference to bypass Microsoft Partner Center validation error.

See:
https://github.com/microsoft/WindowsAppSDK/issues/4836

and internal bug: 55448079
