### PR TITLE
Fix slight blurriness in Settings StackPanel

### DIFF
--- a/WinUIGallery/Pages/SettingsPage.xaml
+++ b/WinUIGallery/Pages/SettingsPage.xaml
@@ -36,112 +36,114 @@
             Padding="36,0,36,0"
             VerticalScrollBarVisibility="Auto"
             VerticalScrollMode="Auto">
-            <StackPanel MaxWidth="1064" Spacing="{StaticResource SettingsCardSpacing}">
-                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="Appearance &amp; behavior" />
-                <toolkit:SettingsCard Description="Select which app theme to display" Header="App theme">
-                    <toolkit:SettingsCard.HeaderIcon>
-                        <FontIcon Glyph="&#xE790;" />
-                    </toolkit:SettingsCard.HeaderIcon>
-                    <ComboBox
-                        x:Name="themeMode"
-                        AutomationProperties.AutomationId="themeModeComboBox"
-                        SelectionChanged="themeMode_SelectionChanged">
-                        <ComboBoxItem Content="Light" Tag="Light" />
-                        <ComboBoxItem Content="Dark" Tag="Dark" />
-                        <ComboBoxItem Content="Use system setting" Tag="Default" />
-                    </ComboBox>
-                </toolkit:SettingsCard>
+            <Border>
+                <StackPanel MaxWidth="1064" Spacing="{StaticResource SettingsCardSpacing}">
+                    <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="Appearance &amp; behavior" />
+                    <toolkit:SettingsCard Description="Select which app theme to display" Header="App theme">
+                        <toolkit:SettingsCard.HeaderIcon>
+                            <FontIcon Glyph="&#xE790;" />
+                        </toolkit:SettingsCard.HeaderIcon>
+                        <ComboBox
+                            x:Name="themeMode"
+                            AutomationProperties.AutomationId="themeModeComboBox"
+                            SelectionChanged="themeMode_SelectionChanged">
+                            <ComboBoxItem Content="Light" Tag="Light" />
+                            <ComboBoxItem Content="Dark" Tag="Dark" />
+                            <ComboBoxItem Content="Use system setting" Tag="Default" />
+                        </ComboBox>
+                    </toolkit:SettingsCard>
 
-                <toolkit:SettingsCard Header="Navigation style">
-                    <toolkit:SettingsCard.HeaderIcon>
-                        <FontIcon Glyph="&#xF594;" />
-                    </toolkit:SettingsCard.HeaderIcon>
-                    <ComboBox x:Name="navigationLocation" SelectionChanged="navigationLocation_SelectionChanged">
-                        <ComboBoxItem Content="Left" />
-                        <ComboBoxItem Content="Top" />
-                    </ComboBox>
-                </toolkit:SettingsCard>
+                    <toolkit:SettingsCard Header="Navigation style">
+                        <toolkit:SettingsCard.HeaderIcon>
+                            <FontIcon Glyph="&#xF594;" />
+                        </toolkit:SettingsCard.HeaderIcon>
+                        <ComboBox x:Name="navigationLocation" SelectionChanged="navigationLocation_SelectionChanged">
+                            <ComboBoxItem Content="Left" />
+                            <ComboBoxItem Content="Top" />
+                        </ComboBox>
+                    </toolkit:SettingsCard>
 
-                <toolkit:SettingsExpander Description="Controls provide audible feedback" Header="Sound">
-                    <toolkit:SettingsExpander.HeaderIcon>
-                        <FontIcon Glyph="&#xEC4F;" />
-                    </toolkit:SettingsExpander.HeaderIcon>
-                    <ToggleSwitch x:Name="soundToggle" Toggled="soundToggle_Toggled" />
-                    <toolkit:SettingsExpander.Items>
-                        <toolkit:SettingsCard
-                            x:Name="SpatialAudioCard"
-                            Header="Enable Spatial Audio"
-                            IsEnabled="False">
-                            <toolkit:SettingsCard.Description>
-                                <HyperlinkButton Click="soundPageHyperlink_Click" Content="Learn more about enabling sounds in your app" />
-                            </toolkit:SettingsCard.Description>
-                            <ToggleSwitch x:Name="spatialSoundBox" Toggled="spatialSoundBox_Toggled" />
-                        </toolkit:SettingsCard>
-                    </toolkit:SettingsExpander.Items>
-                </toolkit:SettingsExpander>
+                    <toolkit:SettingsExpander Description="Controls provide audible feedback" Header="Sound">
+                        <toolkit:SettingsExpander.HeaderIcon>
+                            <FontIcon Glyph="&#xEC4F;" />
+                        </toolkit:SettingsExpander.HeaderIcon>
+                        <ToggleSwitch x:Name="soundToggle" Toggled="soundToggle_Toggled" />
+                        <toolkit:SettingsExpander.Items>
+                            <toolkit:SettingsCard
+                                x:Name="SpatialAudioCard"
+                                Header="Enable Spatial Audio"
+                                IsEnabled="False">
+                                <toolkit:SettingsCard.Description>
+                                    <HyperlinkButton Click="soundPageHyperlink_Click" Content="Learn more about enabling sounds in your app" />
+                                </toolkit:SettingsCard.Description>
+                                <ToggleSwitch x:Name="spatialSoundBox" Toggled="spatialSoundBox_Toggled" />
+                            </toolkit:SettingsCard>
+                        </toolkit:SettingsExpander.Items>
+                    </toolkit:SettingsExpander>
 
