### PR TITLE
Fix variable naming inconsistency in SetOwnership method

### DIFF
--- a/WinUIGallery/Samples/SampleCode/AppWindow/AppWindowSample4_cs.txt
+++ b/WinUIGallery/Samples/SampleCode/AppWindow/AppWindowSample4_cs.txt
@@ -46,7 +46,7 @@ public sealed partial class ModalWindow : Window
     private void SetOwnership(AppWindow ownedAppWindow, Window ownerWindow)
     {
         // Get the HWND (window handle) of the owner window (main window).
-        IntPtr parentHwnd = WindowNative.GetWindowHandle(ownerWindow);
+        IntPtr ownerHwnd = WindowNative.GetWindowHandle(ownerWindow);
 
         // Get the HWND of the AppWindow (modal window).
         IntPtr ownedHwnd = Win32Interop.GetWindowFromWindowId(ownedAppWindow.Id);
@@ -55,11 +55,11 @@ public sealed partial class ModalWindow : Window
         // or SetWindowLong for 32-bit systems.
         if (IntPtr.Size == 8) // Check if the system is 64-bit
         {
-            SetWindowLongPtr(ownedHwnd, -8, parentHwnd); // -8 = GWLP_HWNDPARENT
+            SetWindowLongPtr(ownedHwnd, -8, ownerHwnd); // -8 = GWLP_HWNDPARENT
         }
         else // 32-bit system
         {
-            SetWindowLong(ownedHwnd, -8, parentHwnd);
+            SetWindowLong(ownedHwnd, -8, ownerHwnd);
         }
     }
 

--- a/WinUIGallery/Samples/SamplePages/ModalWindow.xaml.cs
+++ b/WinUIGallery/Samples/SamplePages/ModalWindow.xaml.cs
@@ -46,7 +46,7 @@ public sealed partial class ModalWindow : Window
     private void SetOwnership(AppWindow ownedAppWindow, Window ownerWindow)
     {
         // Get the HWND (window handle) of the owner window (main window).
-        IntPtr parentHwnd = WindowNative.GetWindowHandle(ownerWindow);
+        IntPtr ownerHwnd = WindowNative.GetWindowHandle(ownerWindow);
 
         // Get the HWND of the AppWindow (modal window).
         IntPtr ownedHwnd = Win32Interop.GetWindowFromWindowId(ownedAppWindow.Id);
@@ -55,11 +55,11 @@ public sealed partial class ModalWindow : Window
         // or SetWindowLong for 32-bit systems.
         if (IntPtr.Size == 8) // Check if the system is 64-bit
         {
-            SetWindowLongPtr(ownedHwnd, -8, parentHwnd); // -8 = GWLP_HWNDPARENT
+            SetWindowLongPtr(ownedHwnd, -8, ownerHwnd); // -8 = GWLP_HWNDPARENT
         }
         else // 32-bit system
         {
-            SetWindowLong(ownedHwnd, -8, parentHwnd);
+            SetWindowLong(ownedHwnd, -8, ownerHwnd);
         }
     }
 


### PR DESCRIPTION
## Description
- **No functional changes**.
- Renamed `parentHwnd` to `ownerHwnd` in `SetOwnership` method for consistency.

## Motivation and Context
Improves code readability and maintainability

## How Has This Been Tested?
**Manually tested**

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
