### PR TITLE
Update `RepeatButton` Image Asset Path

### DIFF
--- a/WinUIGallery/Samples/Data/ControlInfoData.json
+++ b/WinUIGallery/Samples/Data/ControlInfoData.json
@@ -1292,7 +1292,7 @@
           ],
           "ApiNamespace": "Microsoft.UI.Xaml.Controls.Primitives",
           "Subtitle": "A button that raises its Click event repeatedly from the time it's pressed until it's released.",
-          "ImagePath": "ms-appx:///Assets/ControlImages/Button.png",
+          "ImagePath": "ms-appx:///Assets/ControlImages/RepeatButton.png",
           "Description": "The RepeatButton control is like a standard Button, except that the Click event occurs continuously while the user presses the RepeatButton.",
           "Content": "<p>A <b>RepeatButton</b> looks just like a regular <b>Button</b>, but it's <b>Click</b> event occurs continuously while the button is pressed.</p><p>Look at the <i>RepeatButtonPage.xaml</i> file in Visual Studio to see the full code for this page.</p>",
           "SourcePath": "/CommonStyles/RepeatButton_themeresources.xaml",


### PR DESCRIPTION
## Description  
Changed the `ImagePath` for the `RepeatButton` control to use the unused asset located at:  
`"ms-appx:///Assets/ControlImages/RepeatButton.png"`  

## Motivation and Context  
The previous image asset path was incorrect (using `Button.png`). This update ensures that the correct image is displayed for the `RepeatButton` control.  

## How Has This Been Tested?  
**Manually Tested**

## Screenshots (if appropriate):  
![image](https://github.com/user-attachments/assets/bda5c2ae-9dbc-40cc-acec-857f5dd26fe9)

## Types of changes  
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  
