### PR TITLE
fix typo in ListView context menus example

### DIFF
--- a/WinUIGallery/ControlPages/ListViewPage.xaml
+++ b/WinUIGallery/ControlPages/ListViewPage.xaml
@@ -450,7 +450,7 @@ sent or received, and those values are bound in the DataTemplate.--&gt;
                             <Grid>
                                 <Grid.ContextFlyout>
                                     <MenuFlyout>
-                                        <MenuFlyoutItem Text="Delete" Click="ContactDeleteMenuyItem_Click"/>
+                                        <MenuFlyoutItem Text="Delete" Click="ContactDeleteMenuItem_Click"/>
                                     </MenuFlyout>
                                 </Grid.ContextFlyout>
 
@@ -503,7 +503,7 @@ sent or received, and those values are bound in the DataTemplate.--&gt;
             &lt;Grid&gt;
                 &lt;Grid.ContextFlyout&gt;
                     &lt;MenuFlyout&gt;
-                        &lt;MenuFlyoutItem Text="Delete" Click="ContactDeleteMenuyItem_Click"/&gt;
+                        &lt;MenuFlyoutItem Text="Delete" Click="ContactDeleteMenuItem_Click"/&gt;
                     &lt;/MenuFlyout&gt;
                 &lt;/Grid.ContextFlyout&gt;
              
@@ -545,7 +545,7 @@ sent or received, and those values are bound in the DataTemplate.--&gt;
                 <x:String xml:space="preserve">
 ObservableCollection&lt;Contact&gt; contacts = new ObservableCollection&lt;Contact&gt;();
 
-private void ContactDeleteMenuyItem_Click(object sender, RoutedEventArgs e)
+private void ContactDeleteMenuItem_Click(object sender, RoutedEventArgs e)
 {
     var item = (sender as FrameworkElement).DataContext;
     var contact = item as Contact;

--- a/WinUIGallery/ControlPages/ListViewPage.xaml.cs
+++ b/WinUIGallery/ControlPages/ListViewPage.xaml.cs
@@ -349,7 +349,7 @@ namespace WinUIGallery.ControlPages
         // ListView with context menu
         //===================================================================================================================
 
-        private void ContactDeleteMenuyItem_Click(object sender, RoutedEventArgs e)
+        private void ContactDeleteMenuItem_Click(object sender, RoutedEventArgs e)
         {
             var item = (sender as FrameworkElement).DataContext;
             var contact = item as Contact;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed spelling error in the ListView context menus example.

## Motivation and Context
This change improves the readability of the example and code but does not impact functionality.

## How Has This Been Tested?
No testing required.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/3bfe754d-0bbe-46e5-9c57-15b4b30d15c3)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