-                <!--  About  -->
-                <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="About" />
-                <toolkit:SettingsExpander
-                    Margin="0,0,0,24"
-                    Description="© 2025 Microsoft. All rights reserved."
-                    Header="{StaticResource AppTitleName}">
-                    <toolkit:SettingsExpander.HeaderIcon>
-                        <BitmapIcon ShowAsMonochrome="False" UriSource="/Assets/Tiles/BadgeLogo.png" />
-                    </toolkit:SettingsExpander.HeaderIcon>
-                    <TextBlock
-                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                        IsTextSelectionEnabled="True"
-                        Text="{x:Bind Version}" />
-                    <toolkit:SettingsExpander.Items>
-                        <toolkit:SettingsCard
-                            x:Name="toCloneRepoCard"
-                            Click="toCloneRepoCard_Click"
-                            Header="To clone this repository"
-                            IsClickEnabled="True">
-                            <TextBlock
-                                x:Name="gitCloneTextBlock"
-                                FontFamily="Consolas"
-                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                IsTextSelectionEnabled="True"
-                                Text="git clone https://github.com/microsoft/WinUI-Gallery" />
-                            <toolkit:SettingsCard.ActionIcon>
-                                <FontIcon Glyph="&#xE8C8;" />
-                            </toolkit:SettingsCard.ActionIcon>
-                        </toolkit:SettingsCard>
-                        <toolkit:SettingsCard
-                            x:Name="bugRequestCard"
-                            Click="bugRequestCard_Click"
-                            Header="File a bug or request new sample"
-                            IsClickEnabled="True">
-                            <toolkit:SettingsCard.ActionIcon>
-                                <FontIcon Glyph="&#xE8A7;" />
-                            </toolkit:SettingsCard.ActionIcon>
-                        </toolkit:SettingsCard>
-                        <toolkit:SettingsCard
-                            HorizontalContentAlignment="Left"
-                            ContentAlignment="Vertical"
-                            Header="Dependencies &amp; references">
-                            <StackPanel Margin="-12,0,0,0" Orientation="Vertical">
-                                <HyperlinkButton Content="{x:Bind WinAppSdkRuntimeDetails}" NavigateUri="https://aka.ms/windowsappsdk" />
-                                <HyperlinkButton Content="WinUI 3" NavigateUri="https://aka.ms/winui" />
-                                <HyperlinkButton Content="Windows Community Toolkit" NavigateUri="https://aka.ms/toolkit/windows" />
-                                <HyperlinkButton Content="ColorCode-Universal" NavigateUri="https://github.com/WilliamABradley/ColorCode-Universal" />
-                                <HyperlinkButton Content="Win2D" NavigateUri="https://github.com/Microsoft/Win2D" />
-                            </StackPanel>
-                        </toolkit:SettingsCard>
-                        <toolkit:SettingsCard
-                            HorizontalContentAlignment="Left"
-                            ContentAlignment="Vertical"
-                            Header="THIS CODE AND INFORMATION IS PROVIDED ‘AS IS’ WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.">
-                            <StackPanel Margin="-12,0,0,0" Orientation="Vertical">
-                                <HyperlinkButton Content="Microsoft Services Agreement" NavigateUri="https://go.microsoft.com/fwlink/?LinkId=822631" />
-                                <HyperlinkButton Content="Microsoft Privacy Statement" NavigateUri="https://go.microsoft.com/fwlink/?LinkId=521839" />
-                            </StackPanel>
-                        </toolkit:SettingsCard>
-                    </toolkit:SettingsExpander.Items>
-                </toolkit:SettingsExpander>
-            </StackPanel>
+                    <!--  About  -->
+                    <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="About" />
+                    <toolkit:SettingsExpander
+                        Margin="0,0,0,24"
+                        Description="© 2025 Microsoft. All rights reserved."
+                        Header="{StaticResource AppTitleName}">
+                        <toolkit:SettingsExpander.HeaderIcon>
+                            <BitmapIcon ShowAsMonochrome="False" UriSource="/Assets/Tiles/BadgeLogo.png" />
+                        </toolkit:SettingsExpander.HeaderIcon>
+                        <TextBlock
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            IsTextSelectionEnabled="True"
+                            Text="{x:Bind Version}" />
+                        <toolkit:SettingsExpander.Items>
+                            <toolkit:SettingsCard
+                                x:Name="toCloneRepoCard"
+                                Click="toCloneRepoCard_Click"
+                                Header="To clone this repository"
+                                IsClickEnabled="True">
+                                <TextBlock
+                                    x:Name="gitCloneTextBlock"
+                                    FontFamily="Consolas"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    IsTextSelectionEnabled="True"
+                                    Text="git clone https://github.com/microsoft/WinUI-Gallery" />
+                                <toolkit:SettingsCard.ActionIcon>
+                                    <FontIcon Glyph="&#xE8C8;" />
+                                </toolkit:SettingsCard.ActionIcon>
+                            </toolkit:SettingsCard>
+                            <toolkit:SettingsCard
+                                x:Name="bugRequestCard"
+                                Click="bugRequestCard_Click"
+                                Header="File a bug or request new sample"
+                                IsClickEnabled="True">
+                                <toolkit:SettingsCard.ActionIcon>
+                                    <FontIcon Glyph="&#xE8A7;" />
+                                </toolkit:SettingsCard.ActionIcon>
+                            </toolkit:SettingsCard>
+                            <toolkit:SettingsCard
+                                HorizontalContentAlignment="Left"
+                                ContentAlignment="Vertical"
+                                Header="Dependencies &amp; references">
+                                <StackPanel Margin="-12,0,0,0" Orientation="Vertical">
+                                    <HyperlinkButton Content="{x:Bind WinAppSdkRuntimeDetails}" NavigateUri="https://aka.ms/windowsappsdk" />
+                                    <HyperlinkButton Content="WinUI 3" NavigateUri="https://aka.ms/winui" />
+                                    <HyperlinkButton Content="Windows Community Toolkit" NavigateUri="https://aka.ms/toolkit/windows" />
+                                    <HyperlinkButton Content="ColorCode-Universal" NavigateUri="https://github.com/WilliamABradley/ColorCode-Universal" />
+                                    <HyperlinkButton Content="Win2D" NavigateUri="https://github.com/Microsoft/Win2D" />
+                                </StackPanel>
+                            </toolkit:SettingsCard>
+                            <toolkit:SettingsCard
+                                HorizontalContentAlignment="Left"
+                                ContentAlignment="Vertical"
+                                Header="THIS CODE AND INFORMATION IS PROVIDED ‘AS IS’ WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.">
+                                <StackPanel Margin="-12,0,0,0" Orientation="Vertical">
+                                    <HyperlinkButton Content="Microsoft Services Agreement" NavigateUri="https://go.microsoft.com/fwlink/?LinkId=822631" />
+                                    <HyperlinkButton Content="Microsoft Privacy Statement" NavigateUri="https://go.microsoft.com/fwlink/?LinkId=521839" />
+                                </StackPanel>
+                            </toolkit:SettingsCard>
+                        </toolkit:SettingsExpander.Items>
+                    </toolkit:SettingsExpander>
+                </StackPanel>
+            </Border>
         </ScrollView>
     </Grid>
 </Page>


### PR DESCRIPTION
## Description  
Wrapped the `StackPanel` inside a `Border` in the **Settings** page to fix a slight blurriness issue when the main window is maximized.  

## Motivation and Context  
- This change improves the visual clarity of items inside the `StackPanel`.
- This was a subtle and hard-to-notice side effect caused by #1791.
- It seems that modifying the visual properties of a `StackPanel` inside a `ScrollView` or `ScrollViewer` can cause rendering issues when the window is maximized.
- Wrapping the StackPanel inside a Border or Grid can help stabilize the rendering.

## How Has This Been Tested?  
- Manually tested by maximizing and resizing the window to check for blurriness.  

## Screenshots (if appropriate):  
The difference is subtle and not easily captured in screenshots. The blurriness requires deep observation while maximizing the window to notice it.

## Types of changes  
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
