### PR TITLE
Fix `TreeView` Example Icon Path Issue After Restructuring

### DIFF
--- a/WinUIGallery/Samples/ControlPages/DesignGuidance/GeometryPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/DesignGuidance/GeometryPage.xaml
@@ -50,7 +50,7 @@
             HorizontalContentAlignment="Stretch"
             XamlSource="Geometry/GeometrySample_xaml.txt">
             <StackPanel HorizontalAlignment="Stretch" Orientation="Vertical">
-                <ScrollViewer HorizontalScrollBarVisibility="Auto" HorizontalScrollMode="Auto">
+                <ScrollViewer HorizontalScrollBarVisibility="Auto" HorizontalScrollMode="Auto" VerticalScrollBarVisibility="Hidden">
                     <Canvas
                         Width="505"
                         Height="271"
@@ -115,7 +115,7 @@
                     </Canvas>
                 </ScrollViewer>
 
-                <ScrollViewer HorizontalScrollBarVisibility="Auto" HorizontalScrollMode="Auto">
+                <ScrollViewer HorizontalScrollBarVisibility="Auto" HorizontalScrollMode="Auto" VerticalScrollBarVisibility="Hidden">
                     <StackPanel>
                         <Grid Margin="0,48,0,24" HorizontalAlignment="Stretch">
                             <Grid.ColumnDefinitions>

--- a/WinUIGallery/Samples/ControlPages/DesignGuidance/SpacingPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/DesignGuidance/SpacingPage.xaml
@@ -115,7 +115,7 @@
             Grid.Row="2"
             Margin="0,36,0,0"
             Style="{StaticResource GalleryTileGridStyle}">
-            <ScrollViewer HorizontalScrollBarVisibility="Auto" HorizontalScrollMode="Auto">
+            <ScrollViewer HorizontalScrollBarVisibility="Auto" HorizontalScrollMode="Auto" VerticalScrollBarVisibility="Hidden">
                 <StackPanel Padding="12,24,12,12">
                     <!--  header  -->
                     <Grid Margin="16,0,0,0" HorizontalAlignment="Stretch">

--- a/WinUIGallery/Samples/ControlPages/DesignGuidance/TypographyPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/DesignGuidance/TypographyPage.xaml
@@ -53,7 +53,8 @@
                 <ScrollViewer
                     Height="450"
                     HorizontalScrollBarVisibility="Auto"
-                    HorizontalScrollMode="Auto">
+                    HorizontalScrollMode="Auto"
+                    VerticalScrollBarVisibility="Hidden">
                     <Canvas
                         Width="750"
                         Height="450"
@@ -157,7 +158,7 @@
                     </Canvas>
                 </ScrollViewer>
 
-                <ScrollViewer HorizontalScrollBarVisibility="Auto" HorizontalScrollMode="Auto">
+                <ScrollViewer HorizontalScrollBarVisibility="Auto" HorizontalScrollMode="Auto" VerticalScrollBarVisibility="Hidden">
                     <StackPanel>
                         <Grid Margin="0,48,0,24" HorizontalAlignment="Stretch">
                             <Grid.ColumnDefinitions>

--- a/WinUIGallery/Samples/ControlPages/PullToRefreshPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/PullToRefreshPage.xaml
@@ -1,40 +1,37 @@
-<Page
-    x:Class="WinUIGallery.ControlPages.PullToRefreshPage"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="using:WinUIGallery.Controls"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
-    <ScrollViewer>
-        <StackPanel>
-            <controls:ControlExample x:Name="Example1" HeaderText="Basic PullToRefresh">
-                <controls:ControlExample.Example>
-                    <Grid>
-                        <RefreshContainer
-                            x:Name="rc"
-                            HorizontalAlignment="Center"
-                            VerticalAlignment="Center"
-                            RefreshRequested="rc_RefreshRequested">
-                            <ListView
-                                x:Name="lv"
-                                Height="200"
-                                MinWidth="200"
-                                BorderBrush="{ThemeResource TextControlBorderBrush}"
-                                BorderThickness="1" />
-                        </RefreshContainer>
-                    </Grid>
-                </controls:ControlExample.Example>
+<Page x:Class="WinUIGallery.ControlPages.PullToRefreshPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:controls="using:WinUIGallery.Controls"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
+    <StackPanel>
+        <controls:ControlExample x:Name="Example1"
+                                 HeaderText="Basic PullToRefresh">
+            <controls:ControlExample.Example>
+                <Grid>
+                    <RefreshContainer x:Name="rc"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"
+                                      RefreshRequested="rc_RefreshRequested">
+                        <ListView x:Name="lv"
+                                  Height="200"
+                                  MinWidth="200"
+                                  BorderBrush="{ThemeResource TextControlBorderBrush}"
+                                  BorderThickness="1" />
+                    </RefreshContainer>
+                </Grid>
+            </controls:ControlExample.Example>
 
-                <controls:ControlExample.Xaml>
-                    <x:String xml:space="preserve">
+            <controls:ControlExample.Xaml>
+                <x:String xml:space="preserve">
 &lt;RefreshContainer x:Name="rc" RefreshRequested="rc_RefreshRequested"&gt;
     &lt;ListView x:Name="lv" Width="300" Height="300" BorderThickness="1" BorderBrush="Black"/&gt;
 &lt;/RefreshContainer&gt;
                 </x:String>
-                </controls:ControlExample.Xaml>
-                <controls:ControlExample.CSharp>
-                    <x:String xml:space="preserve">
+            </controls:ControlExample.Xaml>
+            <controls:ControlExample.CSharp>
+                <x:String xml:space="preserve">
 ObservableCollection&lt;string&gt; items = new ObservableCollection&lt;string&gt;();
 listview.ItemsSource = items;
 
