### PR TITLE
Minor menu reordering

### DIFF
--- a/WinUIGallery/Samples/Data/ControlInfoData.json
+++ b/WinUIGallery/Samples/Data/ControlInfoData.json
@@ -782,6 +782,46 @@
           ]
         },
         {
+          "UniqueId": "ItemsRepeater",
+          "Title": "ItemsRepeater",
+          "BaseClasses": [
+            "Object",
+            "DependencyObject",
+            "UIElement",
+            "FrameworkElement"
+          ],
+          "ApiNamespace": "Microsoft.UI.Xaml.Controls",
+          "Subtitle": "A flexible, primitive control for data-driven layouts.",
+          "ImagePath": "ms-appx:///Assets/ControlImages/ListView.png",
+          "Description": "The ItemsRepeater is like a markup-based loop that supports virtualization.",
+          "Content": "<p>A <b>ItemsRepeater</b> is more basic than an <b>ItemsControl</b>.  It does not have default styling or a control template.  It can contain a collection of items of any type. To populate the view, set the <b>ItemsSource</b> property to a data source.</p><p>Set an <b>ItemTemplate</b> to define the look of individual items.</p><p>And, optionally set the <b>Layout</b> to define how items are sized and positioned. By default, it uses a simple vertical stacking layout.</p><p>Look at the <i>ItemsRepeaterPage.xaml</i> file in Visual Studio to see the full code for this page.</p>",
+          "Docs": [
+            {
+              "Title": "ItemsRepeater - API",
+              "Uri": "https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.itemsrepeater"
+            },
+            {
+              "Title": "Guidelines",
+              "Uri": "https://learn.microsoft.com/windows/apps/design/controls/items-repeater"
+            },
+            {
+              "Title": "StackLayout - API",
+              "Uri": "https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.stacklayout"
+            },
+            {
+              "Title": "UniformGridLayout - API",
+              "Uri": "https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.uniformgridlayout"
+            }
+          ],
+          "RelatedControls": [
+            "ItemsView",
+            "ScrollView",
+            "ScrollViewer",
+            "ListView",
+            "GridView"
+          ]
+        },
+        {
           "UniqueId": "ItemsView",
           "Title": "ItemsView",
           "BaseClasses": [
@@ -2161,46 +2201,6 @@
             "Flyout",
             "ItemsRepeater",
             "SplitView"
-          ]
-        },
-        {
-          "UniqueId": "ItemsRepeater",
-          "Title": "ItemsRepeater",
-          "BaseClasses": [
-            "Object",
-            "DependencyObject",
-            "UIElement",
-            "FrameworkElement"
-          ],
-          "ApiNamespace": "Microsoft.UI.Xaml.Controls",
-          "Subtitle": "A flexible, primitive control for data-driven layouts.",
-          "ImagePath": "ms-appx:///Assets/ControlImages/ListView.png",
-          "Description": "The ItemsRepeater is like a markup-based loop that supports virtualization.",
-          "Content": "<p>A <b>ItemsRepeater</b> is more basic than an <b>ItemsControl</b>.  It does not have default styling or a control template.  It can contain a collection of items of any type. To populate the view, set the <b>ItemsSource</b> property to a data source.</p><p>Set an <b>ItemTemplate</b> to define the look of individual items.</p><p>And, optionally set the <b>Layout</b> to define how items are sized and positioned. By default, it uses a simple vertical stacking layout.</p><p>Look at the <i>ItemsRepeaterPage.xaml</i> file in Visual Studio to see the full code for this page.</p>",
-          "Docs": [
-            {
-              "Title": "ItemsRepeater - API",
-              "Uri": "https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.itemsrepeater"
-            },
-            {
-              "Title": "Guidelines",
-              "Uri": "https://learn.microsoft.com/windows/apps/design/controls/items-repeater"
-            },
-            {
-              "Title": "StackLayout - API",
-              "Uri": "https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.stacklayout"
-            },
-            {
-              "Title": "UniformGridLayout - API",
-              "Uri": "https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.controls.uniformgridlayout"
-            }
-          ],
-          "RelatedControls": [
-            "ItemsView",
-            "ScrollView",
-            "ScrollViewer",
-            "ListView",
-            "GridView"
           ]
         },
         {

--- a/WinUIGallery/Samples/Data/ControlInfoData.json
+++ b/WinUIGallery/Samples/Data/ControlInfoData.json
@@ -322,64 +322,7 @@
       "ImagePath": "",
       "IconGlyph": "",
       "Items": [
-        {
-          "UniqueId": "XamlUICommand",
-          "Title": "XamlUICommand",
-          "BaseClasses": [
-            "Object",
-            "DependencyObject"
-          ],
-          "ApiNamespace": "Microsoft.UI.Xaml.Input",
-          "Subtitle": "An object which is used to define the look and feel of a given command.",
-          "ImagePath": "ms-appx:///Assets/ControlImages/AppBarSeparator.png",
-          "Description": "An object which is used to define the look and feel of a given command, which can be reused across your app, and which is understood natively by the standard XAML controls.",
-          "IsUpdated": true,
-          "Docs": [
-            {
-              "Title": "Guidelines",
-              "Uri": "https://learn.microsoft.com/windows/apps/design/controls/commanding#command-experiences-using-the-xamluicommand-class"
-            },
-            {
-              "Title": "XamlUICommand - API",
-              "Uri": "https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.xamluicommand"
-            }
-          ],
-          "RelatedControls": [
-            "StandardUICommand",
-            "AppBarButton",
-            "AppBarToggleButton",
-            "CommandBar"
-          ]
-        },
-        {
-          "UniqueId": "StandardUICommand",
-          "Title": "StandardUICommand",
-          "BaseClasses": [
-            "Object",
-            "DependencyObject",
-            "XamlUICommand"
-          ],
-          "ApiNamespace": "Microsoft.UI.Xaml.Input",
-          "Subtitle": "A StandardUICommand is a built-in 'XamlUICommand' which represents a commonly used command, e.g. 'Save'.",
-          "ImagePath": "ms-appx:///Assets/ControlImages/AppBarSeparator.png",
-          "Description": "StandardUICommands are a set of built-in XamlUICommands represeting commonly used commands. Including the look and feel of a given command, which can be reused across your app, and which is understood natively by the standard XAML controls. E.g. Save, Open, Copy, Paste, etc.",
-          "Docs": [
-            {
-              "Title": "Guidelines",
-              "Uri": "https://learn.microsoft.com/windows/apps/design/controls/commanding#command-experiences-using-the-standarduicommand-class"
-            },
-            {
-              "Title": "StandardUICommand - API",
-              "Uri": "https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.standarduicommand"
-            }
-          ],
-          "RelatedControls": [
-            "XamlUICommand",
-            "AppBarButton",
-            "AppBarToggleButton",
-            "CommandBar"
-          ]
-        },
+
         {
           "UniqueId": "AppBarButton",
           "Title": "AppBarButton",
@@ -549,38 +492,6 @@
           ]
         },
         {
-          "UniqueId": "MenuBar",
-          "Title": "MenuBar",
-          "BaseClasses": [
-            "Object",
-            "DependencyObject",
-            "UIElement",
-            "FrameworkElement",
-            "Control"
-          ],
-          "ApiNamespace": "Microsoft.UI.Xaml.Controls",
-          "Subtitle": "A classic menu, allowing the display of MenuItems containing MenuFlyoutItems.",
-          "ImagePath": "ms-appx:///Assets/ControlImages/MenuBar.png",
-          "Description": "The Menubar simplifies the creation of basic applications by providing a set of menus at the top of the app or window.",
-          "SourcePath": "/MenuBar",
-          "Docs": [
-            {
-              "Title": "MenuBar - API",
-              "Uri": "https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.Controls.MenuBar"
-            },
-            {
-              "Title": "Guidelines",
-              "Uri": "https://learn.microsoft.com/windows/apps/design/controls/menus"
-            }
-          ],
-          "RelatedControls": [
-            "CommandBar",
-            "MenuFlyout",
-            "StandardUICommand",
-            "XamlUICommand"
-          ]
-        },
-        {
           "UniqueId": "CommandBarFlyout",
           "Title": "CommandBarFlyout",
           "BaseClasses": [
@@ -608,6 +519,38 @@
             "MenuFlyout",
             "RichEditBox",
             "TextBox",
+            "StandardUICommand",
+            "XamlUICommand"
+          ]
+        },
+        {
+          "UniqueId": "MenuBar",
+          "Title": "MenuBar",
+          "BaseClasses": [
+            "Object",
+            "DependencyObject",
+            "UIElement",
+            "FrameworkElement",
+            "Control"
+          ],
+          "ApiNamespace": "Microsoft.UI.Xaml.Controls",
+          "Subtitle": "A classic menu, allowing the display of MenuItems containing MenuFlyoutItems.",
+          "ImagePath": "ms-appx:///Assets/ControlImages/MenuBar.png",
+          "Description": "The Menubar simplifies the creation of basic applications by providing a set of menus at the top of the app or window.",
+          "SourcePath": "/MenuBar",
+          "Docs": [
+            {
+              "Title": "MenuBar - API",
+              "Uri": "https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.Controls.MenuBar"
+            },
+            {
+              "Title": "Guidelines",
+              "Uri": "https://learn.microsoft.com/windows/apps/design/controls/menus"
+            }
+          ],
+          "RelatedControls": [
+            "CommandBar",
+            "MenuFlyout",
             "StandardUICommand",
             "XamlUICommand"
           ]
@@ -700,6 +643,64 @@
           "RelatedControls": [
             "GridView",
             "ListView"
+          ]
+        },
+        {
+          "UniqueId": "StandardUICommand",
+          "Title": "StandardUICommand",
+          "BaseClasses": [
+            "Object",
+            "DependencyObject",
+            "XamlUICommand"
+          ],
+          "ApiNamespace": "Microsoft.UI.Xaml.Input",
+          "Subtitle": "A StandardUICommand is a built-in 'XamlUICommand' which represents a commonly used command, e.g. 'Save'.",
+          "ImagePath": "ms-appx:///Assets/ControlImages/AppBarSeparator.png",
+          "Description": "StandardUICommands are a set of built-in XamlUICommands represeting commonly used commands. Including the look and feel of a given command, which can be reused across your app, and which is understood natively by the standard XAML controls. E.g. Save, Open, Copy, Paste, etc.",
+          "Docs": [
+            {
+              "Title": "Guidelines",
+              "Uri": "https://learn.microsoft.com/windows/apps/design/controls/commanding#command-experiences-using-the-standarduicommand-class"
+            },
+            {
+              "Title": "StandardUICommand - API",
+              "Uri": "https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.standarduicommand"
+            }
+          ],
+          "RelatedControls": [
+            "XamlUICommand",
+            "AppBarButton",
+            "AppBarToggleButton",
+            "CommandBar"
+          ]
+        },
+        {
+          "UniqueId": "XamlUICommand",
+          "Title": "XamlUICommand",
+          "BaseClasses": [
+            "Object",
+            "DependencyObject"
+          ],
+          "ApiNamespace": "Microsoft.UI.Xaml.Input",
+          "Subtitle": "An object which is used to define the look and feel of a given command.",
+          "ImagePath": "ms-appx:///Assets/ControlImages/AppBarSeparator.png",
+          "Description": "An object which is used to define the look and feel of a given command, which can be reused across your app, and which is understood natively by the standard XAML controls.",
+          "IsUpdated": true,
+          "Docs": [
+            {
+              "Title": "Guidelines",
+              "Uri": "https://learn.microsoft.com/windows/apps/design/controls/commanding#command-experiences-using-the-xamluicommand-class"
+            },
+            {
+              "Title": "XamlUICommand - API",
+              "Uri": "https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.input.xamluicommand"
+            }
+          ],
+          "RelatedControls": [
+            "StandardUICommand",
+            "AppBarButton",
+            "AppBarToggleButton",
+            "CommandBar"
           ]
         }
       ]
