### PR TITLE
Update WinAppSDK Version and Remove WebView2 Workaround

### DIFF
--- a/WinUIGallery/WinUIGallery.csproj
+++ b/WinUIGallery/WinUIGallery.csproj
@@ -99,9 +99,6 @@
             just add versionless PackageReferences here.  They will be updated to their actual versions by either the Packages.props file
             in the WinUI repo, or the next ItemGroup below when standalone. -->
     <ItemGroup>
-        <!-- https://github.com/microsoft/WindowsAppSDK/issues/4836 -->
-        <!-- Explicitly added latest version of WebView2 as temporary workaround for Windows Store validation error. -->
-        <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2903.40" />
         <PackageReference Include="Microsoft.WindowsAppSDK" />
         <PackageReference Include="ColorCode.Core" />
         <PackageReference Include="Microsoft.Graphics.Win2D" />

--- a/standalone.props
+++ b/standalone.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- The NuGet versions of dependencies to build against. -->
     <WindowsSdkPackageVersion>10.0.22621.42</WindowsSdkPackageVersion>
-    <WindowsAppSdkPackageVersion>1.6.241106002</WindowsAppSdkPackageVersion>
+    <WindowsAppSdkPackageVersion>1.6.250108002</WindowsAppSdkPackageVersion>
     <MicrosoftNETCoreUniversalWindowsPlatformVersion>6.2.11</MicrosoftNETCoreUniversalWindowsPlatformVersion>
     <GraphicsWin2DVersion>1.0.4</GraphicsWin2DVersion>
     <ColorCodeVersion>2.0.13</ColorCodeVersion>


### PR DESCRIPTION
- Update WinAppSDK Version to 1.6.4
- Remove WebView2 Workaround since latest WinAppSDK bits resolve the duplicate key issue: https://github.com/microsoft/WindowsAppSDK/issues/4836