### PR TITLE
Minor UX tweaks for icons + color sections

### DIFF
--- a/WinUIGallery/App.xaml
+++ b/WinUIGallery/App.xaml
@@ -60,7 +60,7 @@
 
             <!--  Style Overrides  -->
             <SolidColorBrush x:Key="GridViewHeaderItemDividerStroke" Color="Transparent" />
-            <x:Double x:Key="TeachingTipMinWidth">50</x:Double>
+            <x:Double x:Key="TeachingTipMinWidth">48</x:Double>
 
             <!--  Application-specific styles  -->
             <Style
@@ -124,53 +124,40 @@
                 </Style.Setters>
             </Style>
 
-            <x:Double x:Key="ColorSectionSpacing">12</x:Double>
+            <x:Double x:Key="ColorSectionSpacing">4</x:Double>
 
-            <Style x:Key="SubtleButtonStyle"
-                   TargetType="Button">
-                <Setter Property="Background"
-                        Value="{ThemeResource SubtleFillColorTransparent}" />
-                <Setter Property="BackgroundSizing"
-                        Value="InnerBorderEdge" />
-                <Setter Property="Foreground"
-                        Value="{ThemeResource TextFillColorPrimary}" />
-                <Setter Property="BorderThickness"
-                        Value="0" />
-                <Setter Property="Padding"
-                        Value="{StaticResource ButtonPadding}" />
-                <Setter Property="HorizontalAlignment"
-                        Value="Left" />
-                <Setter Property="VerticalAlignment"
-                        Value="Center" />
-                <Setter Property="FontFamily"
-                        Value="{ThemeResource ContentControlThemeFontFamily}" />
-                <Setter Property="FontWeight"
-                        Value="Normal" />
-                <Setter Property="FontSize"
-                        Value="{ThemeResource ControlContentThemeFontSize}" />
-                <Setter Property="UseSystemFocusVisuals"
-                        Value="{StaticResource UseSystemFocusVisuals}" />
-                <Setter Property="FocusVisualMargin"
-                        Value="-3" />
-                <Setter Property="CornerRadius"
-                        Value="{ThemeResource ControlCornerRadius}" />
+            <Style x:Key="SubtleButtonStyle" TargetType="Button">
+                <Setter Property="Background" Value="{ThemeResource SubtleFillColorTransparent}" />
+                <Setter Property="BackgroundSizing" Value="InnerBorderEdge" />
+                <Setter Property="Foreground" Value="{ThemeResource TextFillColorPrimary}" />
+                <Setter Property="BorderThickness" Value="0" />
+                <Setter Property="Padding" Value="{StaticResource ButtonPadding}" />
+                <Setter Property="HorizontalAlignment" Value="Left" />
+                <Setter Property="VerticalAlignment" Value="Center" />
+                <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
+                <Setter Property="FontWeight" Value="Normal" />
+                <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
+                <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+                <Setter Property="FocusVisualMargin" Value="-3" />
+                <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="Button">
-                            <ContentPresenter x:Name="ContentPresenter"
-                                              Padding="{TemplateBinding Padding}"
-                                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                              AnimatedIcon.State="Normal"
-                                              AutomationProperties.AccessibilityView="Raw"
-                                              Background="{TemplateBinding Background}"
-                                              BackgroundSizing="{TemplateBinding BackgroundSizing}"
-                                              BorderBrush="{TemplateBinding BorderBrush}"
-                                              BorderThickness="{TemplateBinding BorderThickness}"
-                                              Content="{TemplateBinding Content}"
-                                              ContentTemplate="{TemplateBinding ContentTemplate}"
-                                              ContentTransitions="{TemplateBinding ContentTransitions}"
-                                              CornerRadius="{TemplateBinding CornerRadius}">
+                            <ContentPresenter
+                                x:Name="ContentPresenter"
+                                Padding="{TemplateBinding Padding}"
+                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                AnimatedIcon.State="Normal"
+                                AutomationProperties.AccessibilityView="Raw"
+                                Background="{TemplateBinding Background}"
+                                BackgroundSizing="{TemplateBinding BackgroundSizing}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                Content="{TemplateBinding Content}"
+                                ContentTemplate="{TemplateBinding ContentTemplate}"
+                                ContentTransitions="{TemplateBinding ContentTransitions}"
+                                CornerRadius="{TemplateBinding CornerRadius}">
                                 <ContentPresenter.BackgroundTransition>
                                     <BrushTransition Duration="0:0:0.083" />
                                 </ContentPresenter.BackgroundTransition>
@@ -180,59 +167,44 @@
                                         <VisualState x:Name="Normal" />
                                         <VisualState x:Name="PointerOver">
                                             <Storyboard>
-                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
-                                                                               Storyboard.TargetProperty="Background">
-                                                    <DiscreteObjectKeyFrame KeyTime="0"
-                                                                            Value="{ThemeResource SubtleFillColorSecondary}" />
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Background">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SubtleFillColorSecondary}" />
                                                 </ObjectAnimationUsingKeyFrames>