@@ -2955,27 +2956,32 @@
           ]
         },
         {
-          "UniqueId": "RadialGradientBrush",
-          "Title": "RadialGradientBrush",
+          "UniqueId": "Line",
+          "Title": "Line",
           "BaseClasses": [
             "Object",
             "DependencyObject",
-            "Brush",
-            "XamlCompositionBrushBase"
+            "UIElement",
+            "FrameworkElement",
+            "Shape"
           ],
-          "ApiNamespace": "Microsoft.UI.Xaml.Media",
-          "Subtitle": "A brush to show radial gradients.",
-          "ImagePath": "ms-appx:///Assets/ControlImages/Canvas.png",
-          "Description": "Paints an area with a radial gradient. A center point defines the beginning of the gradient, and a radius defines the end point of the gradient.",
-          "Content": "The RadialGradientBrush is similar in programming model to the LinearGradientBrush. However, the linear gradient has a start and an end point to define the gradient vector, while the radial gradient has a circle, along with a focal point, to define the gradient behavior. The circle defines the end point of the gradient. The parameters can be provided as a ratio or absolute value by picking the mapping mode.",
+          "ApiNamespace": "Microsoft.UI.Xaml.Shapes",
+          "Subtitle": "Draws a straight line between two points.",
+          "ImagePath": "ms-appx:///Assets/ControlImages/Line.png",
+          "Description": "Draws a straight line between two points.",
+          "Content": "<p>Look at the <i>LinePage.xaml</i> file in Visual Studio to see the full code for this page.</p>",
           "Docs": [
             {
-              "Title": "RadialGradientBrush - API",
-              "Uri": "https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.media.RadialGradientBrush"
+              "Title": "Lines - API",
+              "Uri": "https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.shapes"
+            },
+            {
+              "Title": "Guidelines",
+              "Uri": "https://learn.microsoft.com/previous-versions/windows/apps/hh465055(v=win.10)"
             }
           ],
           "RelatedControls": [
-            "Acrylic"
+            "Shape"
           ]
         },
         {
@@ -3007,32 +3013,27 @@
           ]
         },
         {
-          "UniqueId": "Line",
-          "Title": "Line",
+          "UniqueId": "RadialGradientBrush",
+          "Title": "RadialGradientBrush",
           "BaseClasses": [
             "Object",
             "DependencyObject",
-            "UIElement",
-            "FrameworkElement",
-            "Shape"
+            "Brush",
+            "XamlCompositionBrushBase"
           ],
-          "ApiNamespace": "Microsoft.UI.Xaml.Shapes",
-          "Subtitle": "Draws a straight line between two points.",
-          "ImagePath": "ms-appx:///Assets/ControlImages/Line.png",
-          "Description": "Draws a straight line between two points.",
-          "Content": "<p>Look at the <i>LinePage.xaml</i> file in Visual Studio to see the full code for this page.</p>",
+          "ApiNamespace": "Microsoft.UI.Xaml.Media",
+          "Subtitle": "A brush to show radial gradients.",
+          "ImagePath": "ms-appx:///Assets/ControlImages/Canvas.png",
+          "Description": "Paints an area with a radial gradient. A center point defines the beginning of the gradient, and a radius defines the end point of the gradient.",
+          "Content": "The RadialGradientBrush is similar in programming model to the LinearGradientBrush. However, the linear gradient has a start and an end point to define the gradient vector, while the radial gradient has a circle, along with a focal point, to define the gradient behavior. The circle defines the end point of the gradient. The parameters can be provided as a ratio or absolute value by picking the mapping mode.",
           "Docs": [
             {
-              "Title": "Lines - API",
-              "Uri": "https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.shapes"
-            },
-            {
-              "Title": "Guidelines",
-              "Uri": "https://learn.microsoft.com/previous-versions/windows/apps/hh465055(v=win.10)"
+              "Title": "RadialGradientBrush - API",
+              "Uri": "https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.media.RadialGradientBrush"
             }
           ],
           "RelatedControls": [
-            "Shape"
+            "Acrylic"
           ]
         },
         {
@@ -3326,6 +3327,31 @@
       "IconGlyph": "",
       "Items": [
         {
+          "UniqueId": "XamlCompInterop",
+          "Title": "Animation interop",
+          "Subtitle": "XAML and Composition interop allows you to animate elements using expressions, natural animations, and more.",
+          "ImagePath": "ms-appx:///Assets/ControlImages/AnimationInterop.png",
+          "Description": "XAML and Composition interop allows you to animate elements using expressions, natural animations, and more",
+          "Content": "<p>Look at the <i>XamlCompInteropPage.xaml.cs</i> file in Visual Studio to see the full code for this page.</p>",
+          "Docs": [
+            {
+              "Title": "Quickstart: Motion",
+              "Uri": "https://learn.microsoft.com/windows/apps/design/motion"
+            },
+            {
+              "Title": "Composition Animation - API",
+              "Uri": "https://learn.microsoft.com/windows/apps/windows-app-sdk/composition"
+            },
+            {
+              "Title": "Guidelines - Xaml Property Animations",
+              "Uri": "https://learn.microsoft.com/windows/apps/design/motion/xaml-property-animations"
+            }
+          ],
+          "RelatedControls": [
+            "EasingFunction"
+          ]
+        },
+        {
           "UniqueId": "ConnectedAnimation",
           "Title": "Connected Animation",
           "BaseClasses": [
@@ -3388,6 +3414,33 @@
           ]
         },
         {
+          "UniqueId": "ImplicitTransition",
+          "Title": "Implicit Transitions",
+          "ApiNamespace": "Microsoft.UI.Xaml",
+          "Subtitle": "Use Implicit Transitions to automatically animate changes to properties.",
+          "ImagePath": "ms-appx:///Assets/ControlImages/ImplicitTransition.png",
+          "Description": "Use Implicit Transitions to automatically animate changes to properties.",
+          "Content": "<p>Look at the <i>ImplicitTransitionPage.xaml</i> file in Visual Studio to see the full code for this page.</p>",
+          "Docs": [
+            {
+              "Title": "Transitions - API",
+              "Uri": "https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.uielement.transitions#Windows_UI_Xaml_UIElement_Transitions"
+            },
+            {
+              "Title": "Guidelines",
+              "Uri": "https://learn.microsoft.com/windows/apps/design/motion/motion-in-practice#implicit-animations"
+            },
+            {
+              "Title": "Quickstart: Motion",
+              "Uri": "https://learn.microsoft.com/windows/apps/design/motion"
+            }
+          ],
+          "RelatedControls": [
+            "PageTransition",
+            "ThemeTransition"
+          ]
+        },
+        {
           "UniqueId": "PageTransition",
           "Title": "Page Transitions",
           "ApiNamespace": "Microsoft.UI.Xaml.Media.Animation",
@@ -3439,58 +3492,6 @@
           "RelatedControls": [
             "ImplicitTransition",
             "PageTransition"
-          ]
-        },
-        {
-          "UniqueId": "XamlCompInterop",
-          "Title": "Animation interop",
-          "Subtitle": "XAML and Composition interop allows you to animate elements using expressions, natural animations, and more.",
-          "ImagePath": "ms-appx:///Assets/ControlImages/AnimationInterop.png",
-          "Description": "XAML and Composition interop allows you to animate elements using expressions, natural animations, and more",
-          "Content": "<p>Look at the <i>XamlCompInteropPage.xaml.cs</i> file in Visual Studio to see the full code for this page.</p>",
-          "Docs": [
-            {
-              "Title": "Quickstart: Motion",
-              "Uri": "https://learn.microsoft.com/windows/apps/design/motion"
-            },
-            {
-              "Title": "Composition Animation - API",
-              "Uri": "https://learn.microsoft.com/windows/apps/windows-app-sdk/composition"
-            },
-            {
-              "Title": "Guidelines - Xaml Property Animations",
-              "Uri": "https://learn.microsoft.com/windows/apps/design/motion/xaml-property-animations"
-            }
-          ],
-          "RelatedControls": [
-            "EasingFunction"
-          ]
-        },
-        {
-          "UniqueId": "ImplicitTransition",
-          "Title": "Implicit Transitions",
-          "ApiNamespace": "Microsoft.UI.Xaml",
-          "Subtitle": "Use Implicit Transitions to automatically animate changes to properties.",
-          "ImagePath": "ms-appx:///Assets/ControlImages/ImplicitTransition.png",
-          "Description": "Use Implicit Transitions to automatically animate changes to properties.",
-          "Content": "<p>Look at the <i>ImplicitTransitionPage.xaml</i> file in Visual Studio to see the full code for this page.</p>",
-          "Docs": [
-            {
-              "Title": "Transitions - API",
-              "Uri": "https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.uielement.transitions#Windows_UI_Xaml_UIElement_Transitions"
-            },
-            {
-              "Title": "Guidelines",
-              "Uri": "https://learn.microsoft.com/windows/apps/design/motion/motion-in-practice#implicit-animations"
-            },
-            {
-              "Title": "Quickstart: Motion",
-              "Uri": "https://learn.microsoft.com/windows/apps/design/motion"
-            }
-          ],
-          "RelatedControls": [
-            "PageTransition",
-            "ThemeTransition"
           ]
         },
         {


### PR DESCRIPTION
- A few items in the NavView were either not alphabetically sorted, or just had a weird ordering in general.
- Moved ItemsRepeater under Collections. This control is more used in context of binding a collection, like ItemsView/ListView etc. vs. in context of a layout panel like a Grid or StackPanel