### PR TITLE
Improve Scroll Behavior on Various Pages

### DIFF
--- a/WinUIGallery/Samples/ControlPages/Design/GeometryPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/Design/GeometryPage.xaml
@@ -50,7 +50,7 @@
             HorizontalContentAlignment="Stretch"
             XamlSource="Geometry/GeometrySample_xaml.txt">
             <StackPanel HorizontalAlignment="Stretch" Orientation="Vertical">
-                <ScrollViewer HorizontalScrollBarVisibility="Auto" HorizontalScrollMode="Auto">
+                <ScrollViewer HorizontalScrollBarVisibility="Auto" HorizontalScrollMode="Auto" VerticalScrollBarVisibility="Hidden">
                     <Canvas
                         Width="505"
                         Height="271"
@@ -115,7 +115,7 @@
                     </Canvas>
                 </ScrollViewer>
 
-                <ScrollViewer HorizontalScrollBarVisibility="Auto" HorizontalScrollMode="Auto">
+                <ScrollViewer HorizontalScrollBarVisibility="Auto" HorizontalScrollMode="Auto" VerticalScrollBarVisibility="Hidden">
                     <StackPanel>
                         <Grid Margin="0,48,0,24" HorizontalAlignment="Stretch">
                             <Grid.ColumnDefinitions>

--- a/WinUIGallery/Samples/ControlPages/Design/SpacingPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/Design/SpacingPage.xaml
@@ -115,7 +115,7 @@
             Grid.Row="2"
             Margin="0,36,0,0"
             Style="{StaticResource GalleryTileGridStyle}">
-            <ScrollViewer HorizontalScrollBarVisibility="Auto" HorizontalScrollMode="Auto">
+            <ScrollViewer HorizontalScrollBarVisibility="Auto" HorizontalScrollMode="Auto" VerticalScrollBarVisibility="Hidden">
                 <StackPanel Padding="12,24,12,12">
                     <!--  header  -->
                     <Grid Margin="16,0,0,0" HorizontalAlignment="Stretch">

--- a/WinUIGallery/Samples/ControlPages/Design/TypographyPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/Design/TypographyPage.xaml
@@ -53,7 +53,8 @@
                 <ScrollViewer
                     Height="450"
                     HorizontalScrollBarVisibility="Auto"
-                    HorizontalScrollMode="Auto">
+                    HorizontalScrollMode="Auto"
+                    VerticalScrollBarVisibility="Hidden">
                     <Canvas
                         Width="750"
                         Height="450"
@@ -157,7 +158,7 @@
                     </Canvas>
                 </ScrollViewer>
 
-                <ScrollViewer HorizontalScrollBarVisibility="Auto" HorizontalScrollMode="Auto">
+                <ScrollViewer HorizontalScrollBarVisibility="Auto" HorizontalScrollMode="Auto" VerticalScrollBarVisibility="Hidden">
                     <StackPanel>
                         <Grid Margin="0,48,0,24" HorizontalAlignment="Stretch">
                             <Grid.ColumnDefinitions>

--- a/WinUIGallery/Samples/ControlPages/PullToRefreshPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/PullToRefreshPage.xaml
@@ -5,36 +5,35 @@
     xmlns:controls="using:WinUIGallery.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
-    <ScrollViewer>
-        <StackPanel>
-            <controls:ControlExample x:Name="Example1" HeaderText="Basic PullToRefresh">
-                <controls:ControlExample.Example>
-                    <Grid>
-                        <RefreshContainer
-                            x:Name="rc"
-                            HorizontalAlignment="Center"
-                            VerticalAlignment="Center"
-                            RefreshRequested="rc_RefreshRequested">
-                            <ListView
-                                x:Name="lv"
-                                Height="200"
-                                MinWidth="200"
-                                BorderBrush="{ThemeResource TextControlBorderBrush}"
-                                BorderThickness="1" />
-                        </RefreshContainer>
-                    </Grid>
-                </controls:ControlExample.Example>
+    mc:Ignorable="d">   
+    <StackPanel>
+        <controls:ControlExample x:Name="Example1" HeaderText="Basic PullToRefresh">
+            <controls:ControlExample.Example>
+                <Grid>
+                    <RefreshContainer
+                        x:Name="rc"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        RefreshRequested="rc_RefreshRequested">
+                        <ListView
+                            x:Name="lv"
+                            Height="200"
+                            MinWidth="200"
+                            BorderBrush="{ThemeResource TextControlBorderBrush}"
+                            BorderThickness="1" />
+                    </RefreshContainer>
+                </Grid>
+            </controls:ControlExample.Example>
 