-                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
-                                                                               Storyboard.TargetProperty="Foreground">
-                                                    <DiscreteObjectKeyFrame KeyTime="0"
-                                                                            Value="{ThemeResource TextFillColorPrimary}" />
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextFillColorPrimary}" />
                                                 </ObjectAnimationUsingKeyFrames>
                                             </Storyboard>
                                             <VisualState.Setters>
-                                                <Setter Target="ContentPresenter.(AnimatedIcon.State)"
-                                                        Value="PointerOver" />
+                                                <Setter Target="ContentPresenter.(AnimatedIcon.State)" Value="PointerOver" />
                                             </VisualState.Setters>
                                         </VisualState>
 
                                         <VisualState x:Name="Pressed">
                                             <Storyboard>
-                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
-                                                                               Storyboard.TargetProperty="Background">
-                                                    <DiscreteObjectKeyFrame KeyTime="0"
-                                                                            Value="{ThemeResource SubtleFillColorTertiary}" />
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Background">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SubtleFillColorTertiary}" />
                                                 </ObjectAnimationUsingKeyFrames>
-                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
-                                                                               Storyboard.TargetProperty="Foreground">
-                                                    <DiscreteObjectKeyFrame KeyTime="0"
-                                                                            Value="{ThemeResource TextFillColorSecondary}" />
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextFillColorSecondary}" />
                                                 </ObjectAnimationUsingKeyFrames>
                                             </Storyboard>
                                             <VisualState.Setters>
-                                                <Setter Target="ContentPresenter.(AnimatedIcon.State)"
-                                                        Value="Pressed" />
+                                                <Setter Target="ContentPresenter.(AnimatedIcon.State)" Value="Pressed" />
                                             </VisualState.Setters>
                                         </VisualState>
 
                                         <VisualState x:Name="Disabled">
                                             <Storyboard>
-                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
-                                                                               Storyboard.TargetProperty="Background">
-                                                    <DiscreteObjectKeyFrame KeyTime="0"
-                                                                            Value="{ThemeResource ControlFillColorDisabled}" />
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Background">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ControlFillColorDisabled}" />
                                                 </ObjectAnimationUsingKeyFrames>
-                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
-                                                                               Storyboard.TargetProperty="Foreground">
-                                                    <DiscreteObjectKeyFrame KeyTime="0"
-                                                                            Value="{ThemeResource TextFillColorDisabled}" />
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextFillColorDisabled}" />
                                                 </ObjectAnimationUsingKeyFrames>
                                             </Storyboard>
                                             <VisualState.Setters>
                                                 <!--  DisabledVisual Should be handled by the control, not the animated icon.  -->
-                                                <Setter Target="ContentPresenter.(AnimatedIcon.State)"
-                                                        Value="Normal" />
+                                                <Setter Target="ContentPresenter.(AnimatedIcon.State)" Value="Normal" />
                                             </VisualState.Setters>
                                         </VisualState>
                                     </VisualStateGroup>

--- a/WinUIGallery/ControlPages/DesignGuidance/IconographyPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/IconographyPage.xaml
@@ -190,12 +190,14 @@
                 </ScrollViewer>
 
                 <Grid
+                    x:Name="SidePanel"
                     Grid.Column="1"
                     Padding="16"
                     Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                     BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                     BorderThickness="1,0,0,0"
-                    DataContext="{x:Bind}">
+                    DataContext="{x:Bind}"
+                    Visibility="Collapsed">
                     <StackPanel>
                         <FontIcon
                             Margin="0,0,0,24"
@@ -237,16 +239,14 @@
                             Text="Tags" />
                         <ItemsView
                             x:Name="TagsItemsView"
-                            Width="264"
                             Margin="0,8,0,4"
-                            HorizontalAlignment="Left"
                             x:Load="{x:Bind SelectedItem.Tags, Mode=OneWay, Converter={StaticResource emptyCollectionToFalseConverter}}"
                             IsItemInvokedEnabled="True"
                             ItemInvoked="TagsItemsView_ItemInvoked"
-                            ItemsSource="{Binding SelectedItem.Tags, Mode=OneWay}"
+                            ItemsSource="{x:Bind SelectedItem.Tags, Mode=OneWay}"
                             SelectionMode="None">
                             <ItemsView.Layout>
-                                <LinedFlowLayout LineSpacing="4" MinItemSpacing="4" />
+                                <toolkit:WrapLayout HorizontalSpacing="4" VerticalSpacing="4" />
                             </ItemsView.Layout>
                             <ItemsView.ItemTemplate>
                                 <DataTemplate x:DataType="x:String">
@@ -275,8 +275,9 @@
                         <TextBlock
                             x:Name="NoTagsTextBlock"
                             Grid.Row="1"
+                            Margin="0,4,0,0"
                             x:Load="{x:Bind SelectedItem.Tags, Mode=OneWay, Converter={StaticResource emptyCollectionToTrueConverter}}"
-                            Text="No tags" />
+                            Text="No tags available." />
                     </StackPanel>
                 </Grid>
             </Grid>

