### PR TITLE
Remove background acrylic brush sample

### DIFF
--- a/WinUIGallery/Samples/ControlPages/AcrylicPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/AcrylicPage.xaml
@@ -39,8 +39,11 @@
         <RichTextBlock>
             <Paragraph>
                 Acrylic Brush might fall back to SolidColorbrush in certain scenarios.
-                If you can't see the Acrylic effect, please refer to <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/style/acrylic#usability-and-adaptability">Acrylic brush adaptability documentation</Hyperlink>
-                .</Paragraph>
+                If you can't see the Acrylic effect, please refer to
+                <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/style/acrylic#usability-and-adaptability">Acrylic brush adaptability documentation</Hyperlink>.
+                Acrylic Brush uses in-app acrylic. See
+                <Hyperlink Click="SystemBackdropLink_Click">SystemBackdrops (Mica/Acrylic)</Hyperlink> for background acrylic.
+            </Paragraph>
         </RichTextBlock>
         <controls:ControlExample x:Name="Example1" HeaderText="Default in-app acrylic brush.">
             <controls:ControlExample.Example>

--- a/WinUIGallery/Samples/ControlPages/AcrylicPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/AcrylicPage.xaml
@@ -77,41 +77,6 @@
                 </x:String>
             </controls:ControlExample.Xaml>
         </controls:ControlExample>
-        <controls:ControlExample x:Name="Example2" HeaderText="Default background acrylic brush.">
-            <controls:ControlExample.Example>
-                <Grid
-                    x:Name="Example2Grid"
-                    Width="320"
-                    Height="200">
-                    <Grid>
-                        <Rectangle
-                            Width="100"
-                            Height="200"
-                            HorizontalAlignment="Left"
-                            VerticalAlignment="Top"
-                            Fill="Aqua" />
-                        <Ellipse
-                            Width="152"
-                            Height="152"
-                            HorizontalAlignment="Center"
-                            VerticalAlignment="Center"
-                            Fill="Magenta" />
-                        <Rectangle
-                            Width="80"
-                            Height="100"
-                            HorizontalAlignment="Right"
-                            VerticalAlignment="Bottom"
-                            Fill="Yellow" />
-                    </Grid>
-                    <Rectangle Margin="12" Fill="{ThemeResource AcrylicBackgroundFillColorDefaultBrush}" />
-                </Grid>
-            </controls:ControlExample.Example>
-            <controls:ControlExample.Xaml>
-                <x:String>
-                    &lt;Rectangle Fill="{ThemeResource AcrylicBackgroundFillColorDefaultBrush}" /&gt;
-                </x:String>
-            </controls:ControlExample.Xaml>
-        </controls:ControlExample>
         <controls:ControlExample x:Name="Example3" HeaderText="Custom acrylic in-app brush.">
             <controls:ControlExample.Example>
                 <Grid

--- a/WinUIGallery/Samples/ControlPages/AcrylicPage.xaml.cs
+++ b/WinUIGallery/Samples/ControlPages/AcrylicPage.xaml.cs
@@ -2,8 +2,10 @@ using System.Linq;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Documents;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Shapes;
+using WinUIGallery.Pages;
 
 namespace WinUIGallery.ControlPages;
 
@@ -48,5 +50,10 @@ public sealed partial class AcrylicPage : Page
     {
         Rectangle shape = CustomAcrylicShapeLumin;
         ((Microsoft.UI.Xaml.Media.AcrylicBrush)shape.Fill).TintLuminosityOpacity = e.NewValue;
+    }
+
+    private void SystemBackdropLink_Click(Hyperlink sender, HyperlinkClickEventArgs args)
+    {
+        NavigationRootPage.GetForElement(this).Navigate(typeof(ItemPage), "SystemBackdrops");
     }
 }

--- a/WinUIGallery/Samples/Data/ControlInfoData.json
+++ b/WinUIGallery/Samples/Data/ControlInfoData.json
@@ -2871,6 +2871,7 @@
           "Subtitle": "A translucent material recommended for panel backgrounds.",
           "ImagePath": "ms-appx:///Assets/ControlImages/Acrylic.png",
           "Description": "A translucent material recommended for panel backgrounds.",
+          "IsUpdated": true,
           "SourcePath": "/Materials/Acrylic",
           "Docs": [
             {


### PR DESCRIPTION
Removed the "Default background acrylic brush" sample from AcrylicPage.xaml.

## Description
1. Removed the sample
2. Added a link to the SystemBackdrop sample in the acrylic brush page to help developers find background acrylic.

## Motivation and Context
The Background acrylic brush defaults to in-app acrylic because background acrylic brushes don't exist in winui 3.

## How Has This Been Tested?
Manual

## Screenshots:
![image](https://github.com/user-attachments/assets/3f2b3b4a-8fb7-4ac9-91c5-724924291ffb)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
