### PR TITLE
Fixed 24H2 build number

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -26,7 +26,7 @@ body:
       multiple: true
       options:
         - Insider Build (xxxxx)
-        - Windows 11 24H2 (26052)
+        - Windows 11 24H2 (26100)
         - Windows 11 23H2 (22631)
         - Windows 11 22H2 (22621)
         - Windows 11 21H2 (22000)


### PR DESCRIPTION
Fixed 24H2 build number in the issue template. The correct build is `26100` not `26052`.