--- a/WinUIGallery/ControlPages/DesignGuidance/IconographyPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/IconographyPage.xaml
@@ -35,7 +35,7 @@
             <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
             <Setter Property="Background" Value="{ThemeResource ControlFillColorDefaultBrush}" />
             <Setter Property="SampleType" Value="Inline" />
-            <Setter Property="Foreground" Value="{ThemeResource TextFillColorSecondaryBrush}" />
+
             <Setter Property="VerticalContentAlignment" Value="Center" />
             <Setter Property="Margin" Value="0,0,0,8" />
         </Style>
@@ -169,7 +169,7 @@
             <Grid Style="{ThemeResource GalleryTileGridStyle}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="296" />
+                    <ColumnDefinition Width="316" />
                 </Grid.ColumnDefinitions>
                 <ScrollViewer
                     Padding="4"
@@ -197,10 +197,6 @@
                     BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                     BorderThickness="1,0,0,0"
                     DataContext="{x:Bind}">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                    </Grid.RowDefinitions>
                     <StackPanel>
                         <FontIcon
                             Margin="0,0,0,24"
@@ -209,46 +205,59 @@
                             FontFamily="{StaticResource SymbolThemeFontFamily}"
                             FontSize="48"
                             Glyph="{Binding SelectedItem.Character, Mode=OneWay}" />
-
-                        <TextBlock FontWeight="SemiBold" Text="Icon name" />
+                        <TextBlock
+                            FontSize="12"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Text="Icon name" />
                         <controls:SampleCodePresenter Code="{Binding SelectedItem.Name, Mode=OneWay}" Style="{StaticResource CodeValuePresenterStyle}" />
-                        <TextBlock FontWeight="SemiBold" Text="Text glyph" />
+                        <TextBlock
+                            FontSize="12"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Text="Text glyph" />
                         <controls:SampleCodePresenter Code="{Binding SelectedItem.TextGlyph, Mode=OneWay}" Style="{StaticResource CodeValuePresenterStyle}" />
-                        <TextBlock FontWeight="SemiBold" Text="Code glyph" />
+                        <TextBlock
+                            FontSize="12"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Text="Code glyph" />
                         <controls:SampleCodePresenter Code="{Binding SelectedItem.CodeGlyph, Mode=OneWay}" Style="{StaticResource CodeValuePresenterStyle}" />
-                        <TextBlock FontWeight="SemiBold" Text="XAML" />
+                        <TextBlock
+                            FontSize="12"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Text="XAML" />
                         <controls:SampleCodePresenter x:Name="XAMLCodePresenter" Style="{StaticResource CodeValuePresenterStyle}" />
-                        <TextBlock FontWeight="SemiBold" Text="C#" />
+                        <TextBlock
+                            Margin="0,0,0,4"
+                            FontSize="12"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Text="C#" />
                         <controls:SampleCodePresenter x:Name="CSharpCodePresenter" Style="{StaticResource CodeValuePresenterStyle}" />
                         <TextBlock
                             Margin="0,4,0,0"
-                            FontWeight="SemiBold"
+                            FontSize="12"
                             Text="Tags" />
+                        <ItemsRepeater
+                            x:Name="TagsItemsView"
+                            Margin="0,8,0,4"
+                            x:Load="{x:Bind SelectedItem.Tags, Mode=OneWay, Converter={StaticResource emptyCollectionToFalseConverter}}"
+                            ItemsSource="{Binding SelectedItem.Tags, Mode=OneWay}">
+                            <ItemsRepeater.Layout>
+                                <toolkit:WrapLayout HorizontalSpacing="4" VerticalSpacing="4" />
+                            </ItemsRepeater.Layout>
+                            <ItemsRepeater.ItemTemplate>
+                                <DataTemplate x:DataType="x:String">
+                                    <Button
+                                        Padding="4,1,4,1"
+                                        Click="TagButton_Click"
+                                        Content="{x:Bind Mode=OneWay}" />
+                                </DataTemplate>
+                            </ItemsRepeater.ItemTemplate>
+                        </ItemsRepeater>
+                        <TextBlock
+                            x:Name="NoTagsTextBlock"
+                            Grid.Row="1"
+                            x:Load="{x:Bind SelectedItem.Tags, Mode=OneWay, Converter={StaticResource emptyCollectionToTrueConverter}}"
+                            Text="No tags" />
                     </StackPanel>
-                    <ItemsRepeater
-                        x:Name="TagsItemsView"
-                        Grid.Row="1"
-                        Margin="0,4,0,4"
-                        x:Load="{x:Bind SelectedItem.Tags, Mode=OneWay, Converter={StaticResource emptyCollectionToFalseConverter}}"
-                        ItemsSource="{Binding SelectedItem.Tags, Mode=OneWay}">
-                        <ItemsRepeater.Layout>
-                            <toolkit:WrapLayout HorizontalSpacing="4" VerticalSpacing="4" />
-                        </ItemsRepeater.Layout>
-                        <ItemsRepeater.ItemTemplate>
-                            <DataTemplate x:DataType="x:String">
-                                <Button
-                                    Padding="4,1,4,1"
-                                    Click="TagButton_Click"
-                                    Content="{x:Bind Mode=OneWay}"
-                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                            </DataTemplate>
-                        </ItemsRepeater.ItemTemplate>
-                    </ItemsRepeater>
-                    <TextBlock
-                        x:Name="NoTagsTextBlock"
-                        Grid.Row="1"
-                        x:Load="{x:Bind SelectedItem.Tags, Mode=OneWay, Converter={StaticResource emptyCollectionToTrueConverter}}"
-                        Text="No tags" />
                 </Grid>
             </Grid>
         </controls1:SampleThemeListener>