-                <controls:ControlExample.Xaml>
-                    <x:String xml:space="preserve">
+            <controls:ControlExample.Xaml>
+                <x:String xml:space="preserve">
 &lt;RefreshContainer x:Name="rc" RefreshRequested="rc_RefreshRequested"&gt;
     &lt;ListView x:Name="lv" Width="300" Height="300" BorderThickness="1" BorderBrush="Black"/&gt;
 &lt;/RefreshContainer&gt;
-                </x:String>
-                </controls:ControlExample.Xaml>
-                <controls:ControlExample.CSharp>
-                    <x:String xml:space="preserve">
+            </x:String>
+            </controls:ControlExample.Xaml>
+            <controls:ControlExample.CSharp>
+                <x:String xml:space="preserve">
 ObservableCollection&lt;string&gt; items = new ObservableCollection&lt;string&gt;();
 listview.ItemsSource = items;
 
@@ -55,22 +54,22 @@ private void WorkCompleted()
         this.RefreshCompletionDeferral = null;
     }
 }
-                    </x:String>
-                </controls:ControlExample.CSharp>
-            </controls:ControlExample>
+                </x:String>
+            </controls:ControlExample.CSharp>
+        </controls:ControlExample>
 
-            <controls:ControlExample x:Name="Example2" HeaderText="Custom Icon PullToRefresh">
-                <controls:ControlExample.Example>
-                    <Grid x:Name="Ex2Grid">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition />
-                        </Grid.RowDefinitions>
-                    </Grid>
-                </controls:ControlExample.Example>
+        <controls:ControlExample x:Name="Example2" HeaderText="Custom Icon PullToRefresh">
+            <controls:ControlExample.Example>
+                <Grid x:Name="Ex2Grid">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition />
+                    </Grid.RowDefinitions>
+                </Grid>
+            </controls:ControlExample.Example>
 
-                <controls:ControlExample.Xaml>
-                    <x:String xml:space="preserve">
+            <controls:ControlExample.Xaml>
+                <x:String xml:space="preserve">
 &lt;RefreshContainer x:Name="rc" RefreshRequested="rc_RefreshRequested"&gt;
     &lt;RefreshContainer.Visualizer&gt;
         &lt;RefreshVisualizer RefreshStateChanged="rv2_RefreshStateChanged"&gt;
@@ -81,10 +80,10 @@ private void WorkCompleted()
     &lt;/RefreshContainer.Visualizer&gt;
     &lt;ListView x:Name="lv" Width="300" Height="300" BorderThickness="1" BorderBrush="Black"/&gt;
 &lt;/RefreshContainer&gt;
-                </x:String>
-                </controls:ControlExample.Xaml>
-                <controls:ControlExample.CSharp>
-                    <x:String xml:space="preserve">
+            </x:String>
+            </controls:ControlExample.Xaml>
+            <controls:ControlExample.CSharp>
+                <x:String xml:space="preserve">
 ObservableCollection&lt;string&gt; items = new ObservableCollection&lt;string&gt;();
 listview.ItemsSource = items;
 
@@ -110,10 +109,9 @@ private void rv2_RefreshStateChanged()
     var visualizerContentVisual = ElementCompositionPreview.GetElementVisual(rv2.Content);
     visualizerContentVisual.StopAnimation("RotationAngle");
 }
-                    </x:String>
-                </controls:ControlExample.CSharp>
-            </controls:ControlExample>
+                </x:String>
+            </controls:ControlExample.CSharp>
+        </controls:ControlExample>
 
-        </StackPanel>
-    </ScrollViewer>
+    </StackPanel>
 </Page>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove `ScrollViewer` from `PullToRefresh` page and hide vertical scrollbar in `Geometry`, `Spacing`, and `Typography` pages.

## Motivation and Context
The `ScrollBar` was visible even when there was no need to scroll, making the screen look cluttered. These changes ensure a cleaner and more polished UI.

## How Has This Been Tested?
**Manually** tested

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/f72ab104-3d17-461f-a9d9-884047cb06d1)
![image](https://github.com/user-attachments/assets/f6b4630a-ae26-453b-9992-5147882e75b1)
![image](https://github.com/user-attachments/assets/7e4da368-564a-4cc9-aa0b-5ec3cb1bedbc)
![image](https://github.com/user-attachments/assets/0e396a29-133b-462c-9418-ad3e89f94345)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
