### PR TITLE
Fix the theme resource link

### DIFF
--- a/WinUIGallery/DataModel/ControlInfoData.json
+++ b/WinUIGallery/DataModel/ControlInfoData.json
@@ -24,7 +24,7 @@
             },
             {
               "Title": "WinUI Theme Resources (GitHub)",
-              "Uri": "https://github.com/microsoft/microsoft-ui-xaml/blob/winui3/release/X.Y-stable/controls/dev/CommonStyles/Common_themeresources_any.xaml"
+              "Uri": "https://github.com/microsoft/microsoft-ui-xaml/blob/winui3/release/X.Y-stable/src/controls/dev/CommonStyles/Common_themeresources_any.xaml"
             }
           ]
         },

--- a/WinUIGallery/DataModel/ControlInfoData.json
+++ b/WinUIGallery/DataModel/ControlInfoData.json
@@ -24,7 +24,7 @@
             },
             {
               "Title": "WinUI Theme Resources (GitHub)",
-              "Uri": "https://github.com/microsoft/microsoft-ui-xaml/blob/winui3/release/X.Y-stable/src/controls/dev/CommonStyles/Common_themeresources_any.xaml"
+              "Uri": "https://github.com/microsoft/microsoft-ui-xaml/blob/main/src/controls/dev/CommonStyles/Common_themeresources_any.xaml"
             }
           ]
         },
@@ -40,7 +40,7 @@
             },
             {
               "Title": "WinUI Theme Resources (GitHub)",
-              "Uri": "https://github.com/microsoft/microsoft-ui-xaml/blob/winui3/release/X.Y-stable/src/controls/dev/CommonStyles/Common_themeresources_any.xaml"
+              "Uri": "https://github.com/microsoft/microsoft-ui-xaml/blob/main/src/controls/dev/CommonStyles/Common_themeresources_any.xaml"
             }
           ]
         },

--- a/WinUIGallery/DataModel/ControlInfoData.json
+++ b/WinUIGallery/DataModel/ControlInfoData.json
@@ -36,11 +36,11 @@
           "Docs": [
             {
               "Title": "Geometry in Windows 11",
-              "Uri": "https://learn.microsoft.com/en-us/windows/apps/design/signature-experiences/geometry"
+              "Uri": "https://learn.microsoft.com/windows/apps/design/signature-experiences/geometry"
             },
             {
               "Title": "WinUI Theme Resources (GitHub)",
-              "Uri": "https://github.com/microsoft/microsoft-ui-xaml/blob/winui3/release/X.Y-stable/controls/dev/CommonStyles/Common_themeresources_any.xaml"
+              "Uri": "https://github.com/microsoft/microsoft-ui-xaml/blob/winui3/release/X.Y-stable/src/controls/dev/CommonStyles/Common_themeresources_any.xaml"
             }
           ]
         },
@@ -68,7 +68,7 @@
           "Docs": [
             {
               "Title": "Content design basics",
-              "Uri": "https://learn.microsoft.com/en-us/windows/apps/design/basics/content-basics"
+              "Uri": "https://learn.microsoft.com/windows/apps/design/basics/content-basics"
             }
           ]
         },
@@ -511,7 +511,7 @@
             },
             {
               "Title": "MenuFlyoutSubItem - API",
-              "Uri": "https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.menuflyoutsubitem"
+              "Uri": "https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.menuflyoutsubitem"
             },
             {
               "Title": "MenuFlyoutSeparator - API",
@@ -523,7 +523,7 @@
             },
             {
               "Title": "RadioMenuFlyoutItem - API",
-              "Uri": "https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.radiomenuflyoutitem"
+              "Uri": "https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.radiomenuflyoutitem"
             },
             {
               "Title": "Guidelines",
@@ -2581,7 +2581,7 @@
           "Docs": [
             {
               "Title": "MapControl - API",
-              "Uri": "https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.mapcontrol"
+              "Uri": "https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.mapcontrol"
             }
           ]
         },


### PR DESCRIPTION
Fixed the "WinUI Theme Resources (Github)" being broken.

## Description
Changed the link in "ControlInfoData.json" from "https://github.com/microsoft/microsoft-ui-xaml/blob/winui3/release/X.Y-stable/controls/dev/CommonStyles/Common_themeresources_any.xaml" to "https://github.com/microsoft/microsoft-ui-xaml/blob/winui3/release/X.Y-stable/src/controls/dev/CommonStyles/Common_themeresources_any.xaml"

## Motivation and Context
Fixes https://github.com/microsoft/WinUI-Gallery/issues/1712

## How Has This Been Tested?
Manual

## Screenshots:
![image](https://github.com/user-attachments/assets/49e53bd6-c895-4f79-8c9f-aec259e193c5)
![image](https://github.com/user-attachments/assets/b519ffee-6c44-48d1-ba1c-8dc8ea02eade)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