--- a/WinUIGallery/ControlPages/DesignGuidance/IconographyPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/IconographyPage.xaml
@@ -136,7 +136,7 @@
                                 For optimal appearance, use these specific sizes: 16, 20, 24, 32, 40, 48, and 64. Deviating from these font sizes could lead to less crisp or blurry outcomes.
                             </Paragraph>
                             <Paragraph>
-                                All glyphs in Segoe Fluent Icons have the same fixed width with a consistent height and left origin point, so<Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/style/segoe-fluent-icons-font#layering-and-mirroring">layering</Hyperlink>
+                                All glyphs in Segoe Fluent Icons have the same fixed width with a consistent height and left origin point, so <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/style/segoe-fluent-icons-font#layering-and-mirroring">layering</Hyperlink>
                                 and colorization effects can be achieved by drawing glyphs directly on top of each other.</Paragraph>
                         </RichTextBlock>
                         <controls:SampleCodePresenter CodeSourceFile="Icons/FontIconSample2_xaml.txt" SampleType="XAML" />

--- a/WinUIGallery/ControlPages/DesignGuidance/IconographyPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/IconographyPage.xaml
@@ -129,7 +129,7 @@
                             <Paragraph>
                                 If you don't specify a FontFamily,
                                 or you specify a FontFamily that is not available on the system at runtime,
-                                the<Hyperlink NavigateUri="https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.fonticon">FontIcon</Hyperlink>
+                                the <Hyperlink NavigateUri="https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.fonticon">FontIcon</Hyperlink>
                                 falls back to the default font family defined by the SymbolThemeFontFamily resource.</Paragraph>
                             <Paragraph>
                                 An icon with a 16-epx font size is the equivalent of a 16x16-epx icon, to make sizing and positioning more predictable.

--- a/WinUIGallery/ControlPages/DesignGuidance/IconographyPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/IconographyPage.xaml
@@ -37,18 +37,18 @@
             <Setter Property="SampleType" Value="Inline" />
             <Setter Property="Foreground" Value="{ThemeResource TextFillColorSecondaryBrush}" />
             <Setter Property="VerticalContentAlignment" Value="Center" />
-            <Setter Property="Margin" Value="0,4,0,4" />
+            <Setter Property="Margin" Value="0,0,0,8" />
         </Style>
 
         <DataTemplate x:Key="IconTemplate">
             <ItemContainer
-                AutomationProperties.Name="{Binding Name}"
-                ToolTipService.ToolTip="{Binding Name}"
-                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                 Width="96"
                 Height="96"
-                Margin="4">
+                Margin="4"
+                AutomationProperties.Name="{Binding Name}"
+                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                ToolTipService.ToolTip="{Binding Name}">
                 <Grid>
                     <!--  Icon  -->
                     <Viewbox
@@ -79,8 +79,14 @@
             </ItemContainer>
         </DataTemplate>
 
-        <converters:EmptyCollectionToObjectConverter x:Key="emptyCollectionToFalseConverter" EmptyValue="False" NotEmptyValue="True" />
-        <converters:EmptyCollectionToObjectConverter x:Key="emptyCollectionToTrueConverter" EmptyValue="True" NotEmptyValue="False" />
+        <converters:EmptyCollectionToObjectConverter
+            x:Key="emptyCollectionToFalseConverter"
+            EmptyValue="False"
+            NotEmptyValue="True" />
+        <converters:EmptyCollectionToObjectConverter
+            x:Key="emptyCollectionToTrueConverter"
+            EmptyValue="True"
+            NotEmptyValue="False" />
     </Page.Resources>
 
     <Grid HorizontalAlignment="Stretch" RowSpacing="8">
@@ -94,23 +100,28 @@
 
         <toolkit:SettingsExpander
             Grid.Row="1"
-            Header="Instructions on how to use Segoe Fluent Icons"
             AutomationProperties.AccessibilityView="Raw"
+            Header="Instructions on how to use Segoe Fluent Icons"
             IsExpanded="False">
             <toolkit:SettingsExpander.Items>
-                <toolkit:SettingsCard Padding="16,8" ContentAlignment="Left" AutomationProperties.Name="How to get the font">
+                <toolkit:SettingsCard
+                    Padding="16,8"
+                    AutomationProperties.Name="How to get the font"
+                    ContentAlignment="Left">
                     <RichTextBlock TextWrapping="Wrap">
                         <Paragraph FontWeight="SemiBold">
                             How to get the font
                         </Paragraph>
                         <Paragraph>
                             On Windows 11: There's nothing you need to do, the font comes with Windows.<LineBreak />