@@ -56,21 +53,22 @@ private void WorkCompleted()
     }
 }
                     </x:String>
-                </controls:ControlExample.CSharp>
-            </controls:ControlExample>
+            </controls:ControlExample.CSharp>
+        </controls:ControlExample>
 
-            <controls:ControlExample x:Name="Example2" HeaderText="Custom Icon PullToRefresh">
-                <controls:ControlExample.Example>
-                    <Grid x:Name="Ex2Grid">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition />
-                        </Grid.RowDefinitions>
-                    </Grid>
-                </controls:ControlExample.Example>
+        <controls:ControlExample x:Name="Example2"
+                                 HeaderText="Custom Icon PullToRefresh">
+            <controls:ControlExample.Example>
+                <Grid x:Name="Ex2Grid">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition />
+                    </Grid.RowDefinitions>
+                </Grid>
+            </controls:ControlExample.Example>
 
-                <controls:ControlExample.Xaml>
-                    <x:String xml:space="preserve">
+            <controls:ControlExample.Xaml>
+                <x:String xml:space="preserve">
 &lt;RefreshContainer x:Name="rc" RefreshRequested="rc_RefreshRequested"&gt;
     &lt;RefreshContainer.Visualizer&gt;
         &lt;RefreshVisualizer RefreshStateChanged="rv2_RefreshStateChanged"&gt;
@@ -82,9 +80,9 @@ private void WorkCompleted()
     &lt;ListView x:Name="lv" Width="300" Height="300" BorderThickness="1" BorderBrush="Black"/&gt;
 &lt;/RefreshContainer&gt;
                 </x:String>
-                </controls:ControlExample.Xaml>
-                <controls:ControlExample.CSharp>
-                    <x:String xml:space="preserve">
+            </controls:ControlExample.Xaml>
+            <controls:ControlExample.CSharp>
+                <x:String xml:space="preserve">
 ObservableCollection&lt;string&gt; items = new ObservableCollection&lt;string&gt;();
 listview.ItemsSource = items;
 
@@ -111,9 +109,8 @@ private void rv2_RefreshStateChanged()
     visualizerContentVisual.StopAnimation("RotationAngle");
 }
                     </x:String>
-                </controls:ControlExample.CSharp>
-            </controls:ControlExample>
+            </controls:ControlExample.CSharp>
+        </controls:ControlExample>
 
-        </StackPanel>
-    </ScrollViewer>
+    </StackPanel>
 </Page>

--- a/WinUIGallery/Samples/ControlPages/TreeViewPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/TreeViewPage.xaml
@@ -16,7 +16,7 @@
                 ItemsSource="{x:Bind Children}">
 
                 <StackPanel Orientation="Horizontal">
-                    <Image Width="20" Source="../Assets/SampleMedia/folder.png" />
+                    <Image Width="20" Source="ms-appx:///Assets/SampleMedia/folder.png" />
                     <TextBlock Margin="0,0,10,0" />
                     <TextBlock Text="{x:Bind Name}" />
                 </StackPanel>

--- a/WinUIGallery/Samples/SamplePages/SamplePage1.xaml
+++ b/WinUIGallery/Samples/SamplePages/SamplePage1.xaml
@@ -6,7 +6,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <ScrollViewer>
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid>
             <Grid.Resources>
                 <x:Double x:Key="TileHeight">150</x:Double>

--- a/WinUIGallery/Samples/SamplePages/SamplePage2.xaml
+++ b/WinUIGallery/Samples/SamplePages/SamplePage2.xaml
@@ -6,7 +6,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <ScrollViewer>
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid>
             <Grid.Resources>
                 <x:Double x:Key="TileHeight">150</x:Double>

--- a/WinUIGallery/Samples/SamplePages/SamplePage3.xaml
+++ b/WinUIGallery/Samples/SamplePages/SamplePage3.xaml
@@ -7,7 +7,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <ScrollViewer>
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid>
             <Grid.Resources>
                 <x:Double x:Key="TileHeight">150</x:Double>

--- a/WinUIGallery/Samples/SamplePages/SamplePage4.xaml
+++ b/WinUIGallery/Samples/SamplePages/SamplePage4.xaml
@@ -7,7 +7,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <ScrollViewer>
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel>
             <Grid>
                 <Grid.Resources>

--- a/WinUIGallery/Samples/SamplePages/SamplePage5.xaml
+++ b/WinUIGallery/Samples/SamplePages/SamplePage5.xaml
@@ -7,7 +7,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <ScrollViewer>
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid>
             <Grid.Resources>
                 <x:Double x:Key="TileHeight">150</x:Double>

--- a/WinUIGallery/Samples/SamplePages/SamplePage6.xaml
+++ b/WinUIGallery/Samples/SamplePages/SamplePage6.xaml
@@ -7,7 +7,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <ScrollViewer>
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid>
             <Grid.Resources>
                 <x:Double x:Key="TileHeight">150</x:Double>

--- a/WinUIGallery/Samples/SamplePages/SamplePage7.xaml
+++ b/WinUIGallery/Samples/SamplePages/SamplePage7.xaml
@@ -6,7 +6,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <ScrollViewer>
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
         <Grid>
             <Grid.Resources>
                 <x:Double x:Key="TileHeight">150</x:Double>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes an issue in the `TreeViewPage` where the folder icon image was not displaying correctly due to project restructuring. The image source was using a relative path, which became invalid after the changes.

## Motivation and Context
Updated the image path to ensure the icon displays correctly.

## Screenshots:
Before:
![image](https://github.com/user-attachments/assets/bc3ea32b-cd38-460b-a3ca-5f5db265250c)

After:
![image](https://github.com/user-attachments/assets/00ab3853-a043-42d2-bf8c-1cc2a6a3c182)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
