### PR TITLE
Fix crash on Templates page due to incorrect file path

### DIFF
--- a/WinUIGallery/Samples/ControlPages/Fundamentals/TemplatesPage.xaml.cs
+++ b/WinUIGallery/Samples/ControlPages/Fundamentals/TemplatesPage.xaml.cs
@@ -32,6 +32,6 @@ public sealed partial class TemplatesPage : Page
     private static string ReadSampleCodeFileContent(string sampleCodeFileName)
     {
         StorageFolder folder = Windows.ApplicationModel.Package.Current.InstalledLocation;
-        return File.ReadAllText($"{folder.Path}\\ControlPagesSampleCode\\Templates\\{sampleCodeFileName}.txt");
+        return File.ReadAllText($"{folder.Path}\\Samples\\SampleCode\\Templates\\{sampleCodeFileName}.txt");
     }
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed an app crash on the Templates page when changing the radio button in the third example. The issue was caused by the structural change in the app, which made the old file path invalid. Updated **ReadSampleCodeFileContent** to use the correct path (**Samples\\SampleCode\\Templates**) to resolve the issue.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