-                            On Windows 10: Segoe Fluent Icons is not included by default on Windows 10. You can download it <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/downloads/#fonts">here</Hyperlink>                            .</Paragraph>
+                            On Windows 10: Segoe Fluent Icons is not included by default on Windows 10. You can download it<Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/downloads/#fonts">here</Hyperlink>
+                            .</Paragraph>
                     </RichTextBlock>
                 </toolkit:SettingsCard>
-                <toolkit:SettingsCard Padding="16,8"
-                                      ContentAlignment="Left"
-                                      AutomationProperties.Name="How to use the font">
+                <toolkit:SettingsCard
+                    Padding="16,8"
+                    AutomationProperties.Name="How to use the font"
+                    ContentAlignment="Left">
                     <StackPanel Orientation="Vertical" Spacing="8">
                         <RichTextBlock TextWrapping="Wrap">
                             <Paragraph FontWeight="SemiBold">
@@ -119,14 +130,15 @@
                             <Paragraph>
                                 If you don't specify a FontFamily,
                                 or you specify a FontFamily that is not available on the system at runtime,
-                                the <Hyperlink NavigateUri="https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.fonticon">FontIcon</Hyperlink> falls back to the default font family defined by the SymbolThemeFontFamily resource.
-                            </Paragraph>
+                                the<Hyperlink NavigateUri="https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.fonticon">FontIcon</Hyperlink>
+                                falls back to the default font family defined by the SymbolThemeFontFamily resource.</Paragraph>
                             <Paragraph>
                                 An icon with a 16-epx font size is the equivalent of a 16x16-epx icon, to make sizing and positioning more predictable.
                                 For optimal appearance, use these specific sizes: 16, 20, 24, 32, 40, 48, and 64. Deviating from these font sizes could lead to less crisp or blurry outcomes.
                             </Paragraph>
                             <Paragraph>
-                                All glyphs in Segoe Fluent Icons have the same fixed width with a consistent height and left origin point, so <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/style/segoe-fluent-icons-font#layering-and-mirroring">layering</Hyperlink> and colorization effects can be achieved by drawing glyphs directly on top of each other.</Paragraph>
+                                All glyphs in Segoe Fluent Icons have the same fixed width with a consistent height and left origin point, so<Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/style/segoe-fluent-icons-font#layering-and-mirroring">layering</Hyperlink>
+                                and colorization effects can be achieved by drawing glyphs directly on top of each other.</Paragraph>
                         </RichTextBlock>
                         <controls:SampleCodePresenter CodeSourceFile="Icons/FontIconSample2_xaml.txt" SampleType="XAML" />
                     </StackPanel>
@@ -169,8 +181,8 @@
                         MinWidth="100"
                         Margin="0,0,0,36"
                         HorizontalAlignment="Stretch"
-                        SelectionChanged="IconsItemsView_SelectionChanged"
                         ItemTemplate="{StaticResource IconTemplate}"
+                        SelectionChanged="IconsItemsView_SelectionChanged"
                         TabFocusNavigation="Once">
                         <ItemsView.Layout>
                             <UniformGridLayout Orientation="Horizontal" />
@@ -185,80 +197,58 @@
                     BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                     BorderThickness="1,0,0,0"
                     DataContext="{x:Bind}">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
                     <StackPanel>
                         <FontIcon
-                            Margin="0,12,0,24"
+                            Margin="0,0,0,24"
                             HorizontalAlignment="Left"
                             VerticalAlignment="Center"
                             FontFamily="{StaticResource SymbolThemeFontFamily}"
-                            FontSize="{x:Bind (x:Double)FontsizeComboBox.SelectedValue, Mode=OneWay}"
+                            FontSize="48"
                             Glyph="{Binding SelectedItem.Character, Mode=OneWay}" />
-                        
-                        <TextBlock Text="Icon name" />
+
+                        <TextBlock FontWeight="SemiBold" Text="Icon name" />
                         <controls:SampleCodePresenter Code="{Binding SelectedItem.Name, Mode=OneWay}" Style="{StaticResource CodeValuePresenterStyle}" />
-                        <TextBlock Text="Text glyph" />
+                        <TextBlock FontWeight="SemiBold" Text="Text glyph" />
                         <controls:SampleCodePresenter Code="{Binding SelectedItem.TextGlyph, Mode=OneWay}" Style="{StaticResource CodeValuePresenterStyle}" />
-                        <TextBlock Text="Code glyph" />
+                        <TextBlock FontWeight="SemiBold" Text="Code glyph" />
                         <controls:SampleCodePresenter Code="{Binding SelectedItem.CodeGlyph, Mode=OneWay}" Style="{StaticResource CodeValuePresenterStyle}" />
-                        <TextBlock Text="XAML" />
+                        <TextBlock FontWeight="SemiBold" Text="XAML" />
                         <controls:SampleCodePresenter x:Name="XAMLCodePresenter" Style="{StaticResource CodeValuePresenterStyle}" />
