### PR TITLE
Fix `TreeView` Example Icon Path Issue After Restructuring

### DIFF
--- a/WinUIGallery/Samples/ControlPages/TreeViewPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/TreeViewPage.xaml
@@ -16,7 +16,7 @@
                 ItemsSource="{x:Bind Children}">
 
                 <StackPanel Orientation="Horizontal">
-                    <Image Width="20" Source="../Assets/SampleMedia/folder.png" />
+                    <Image Width="20" Source="ms-appx:///Assets/SampleMedia/folder.png" />
                     <TextBlock Margin="0,0,10,0" />
                     <TextBlock Text="{x:Bind Name}" />
                 </StackPanel>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes an issue in the `TreeViewPage` where the folder icon image was not displaying correctly due to project restructuring. The image source was using a relative path, which became invalid after the changes.

## Motivation and Context
Updated the image path to ensure the icon displays correctly.

## Screenshots:
Before:
![image](https://github.com/user-attachments/assets/bc3ea32b-cd38-460b-a3ca-5f5db265250c)

After:
![image](https://github.com/user-attachments/assets/00ab3853-a043-42d2-bf8c-1cc2a6a3c182)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
