### PR TITLE
Fix auto-scrolling issue on the TabView page

### DIFF
--- a/WinUIGallery/Samples/ControlPages/TabViewPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/TabViewPage.xaml
@@ -228,6 +228,7 @@
                         TextWrapping="WrapWholeWords" />
 
                     <TabView
+                        BringIntoViewRequested="TabView_BringIntoViewRequested"
                         MinHeight="475"
                         Margin="-12"
                         AddTabButtonClick="TabView_AddButtonClick"
@@ -271,10 +272,12 @@
             <controls:ControlExample.Example>
                 <TabView
                     x:Name="TabView3"
+                    BringIntoViewRequested="TabView_BringIntoViewRequested"
                     MinHeight="475"
                     Margin="-12"
                     IsAddTabButtonVisible="False"
-                    SelectedIndex="0">
+                    SelectedIndex="0"
+                    TabWidthMode="SizeToContent">
                     <TabView.TabItems>
                         <TabViewItem Header="Home" IsClosable="False">
                             <TabViewItem.IconSource>
@@ -378,6 +381,7 @@
                         TextWrapping="WrapWholeWords" />
 
                     <TabView
+                        BringIntoViewRequested="TabView_BringIntoViewRequested"
                         MinWidth="490"
                         IsAddTabButtonVisible="False"
                         SelectedIndex="0"

--- a/WinUIGallery/Samples/ControlPages/TabViewPage.xaml.cs
+++ b/WinUIGallery/Samples/ControlPages/TabViewPage.xaml.cs
@@ -29,13 +29,20 @@ public sealed partial class TabViewPage : Page
         InitializeDataBindingSampleData();
     }
 
-#region SharedTabViewLogic
+    #region SharedTabViewLogic
     private void TabView_Loaded(object sender, RoutedEventArgs e)
     {
         for (int i = 0; i < 3; i++)
         {
             (sender as TabView).TabItems.Add(CreateNewTab(i));
         }
+    }
+
+    private void TabView_BringIntoViewRequested(UIElement sender, BringIntoViewRequestedEventArgs args)
+    {
+        // The TabView control is firing this event when TabWidthMode is set to `SizeToContent` or `Compact`.
+        // This will work around an auto-scroll issue when the page is loaded.
+        args.Handled = true;
     }
 
     private void TabView_AddButtonClick(TabView sender, object args)
@@ -76,9 +83,9 @@ public sealed partial class TabViewPage : Page
 
         return newItem;
     }
-#endregion
+    #endregion
 
-#region ItemsSourceSample
+    #region ItemsSourceSample
     private void InitializeDataBindingSampleData()
     {
         myDatas = new ObservableCollection<MyData>();
@@ -128,9 +135,9 @@ public sealed partial class TabViewPage : Page
         // Remove the requested MyData object from the collection.
         myDatas.Remove(args.Item as MyData);
     }
-#endregion
+    #endregion
 
-#region KeyboardAcceleratorSample
+    #region KeyboardAcceleratorSample
     private void NewTabKeyboardAccelerator_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
     {
         var senderTabView = args.Element as TabView;
@@ -198,7 +205,7 @@ public sealed partial class TabViewPage : Page
 
         args.Handled = true;
     }
-#endregion
+    #endregion
 
     private void TabWidthBehaviorComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Closes #815.
This PR fixes an auto-scrolling issue on the TabView page.
What I found out is that the `TabView` control is firering `BringIntoViewRequested` events when `TabWidthMode` is set to `SizeToContent` or `Compact`. Handling the `BringIntoViewRequested` event stopped the auto-scrolling.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran the app and verified the changes.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