-                        <TextBlock Text="C#" />
+                        <TextBlock FontWeight="SemiBold" Text="C#" />
                         <controls:SampleCodePresenter x:Name="CSharpCodePresenter" Style="{StaticResource CodeValuePresenterStyle}" />
-                        <TextBlock Text="Tags" />
-                        <ItemsView
-                            x:Name="TagsItemsView"
-                            x:Load="{x:Bind SelectedItem.Tags, Mode=OneWay, Converter={StaticResource emptyCollectionToFalseConverter}}"
-                            ItemsSource="{Binding SelectedItem.Tags, Mode=OneWay}"
-                            Margin="0,4,0,4">
-                            <ItemsView.Layout>
-                                <LinedFlowLayout LineSpacing="4" MinItemSpacing="4" />
-                            </ItemsView.Layout>
-                            <ItemsView.ItemTemplate>
-                                <DataTemplate x:DataType="x:String">
-                                    <ItemContainer>
-                                        <Button Content="{x:Bind Mode=OneWay}" Click="TagButton_Click" />
-                                    </ItemContainer>
-                                </DataTemplate>
-                            </ItemsView.ItemTemplate>
-                        </ItemsView>
                         <TextBlock
-                            x:Name="NoTagsTextBlock"
-                            x:Load="{x:Bind SelectedItem.Tags, Mode=OneWay, Converter={StaticResource emptyCollectionToTrueConverter}}"
-                            Text="No tags" />
-
-                        <StackPanel Orientation="Vertical" Visibility="Collapsed">
-                            <TextBlock
-                                Grid.Row="1"
-                                VerticalAlignment="Center"
-                                Text="Color" />
-                            <controls1:InlineColorPicker
-                                x:Name="IconColorPicker"
-                                Grid.Row="1"
-                                Grid.Column="1"
-                                Color="Black" />
-
-                            <TextBlock
-                                Grid.Row="2"
-                                Padding="0,10,0,0"
-                                VerticalAlignment="Center"
-                                Text="FontSize" />
-                            <Grid
-                                Grid.Row="2"
-                                Grid.Column="1"
-                                Padding="0,10,0,0"
-                                ColumnSpacing="8">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <ComboBox
-                                    x:Name="FontsizeComboBox"
-                                    Width="100"
-                                    ItemsSource="{x:Bind FontSizes}"
-                                    SelectedIndex="3" />
-                            </Grid>
-                        </StackPanel>
+                            Margin="0,4,0,0"
+                            FontWeight="SemiBold"
+                            Text="Tags" />
                     </StackPanel>
+                    <ItemsRepeater
+                        x:Name="TagsItemsView"
+                        Grid.Row="1"
+                        Margin="0,4,0,4"
+                        x:Load="{x:Bind SelectedItem.Tags, Mode=OneWay, Converter={StaticResource emptyCollectionToFalseConverter}}"
+                        ItemsSource="{Binding SelectedItem.Tags, Mode=OneWay}">
+                        <ItemsRepeater.Layout>
+                            <toolkit:WrapLayout HorizontalSpacing="4" VerticalSpacing="4" />
+                        </ItemsRepeater.Layout>
+                        <ItemsRepeater.ItemTemplate>
+                            <DataTemplate x:DataType="x:String">
+                                <Button
+                                    Padding="4,1,4,1"
+                                    Click="TagButton_Click"
+                                    Content="{x:Bind Mode=OneWay}"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                            </DataTemplate>
+                        </ItemsRepeater.ItemTemplate>
+                    </ItemsRepeater>
+                    <TextBlock
+                        x:Name="NoTagsTextBlock"
+                        Grid.Row="1"
+                        x:Load="{x:Bind SelectedItem.Tags, Mode=OneWay, Converter={StaticResource emptyCollectionToTrueConverter}}"
+                        Text="No tags" />
                 </Grid>
             </Grid>
         </controls1:SampleThemeListener>

--- a/WinUIGallery/ControlPages/DesignGuidance/IconographyPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/IconographyPage.xaml
@@ -113,7 +113,7 @@
                         </Paragraph>
                         <Paragraph>
                             On Windows 11: There's nothing you need to do, the font comes with Windows.<LineBreak />
-                            On Windows 10: Segoe Fluent Icons is not included by default on Windows 10. You can download it<Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/downloads/#fonts">here</Hyperlink>
+                            On Windows 10: Segoe Fluent Icons is not included by default on Windows 10. You can download it <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/downloads/#fonts">here</Hyperlink>
                             .</Paragraph>
                     </RichTextBlock>
                 </toolkit:SettingsCard>

--- a/WinUIGallery/ControlPages/DesignGuidance/IconographyPage.xaml
+++ b/WinUIGallery/ControlPages/DesignGuidance/IconographyPage.xaml
@@ -35,7 +35,6 @@
             <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
             <Setter Property="Background" Value="{ThemeResource ControlFillColorDefaultBrush}" />
             <Setter Property="SampleType" Value="Inline" />
-
             <Setter Property="VerticalContentAlignment" Value="Center" />
             <Setter Property="Margin" Value="0,0,0,8" />
         </Style>
