### PR TITLE
Make Scratch Pad more discoverable

### DIFF
--- a/WinUIGallery/Pages/NavigationRootPage.xaml
+++ b/WinUIGallery/Pages/NavigationRootPage.xaml
@@ -220,11 +220,6 @@
                             AutomationProperties.AutomationId="CustomUserControls"
                             Content="Custom &amp; User Controls"
                             Tag="CustomUserControls" />
-                        <NavigationViewItem
-                            x:Name="ScratchPadPage"
-                            AutomationProperties.AutomationId="ScratchPad"
-                            Content="Scratch Pad"
-                            Tag="ScratchPad" />
                     </NavigationViewItem.MenuItems>
                 </NavigationViewItem>
 
@@ -318,6 +313,17 @@
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
             </NavigationView.MenuItems>
+            <NavigationView.FooterMenuItems>
+                <NavigationViewItem
+                    x:Name="ScratchPadPage"
+                    AutomationProperties.AutomationId="ScratchPad"
+                    Content="Scratch Pad"
+                    Tag="ScratchPad">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xE70F;" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+            </NavigationView.FooterMenuItems>
         </NavigationView>
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="TitleBarStates">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Scratch Pad is a very useful feature allowing for quick XAML testing, but it is currently buried under System and not easily discoverable.

This PR brings it into the `FooterMenuItems` which makes it more prominent.

![image](https://github.com/user-attachments/assets/9522bfec-2dc8-4efa-ae5b-fc2ad8f76f17)


Alternatively it could also be added under the "Accessibility" menu item, not sure which option is preferrable:


![image](https://github.com/user-attachments/assets/762fbc24-f36f-4fc4-9d6a-e1287f1f403b)



## Motivation and Context

- The app provides many XAML code snippets, so users are likely to want to try some variations of those

## How Has This Been Tested?

On local machine

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/76232a4a-fb94-40e1-96d4-ba77a9b6271a)


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
