### PR TITLE
[WinUI3 Gallery] [RichEditBox]: On applying Text Scaling to 200%, 'Enter search text' placeholder text is getting trimmed

### DIFF
--- a/WinUIGallery/ControlPages/RichEditBoxPage.xaml
+++ b/WinUIGallery/ControlPages/RichEditBoxPage.xaml
@@ -163,7 +163,7 @@
                             RelativePanel.AlignLeftWith="editor" 
                             Margin="0,10,0,0">
                     <TextBlock x:Name="findBoxLabel" Text="Find:" VerticalAlignment="Center" Margin="0,0,0,3"/>
-                    <TextBox x:Name="findBox" PlaceholderText="Enter search text" Margin="10,0,0,0"
+                    <TextBox x:Name="findBox" Width ="225" PlaceholderText="Enter search text" Margin="10,0,0,0"
                             TextChanged="{x:Bind FindBoxHighlightMatches}" 
                             GotFocus="{x:Bind FindBoxHighlightMatches}" 
                             LostFocus="{x:Bind FindBoxRemoveHighlights}"/>

--- a/WinUIGallery/ControlPages/RichEditBoxPage.xaml
+++ b/WinUIGallery/ControlPages/RichEditBoxPage.xaml
@@ -163,7 +163,7 @@
                             RelativePanel.AlignLeftWith="editor" 
                             Margin="0,10,0,0">
                     <TextBlock x:Name="findBoxLabel" Text="Find:" VerticalAlignment="Center" Margin="0,0,0,3"/>
-                    <TextBox x:Name="findBox" Width ="225" PlaceholderText="Enter search text" Margin="10,0,0,0"
+                    <TextBox x:Name="findBox" Width="225" PlaceholderText="Enter search text" Margin="10,0,0,0"
                             TextChanged="{x:Bind FindBoxHighlightMatches}" 
                             GotFocus="{x:Bind FindBoxHighlightMatches}" 
                             LostFocus="{x:Bind FindBoxRemoveHighlights}"/>

--- a/WinUIGallery/ControlPages/RichEditBoxPage.xaml
+++ b/WinUIGallery/ControlPages/RichEditBoxPage.xaml
@@ -163,7 +163,7 @@
                             RelativePanel.AlignLeftWith="editor" 
                             Margin="0,10,0,0">
                     <TextBlock x:Name="findBoxLabel" Text="Find:" VerticalAlignment="Center" Margin="0,0,0,3"/>
-                    <TextBox x:Name="findBox" Width="150" PlaceholderText="Enter search text" Margin="10,0,0,0"
+                    <TextBox x:Name="findBox" PlaceholderText="Enter search text" Margin="10,0,0,0"
                             TextChanged="{x:Bind FindBoxHighlightMatches}" 
                             GotFocus="{x:Bind FindBoxHighlightMatches}" 
                             LostFocus="{x:Bind FindBoxRemoveHighlights}"/>


### PR DESCRIPTION
[WinUI3 Gallery] [RichEditBox]: On applying Text Scaling to 200%, 'Enter search text' placeholder text is getting trimmed.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Removed the `Width` property from the `TextBox` element in the `RichEditBoxPage.xaml` file to prevent the placeholder text from getting trimmed when applying Text Scaling to 200
![asoqs961](https://github.com/user-attachments/assets/7e0c7ed2-4ab9-4e1b-8828-d9bf65bd056e)


<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is an Accessibility issue. User with low vision who rely on text scaling will be impacted and will face difficulties if the placeholder gets trimmed on application of Text Scaling to 200.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Made the changes in the code and tested the scenario by applying Text Scaling to 200% and verified that the placeholder text is not getting trimmed.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
For scaling 225:
![image](https://github.com/user-attachments/assets/75c11689-fd4c-44a0-b4b4-5611409d58f6)
For scaling 100:
![image](https://github.com/user-attachments/assets/58362dd7-2513-4f52-925e-0d7eb0bde090)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