@@ -234,24 +233,45 @@
                         <TextBlock
                             Margin="0,4,0,0"
                             FontSize="12"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                             Text="Tags" />
-                        <ItemsRepeater
+                        <ItemsView
                             x:Name="TagsItemsView"
+                            Width="264"
                             Margin="0,8,0,4"
+                            HorizontalAlignment="Left"
                             x:Load="{x:Bind SelectedItem.Tags, Mode=OneWay, Converter={StaticResource emptyCollectionToFalseConverter}}"
-                            ItemsSource="{Binding SelectedItem.Tags, Mode=OneWay}">
-                            <ItemsRepeater.Layout>
-                                <toolkit:WrapLayout HorizontalSpacing="4" VerticalSpacing="4" />
-                            </ItemsRepeater.Layout>
-                            <ItemsRepeater.ItemTemplate>
+                            IsItemInvokedEnabled="True"
+                            ItemInvoked="TagsItemsView_ItemInvoked"
+                            ItemsSource="{Binding SelectedItem.Tags, Mode=OneWay}"
+                            SelectionMode="None">
+                            <ItemsView.Layout>
+                                <LinedFlowLayout LineSpacing="4" MinItemSpacing="4" />
+                            </ItemsView.Layout>
+                            <ItemsView.ItemTemplate>
                                 <DataTemplate x:DataType="x:String">
-                                    <Button
-                                        Padding="4,1,4,1"
-                                        Click="TagButton_Click"
-                                        Content="{x:Bind Mode=OneWay}" />
+                                    <ItemContainer
+                                        HorizontalAlignment="Left"
+                                        AutomationProperties.Name="{x:Bind}"
+                                        CornerRadius="12">
+                                        <Grid
+                                            Padding="8,3,8,4"
+                                            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                                            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                                            BorderThickness="1"
+                                            CornerRadius="12">
+                                            <TextBlock
+                                                Grid.Column="1"
+                                                VerticalAlignment="Center"
+                                                FontSize="12"
+                                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                Text="{x:Bind}"
+                                                TextTrimming="CharacterEllipsis" />
+                                        </Grid>
+                                    </ItemContainer>
                                 </DataTemplate>
-                            </ItemsRepeater.ItemTemplate>
-                        </ItemsRepeater>
+                            </ItemsView.ItemTemplate>
+                        </ItemsView>
                         <TextBlock
                             x:Name="NoTagsTextBlock"
                             Grid.Row="1"

--- a/WinUIGallery/ControlPages/DesignGuidance/IconographyPage.xaml.cs
+++ b/WinUIGallery/ControlPages/DesignGuidance/IconographyPage.xaml.cs
@@ -62,6 +62,7 @@ namespace WinUIGallery.ControlPages
                     IconsItemsView.ItemsSource = new List<IconData>(IconsDataSource.Icons);
                     SelectedItem = IconsDataSource.Icons[0];
                     SetSampleCodePresenterCode(IconsDataSource.Icons[0]);
+                    IconsItemsView.Select(0);
                 });
             });
         }
@@ -122,10 +123,11 @@ namespace WinUIGallery.ControlPages
                     {
                         SelectedItem = newItems[0];
                         outputString = filteredItemsCount > 1 ? filteredItemsCount + " icons found." : "1 icon found.";
+                        IconsItemsView.Select(0);
                     }
                     else
                     {
-                        outputString = "No icon found.";
+                        outputString = "No icons found.";
                     }
 
                     UIHelper.AnnounceActionForAccessibility(IconsAutoSuggestBox, outputString, "AutoSuggestBoxNumberIconsFoundId");
@@ -145,9 +147,9 @@ namespace WinUIGallery.ControlPages
             }
         }
 
-        private void TagButton_Click(object sender, RoutedEventArgs e)
+        private void TagsItemsView_ItemInvoked(ItemsView sender, ItemsViewItemInvokedEventArgs args)
         {
-            if ((sender as Button).Content is string tag)
+            if (args.InvokedItem is string tag)
             {
                 IconsAutoSuggestBox.Text = tag;
             }

--- a/WinUIGallery/ControlPages/DesignGuidance/IconographyPage.xaml.cs
+++ b/WinUIGallery/ControlPages/DesignGuidance/IconographyPage.xaml.cs
@@ -17,6 +17,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using WinUIGallery.DesktopWap.DataModel;
 using System.Threading;
+using CommunityToolkit.WinUI.Controls;
 
 namespace WinUIGallery.ControlPages
 {
@@ -63,6 +64,7 @@ namespace WinUIGallery.ControlPages
                     SelectedItem = IconsDataSource.Icons[0];
                     SetSampleCodePresenterCode(IconsDataSource.Icons[0]);
                     IconsItemsView.Select(0);
+                    SidePanel.Visibility = Visibility.Visible;
                 });
             });
         }
@@ -143,7 +145,11 @@ namespace WinUIGallery.ControlPages
                 {
                     SelectedItem = currentItems[IconsItemsView.CurrentItemIndex];
                 }
+            }
 
+            if (TagsItemsView != null)
+            {
+                TagsItemsView.Layout = new WrapLayout { VerticalSpacing = 4, HorizontalSpacing = 4 };
             }
         }
 

--- a/WinUIGallery/Controls/DesignGuidance/ColorPageExample.xaml
+++ b/WinUIGallery/Controls/DesignGuidance/ColorPageExample.xaml
@@ -11,13 +11,13 @@
     mc:Ignorable="d">
 
     <Grid
-        Margin="0,24,0,12"
+        Margin="0,36,0,8"
         Padding="12"
         Background="{x:Bind Background, Mode=OneWay}"
         BorderBrush="{ThemeResource GalleryBorderBrush}"
         BorderThickness="1"
         CornerRadius="{StaticResource OverlayCornerRadius}"
-        RowSpacing="12">
+        RowSpacing="4">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
@@ -30,10 +30,13 @@
             Text="{x:Bind Title, Mode=OneWay}" />
         <TextBlock
             Grid.Row="1"
+            Foreground="{x:Bind Foreground, Mode=OneWay}"
+            Opacity="0.8"
             Style="{ThemeResource CaptionTextBlockStyle}"
             Text="{x:Bind Description, Mode=OneWay}" />
         <ContentPresenter
             Grid.Row="2"
+            Margin="0,8,0,0"
             HorizontalAlignment="Center"
             Content="{x:Bind ExampleContent, Mode=OneWay}" />
     </Grid>

--- a/WinUIGallery/Controls/DesignGuidance/ColorTile.xaml
+++ b/WinUIGallery/Controls/DesignGuidance/ColorTile.xaml
@@ -42,23 +42,24 @@
 
             <localControls:CopyButton
                 x:Name="CopyBrushNameButton"
-                AutomationProperties.Name="Copy brush name"
                 Grid.RowSpan="4"
                 Grid.Column="1"
                 Grid.ColumnSpan="2"
                 HorizontalAlignment="Right"
                 VerticalAlignment="Top"
+                AutomationProperties.Name="Copy brush name"
                 Background="Transparent"
                 BorderBrush="Transparent"
                 Click="CopyBrushNameButton_Click"
                 Content="&#xE8C8;"
                 Foreground="{x:Bind Foreground, Mode=OneWay}"
-                ToolTipService.ToolTip="Copy brush name"/>
+                ToolTipService.ToolTip="Copy brush name" />
 
             <TextBlock
                 Grid.Row="1"
                 Margin="0,-4,0,0"
                 IsTextSelectionEnabled="True"
+                Opacity="0.8"
                 Style="{StaticResource CaptionTextBlockStyle}"
                 Text="{x:Bind ColorExplanation, Mode=OneWay}"
                 TextWrapping="WrapWholeWords" />

--- a/WinUIGallery/WinUIGallery.csproj
+++ b/WinUIGallery/WinUIGallery.csproj
@@ -110,6 +110,7 @@
         <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" />
         <PackageReference Include="CommunityToolkit.WinUI.Converters" />
         <PackageReference Include="CommunityToolkit.WinUI.Animations" />
+        <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" />
         <Manifest Include="$(ApplicationManifest)" />
         <!-- System.Private.Uri is pulled in transitively through ColorCode.Core and contains vulnerabilities
           CVE-2019-0657, CVE-2019-0980, and CVE-2019-0981. Since no meta-package depends on version 4.3.2, which
@@ -125,6 +126,7 @@
         <PackageReference Update="CommunityToolkit.WinUI.Controls.SettingsControls" Version="$(CommunityToolkitWinUIVersion)" />
         <PackageReference Update="CommunityToolkit.WinUI.Converters" Version="$(CommunityToolkitWinUIVersion)" />
         <PackageReference Update="CommunityToolkit.WinUI.Animations" Version="$(CommunityToolkitWinUIVersion)" />
+        <PackageReference Update="CommunityToolkit.WinUI.Controls.Primitives" Version="$(CommunityToolkitWinUIVersion)" />
         <PackageReference Update="Microsoft.Graphics.Win2D" Version="$(GraphicsWin2DVersion)" />
         <!-- Get latest WinRT.Runtime.dll from C#/WinRT -->
         <PackageReference Update="Microsoft.Windows.CsWinRT" Version="$(MicrosoftCsWinRTPackageVersion)" />


### PR DESCRIPTION
This PR introduces the following changes:

- Tweaks the UX of the Icon panel for better readability.
- Using an `ItemsView` without buttons, for better accessibility. Using a `WrapLayout` (from the WCT) so labels are not cut off.
- Selecting the first item upon loading, or after searching.
- Collapse the sidepanel until the grid icons is loaded: current behavior shows empty content on the right for 2 seconds which does not look great.

![image](https://github.com/user-attachments/assets/6ab23cae-57ed-481d-ba81-ba01b1121356)



- Spacing tweaks for the color sections so they are clustered together a bit better
- Using a 0.8 opacity for the subtitle to be a bit less prominent

![image](https://github.com/user-attachments/assets/4b5afca2-f2d7-4370-b7c3-1203e43aff31)


