### PR TITLE
AppWindow: Add maximize/restore button & showcase new WASDK 1.7 features

### DIFF
--- a/WinUIGallery/Samples/ControlPages/AppWindowPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/AppWindowPage.xaml
@@ -89,12 +89,10 @@
 
                     <TextBlock FontWeight="SemiBold"
                                Text="TitleBar theme" />
-                    <ComboBox x:Name="TitleBarPreferredTheme" SelectedIndex="0" HorizontalAlignment="Stretch">
-                        <x:String>UseDefaultAppMode</x:String>
-                        <x:String>Legacy</x:String>
-                        <x:String>Light</x:String>
-                        <x:String>Dark</x:String>
-                    </ComboBox>
+                    <ComboBox x:Name="TitleBarPreferredTheme"
+                              ItemsSource="{x:Bind TitleBarThemes}"
+                              SelectedItem="{x:Bind SelectedTheme, Mode=TwoWay}"
+                              HorizontalAlignment="Stretch" />
                 </StackPanel>
             </controls:ControlExample.Options>
 

--- a/WinUIGallery/Samples/ControlPages/AppWindowPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/AppWindowPage.xaml
@@ -317,6 +317,8 @@ public sealed partial class SampleWindow3 : Window
         presenter.SetBorderAndTitleBar($(HasBorder),$(HasTitleBar));
 
         appWindow.SetPresenter(presenter);
+                    
+        SizeChanged += SampleWindow3_SizeChanged;
     }
 
     private AppWindow GetAppWindowForCurrentWindow()
@@ -326,9 +328,21 @@ public sealed partial class SampleWindow3 : Window
         return AppWindow.GetFromWindowId(myWndId);
     }
 
-    private void MaximizeBtn_Click(object sender, RoutedEventArgs e)
+    private void MaximizeRestoreBtn_Click(object sender, RoutedEventArgs e)
     {
-        presenter.Maximize();
+        if (presenter.State == OverlappedPresenterState.Maximized)
+        {
+            presenter.Restore();
+        }
+        else
+        {
+            presenter.Maximize();
+        }
+    }
+
+    private void SampleWindow3_SizeChanged(object sender, WindowSizeChangedEventArgs e)
+    {
+        MaximizeRestoreBtn.Content = presenter.State == OverlappedPresenterState.Maximized ? "Restore" : "Maximize";
     }
 
     private void MinimizeBtn_Click(object sender, RoutedEventArgs e)
@@ -338,7 +352,8 @@ public sealed partial class SampleWindow3 : Window
 
     private void RestoreBtn_Click(object sender, RoutedEventArgs e)
     {
-        presenter.Restore();
+        presenter.Minimize();
+        Task.Delay(3000).ContinueWith(t => presenter.Restore());
     }
 
     private void CloseBtn_Click(object sender, RoutedEventArgs e)
@@ -425,11 +440,6 @@ public sealed partial class SampleWindow4 : Window
         IntPtr hWnd = WindowNative.GetWindowHandle(this);
         WindowId myWndId = Win32Interop.GetWindowIdFromWindow(hWnd);
         return AppWindow.GetFromWindowId(myWndId);
-    }
-
-    private void MaximizeBtn_Click(object sender, RoutedEventArgs e)
-    {
-        presenter.Maximize();
     }
 
     private void MinimizeBtn_Click(object sender, RoutedEventArgs e)

--- a/WinUIGallery/Samples/ControlPages/AppWindowPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/AppWindowPage.xaml
@@ -86,6 +86,15 @@
                             SpinButtonPlacementMode="Inline"
                             Value="50" />
                     </Grid>
+
+                    <TextBlock FontWeight="SemiBold"
+                               Text="TitleBar theme" />
+                    <ComboBox x:Name="TitleBarPreferredTheme" SelectedIndex="0" HorizontalAlignment="Stretch">
+                        <x:String>UseDefaultAppMode</x:String>
+                        <x:String>Legacy</x:String>
+                        <x:String>Light</x:String>
+                        <x:String>Dark</x:String>
+                    </ComboBox>
                 </StackPanel>
             </controls:ControlExample.Options>
 
@@ -118,9 +127,18 @@ public sealed partial class SampleWindow1 : Window
 
         // Set the window position on screen
         appWindow.Move(new Windows.Graphics.PointInt32($(X), $(Y)));
+        
+        // Set the preferred theme for the title bar
+        appWindow.TitleBar.PreferredTheme = TitleBarTheme.$(TitleBarPreferredTheme);
+        
+        // Set the taskbar icon (displayed in the taskbar)
+        appWindow.SetTaskbarIcon("Assets/Tiles/GalleryIcon.ico");
 
-        // Set the window icon
-        appWindow.SetIcon("Assets/Tiles/GalleryIcon.ico");
+        // Set the title bar icon (displayed in the window's title bar)
+        appWindow.SetTitleBarIcon("Assets/Tiles/GalleryIcon.ico");
+
+        // Set the window icon (affects both taskbar and title bar, can be omitted if the above two are set)
+        // appWindow.SetIcon("Assets/Tiles/GalleryIcon.ico"); 
     }
 
     //Returrns the AppWindow instance associated with the current window.
@@ -161,6 +179,7 @@ public sealed partial class SampleWindow1 : Window
                 <controls:ControlExampleSubstitution Key="Height" Value="{x:Bind WindowHeight.Value, Mode=OneWay}" />
                 <controls:ControlExampleSubstitution Key="X" Value="{x:Bind XPoint.Value, Mode=OneWay}" />
                 <controls:ControlExampleSubstitution Key="Y" Value="{x:Bind YPoint.Value, Mode=OneWay}" />
+                <controls:ControlExampleSubstitution Key="TitleBarPreferredTheme" Value="{x:Bind TitleBarPreferredTheme.SelectedItem, Mode=OneWay}" />
             </controls:ControlExample.Substitutions>
         </controls:ControlExample>
 
@@ -290,6 +309,7 @@ public sealed partial class SampleWindow3 : Window
 
         appWindow = GetAppWindowForCurrentWindow();
         appWindow.SetIcon("Assets/Tiles/GalleryIcon.ico");
+        appWindow.TitleBar.PreferredTheme = TitleBarTheme.UseDefaultAppMode;
 
         presenter = OverlappedPresenter.Create();
         presenter.IsAlwaysOnTop = $(IsAlwaysOnTop);
@@ -389,6 +409,7 @@ public sealed partial class SampleWindow4 : Window
 
         appWindow = GetAppWindowForCurrentWindow();
         appWindow.SetIcon("Assets/Tiles/GalleryIcon.ico");
+        appWindow.TitleBar.PreferredTheme = TitleBarTheme.UseDefaultAppMode;
 
         appWindow.Resize(new Windows.Graphics.SizeInt32(800, 500));
         presenter = OverlappedPresenter.Create();
@@ -510,6 +531,7 @@ public sealed partial class SampleWindow7 : Window
 
         appWindow = GetAppWindowForCurrentWindow();
         appWindow.SetIcon("Assets/Tiles/GalleryIcon.ico");
+        appWindow.TitleBar.PreferredTheme = TitleBarTheme.UseDefaultAppMode;
 
         // Creates a CompactOverlay (Picture-in-Picture) presenter
         presenter = CompactOverlayPresenter.Create();

--- a/WinUIGallery/Samples/ControlPages/AppWindowPage.xaml.cs
+++ b/WinUIGallery/Samples/ControlPages/AppWindowPage.xaml.cs
@@ -1,24 +1,19 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Navigation;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
+
 using WinUIGallery.Samples.SamplePages;
 
 namespace WinUIGallery.ControlPages;
 
 public sealed partial class AppWindowPage : Page
 {
+    private IReadOnlyList<TitleBarTheme> TitleBarThemes = Enum.GetValues(typeof(TitleBarTheme)).Cast<TitleBarTheme>().ToList();
+    private TitleBarTheme SelectedTheme = TitleBarTheme.UseDefaultAppMode;
+
     public AppWindowPage()
     {
         this.InitializeComponent();
@@ -26,7 +21,7 @@ public sealed partial class AppWindowPage : Page
 
     private void ShowSampleWindow1(object sender, RoutedEventArgs e)
     {
-        SampleWindow1 window = new SampleWindow1(WindowTitle.Text, (Int32)WindowWidth.Value, (Int32)WindowHeight.Value, (Int32)XPoint.Value, (Int32)YPoint.Value, (string)TitleBarPreferredTheme.SelectedItem);
+        SampleWindow1 window = new SampleWindow1(WindowTitle.Text, (Int32)WindowWidth.Value, (Int32)WindowHeight.Value, (Int32)XPoint.Value, (Int32)YPoint.Value, SelectedTheme);
         window.Activate();
     }
 

--- a/WinUIGallery/Samples/ControlPages/AppWindowPage.xaml.cs
+++ b/WinUIGallery/Samples/ControlPages/AppWindowPage.xaml.cs
@@ -26,7 +26,7 @@ public sealed partial class AppWindowPage : Page
 
     private void ShowSampleWindow1(object sender, RoutedEventArgs e)
     {
-        SampleWindow1 window = new SampleWindow1(WindowTitle.Text, (Int32)WindowWidth.Value, (Int32)WindowHeight.Value, (Int32)XPoint.Value, (Int32)YPoint.Value);
+        SampleWindow1 window = new SampleWindow1(WindowTitle.Text, (Int32)WindowWidth.Value, (Int32)WindowHeight.Value, (Int32)XPoint.Value, (Int32)YPoint.Value, (string)TitleBarPreferredTheme.SelectedItem);
         window.Activate();
     }
 

--- a/WinUIGallery/Samples/SampleCode/AppWindow/AppWindowSample2_cs.txt
+++ b/WinUIGallery/Samples/SampleCode/AppWindow/AppWindowSample2_cs.txt
@@ -16,6 +16,7 @@ public sealed partial class SampleWindow2 : Window
         this.InitializeComponent();
         appWindow = GetAppWindowForCurrentWindow();
         appWindow.SetIcon("Assets/Tiles/GalleryIcon.ico");
+        appWindow.TitleBar.PreferredTheme = TitleBarTheme.UseDefaultAppMode;
 
         // Center the window on the screen.
         CenterWindow(appWindow);

--- a/WinUIGallery/Samples/SampleCode/AppWindow/AppWindowSample5_cs.txt
+++ b/WinUIGallery/Samples/SampleCode/AppWindow/AppWindowSample5_cs.txt
@@ -15,8 +15,11 @@ public sealed partial class ModalWindow : Window
     {
         this.InitializeComponent();
         appWindow = GetAppWindowForCurrentWindow();
+        appWindow.SetIcon("Assets/Tiles/GalleryIcon.ico");
+        appWindow.TitleBar.PreferredTheme = TitleBarTheme.UseDefaultAppMode;
         appWindow.Resize(new Windows.Graphics.SizeInt32(400,300));
 
+        // Create an OverlappedPresenter configured for a dialog window.
         OverlappedPresenter presenter = OverlappedPresenter.CreateForDialog();
 
         // Set this modal window's owner (the main application window).

--- a/WinUIGallery/Samples/SampleCode/AppWindow/AppWindowSample6_cs.txt
+++ b/WinUIGallery/Samples/SampleCode/AppWindow/AppWindowSample6_cs.txt
@@ -15,6 +15,7 @@ public sealed partial class SampleWindow6 : Window
         this.InitializeComponent();
         appWindow = GetAppWindowForCurrentWindow();
         appWindow.SetIcon("Assets/Tiles/GalleryIcon.ico");
+        appWindow.TitleBar.PreferredTheme = TitleBarTheme.UseDefaultAppMode;
 
         // Set the window to Full-Screen mode
         appWindow.SetPresenter(AppWindowPresenterKind.FullScreen);

--- a/WinUIGallery/Samples/SamplePages/ModalWindow.xaml.cs
+++ b/WinUIGallery/Samples/SamplePages/ModalWindow.xaml.cs
@@ -17,6 +17,7 @@ public sealed partial class ModalWindow : Window
         appWindow = GetAppWindowForCurrentWindow();
         appWindow.Resize(new Windows.Graphics.SizeInt32(400,300));
         appWindow.SetIcon("Assets/Tiles/GalleryIcon.ico");
+        appWindow.TitleBar.PreferredTheme = TitleBarTheme.UseDefaultAppMode;
 
         OverlappedPresenter presenter = OverlappedPresenter.CreateForDialog();
 

--- a/WinUIGallery/Samples/SamplePages/SampleWindow1.xaml.cs
+++ b/WinUIGallery/Samples/SamplePages/SampleWindow1.xaml.cs
@@ -16,7 +16,7 @@ public sealed partial class SampleWindow1 : Window
         this.InitializeComponent();
     }
 
-    public SampleWindow1(string WindowTitle, Int32 Width, Int32 Height, Int32 X, Int32 Y)
+    public SampleWindow1(string WindowTitle, Int32 Width, Int32 Height, Int32 X, Int32 Y, string TitleBarPreferredTheme)
     {
         this.InitializeComponent();
 
@@ -32,8 +32,24 @@ public sealed partial class SampleWindow1 : Window
         // Set the window position on screen
         appWindow.Move(new Windows.Graphics.PointInt32(X, Y));
 
-        // Set the window icon
-        appWindow.SetIcon("Assets/Tiles/GalleryIcon.ico");
+        // Set the preferred theme for the title bar
+        appWindow.TitleBar.PreferredTheme = TitleBarPreferredTheme switch
+        {
+            "UseDefaultAppMode" => TitleBarTheme.UseDefaultAppMode,
+            "Legacy" => TitleBarTheme.Legacy,
+            "Light" => TitleBarTheme.Light,
+            "Dark" => TitleBarTheme.Dark,
+            _ => appWindow.TitleBar.PreferredTheme
+        };
+
+        // Set the taskbar icon (displayed in the taskbar)
+        appWindow.SetTaskbarIcon("Assets/Tiles/GalleryIcon.ico");
+
+        // Set the title bar icon (displayed in the window's title bar)
+        appWindow.SetTitleBarIcon("Assets/Tiles/GalleryIcon.ico");
+
+        // Set the window icon (affects both taskbar and title bar, can be omitted if the above two are set)
+        // appWindow.SetIcon("Assets/Tiles/GalleryIcon.ico"); 
     }
 
     //Returrns the AppWindow instance associated with the current window.

--- a/WinUIGallery/Samples/SamplePages/SampleWindow1.xaml.cs
+++ b/WinUIGallery/Samples/SamplePages/SampleWindow1.xaml.cs
@@ -4,6 +4,7 @@ using Microsoft.UI;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using WinRT.Interop;
+using WinUIGallery.Helpers;
 
 namespace WinUIGallery.Samples.SamplePages;
 
@@ -16,7 +17,7 @@ public sealed partial class SampleWindow1 : Window
         this.InitializeComponent();
     }
 
-    public SampleWindow1(string WindowTitle, Int32 Width, Int32 Height, Int32 X, Int32 Y, string TitleBarPreferredTheme)
+    public SampleWindow1(string WindowTitle, Int32 Width, Int32 Height, Int32 X, Int32 Y, TitleBarTheme TitleBarPreferredTheme)
     {
         this.InitializeComponent();
 
@@ -33,14 +34,7 @@ public sealed partial class SampleWindow1 : Window
         appWindow.Move(new Windows.Graphics.PointInt32(X, Y));
 
         // Set the preferred theme for the title bar
-        appWindow.TitleBar.PreferredTheme = TitleBarPreferredTheme switch
-        {
-            "UseDefaultAppMode" => TitleBarTheme.UseDefaultAppMode,
-            "Legacy" => TitleBarTheme.Legacy,
-            "Light" => TitleBarTheme.Light,
-            "Dark" => TitleBarTheme.Dark,
-            _ => appWindow.TitleBar.PreferredTheme
-        };
+        appWindow.TitleBar.PreferredTheme = TitleBarPreferredTheme;
 
         // Set the taskbar icon (displayed in the taskbar)
         appWindow.SetTaskbarIcon("Assets/Tiles/GalleryIcon.ico");

--- a/WinUIGallery/Samples/SamplePages/SampleWindow2.xaml.cs
+++ b/WinUIGallery/Samples/SamplePages/SampleWindow2.xaml.cs
@@ -16,6 +16,7 @@ public sealed partial class SampleWindow2 : Window
         this.InitializeComponent();
         appWindow = GetAppWindowForCurrentWindow();
         appWindow.SetIcon("Assets/Tiles/GalleryIcon.ico");
+        appWindow.TitleBar.PreferredTheme = TitleBarTheme.UseDefaultAppMode;
 
         // Center the window on the screen.
         CenterWindow(appWindow);

--- a/WinUIGallery/Samples/SamplePages/SampleWindow3.xaml
+++ b/WinUIGallery/Samples/SamplePages/SampleWindow3.xaml
@@ -15,19 +15,14 @@
     <StackPanel HorizontalAlignment="Center"
                 VerticalAlignment="Center"
                 Spacing="10">
-        <Button x:Name="MaximizeBtn"
-                Content="Maximize"
-                Click="MaximizeBtn_Click"
-                Width="200" />
+        <Button x:Name="MaximizeRestoreBtn"
+                Click="MaximizeRestoreBtn_Click"
+                Width="200"
+                Content="Maximize" />
         <Button x:Name="MinimizeBtn"
                 Content="Minimize"
                 Click="MinimizeBtn_Click"
                 Width="200" />
-        <Button x:Name="MaximizeRestoreBtn"
-                Click="MaximizeRestoreBtn_Click"
-                Width="200">
-            <TextBlock Text="Maximize and restore the window after 3 seconds" TextWrapping="WrapWholeWords" TextAlignment="Center" />
-        </Button>
         <Button x:Name="RestoreBtn"
                 Click="RestoreBtn_Click"
                 Width="200" >

--- a/WinUIGallery/Samples/SamplePages/SampleWindow3.xaml
+++ b/WinUIGallery/Samples/SamplePages/SampleWindow3.xaml
@@ -23,6 +23,11 @@
                 Content="Minimize"
                 Click="MinimizeBtn_Click"
                 Width="200" />
+        <Button x:Name="MaximizeRestoreBtn"
+                Click="MaximizeRestoreBtn_Click"
+                Width="200">
+            <TextBlock Text="Maximize and restore the window after 3 seconds" TextWrapping="WrapWholeWords" TextAlignment="Center" />
+        </Button>
         <Button x:Name="RestoreBtn"
                 Click="RestoreBtn_Click"
                 Width="200" >

--- a/WinUIGallery/Samples/SamplePages/SampleWindow3.xaml.cs
+++ b/WinUIGallery/Samples/SamplePages/SampleWindow3.xaml.cs
@@ -11,6 +11,7 @@ public sealed partial class SampleWindow3 : Window
 {
     private AppWindow appWindow;
     private OverlappedPresenter presenter;
+    private bool IsMaximized = false;
 
     public SampleWindow3(bool IsAlwaysOnTop, bool IsMaximizable, bool IsMinimizable, bool IsResizable, bool HasBorder, bool HasTitleBar)
     {
@@ -25,6 +26,8 @@ public sealed partial class SampleWindow3 : Window
         appWindow.SetPresenter(presenter);
         appWindow.SetIcon("Assets/Tiles/GalleryIcon.ico");
         appWindow.TitleBar.PreferredTheme = TitleBarTheme.UseDefaultAppMode;
+
+        SizeChanged += SampleWindow3_SizeChanged;
     }
 
     private AppWindow GetAppWindowForCurrentWindow()
@@ -34,20 +37,26 @@ public sealed partial class SampleWindow3 : Window
         return AppWindow.GetFromWindowId(myWndId);
     }
 
-    private void MaximizeBtn_Click(object sender, RoutedEventArgs e)
+    private void MaximizeRestoreBtn_Click(object sender, RoutedEventArgs e)
     {
-        presenter.Maximize();
+        if (presenter.State == OverlappedPresenterState.Maximized)
+        {
+            presenter.Restore();
+        }
+        else
+        {
+            presenter.Maximize();
+        }
+    }
+
+    private void SampleWindow3_SizeChanged(object sender, WindowSizeChangedEventArgs e)
+    {
+        MaximizeRestoreBtn.Content = presenter.State == OverlappedPresenterState.Maximized ? "Restore" : "Maximize";
     }
 
     private void MinimizeBtn_Click(object sender, RoutedEventArgs e)
     {
         presenter.Minimize();
-    }
-
-    private void MaximizeRestoreBtn_Click(object sender, RoutedEventArgs e)
-    {
-        presenter.Maximize();
-        Task.Delay(3000).ContinueWith(t => presenter.Restore());
     }
 
     private void RestoreBtn_Click(object sender, RoutedEventArgs e)

--- a/WinUIGallery/Samples/SamplePages/SampleWindow3.xaml.cs
+++ b/WinUIGallery/Samples/SamplePages/SampleWindow3.xaml.cs
@@ -24,6 +24,7 @@ public sealed partial class SampleWindow3 : Window
         presenter.SetBorderAndTitleBar(HasBorder,HasTitleBar);
         appWindow.SetPresenter(presenter);
         appWindow.SetIcon("Assets/Tiles/GalleryIcon.ico");
+        appWindow.TitleBar.PreferredTheme = TitleBarTheme.UseDefaultAppMode;
     }
 
     private AppWindow GetAppWindowForCurrentWindow()
@@ -41,6 +42,12 @@ public sealed partial class SampleWindow3 : Window
     private void MinimizeBtn_Click(object sender, RoutedEventArgs e)
     {
         presenter.Minimize();
+    }
+
+    private void MaximizeRestoreBtn_Click(object sender, RoutedEventArgs e)
+    {
+        presenter.Maximize();
+        Task.Delay(3000).ContinueWith(t => presenter.Restore());
     }
 
     private void RestoreBtn_Click(object sender, RoutedEventArgs e)

--- a/WinUIGallery/Samples/SamplePages/SampleWindow3.xaml.cs
+++ b/WinUIGallery/Samples/SamplePages/SampleWindow3.xaml.cs
@@ -11,7 +11,6 @@ public sealed partial class SampleWindow3 : Window
 {
     private AppWindow appWindow;
     private OverlappedPresenter presenter;
-    private bool IsMaximized = false;
 
     public SampleWindow3(bool IsAlwaysOnTop, bool IsMaximizable, bool IsMinimizable, bool IsResizable, bool HasBorder, bool HasTitleBar)
     {

--- a/WinUIGallery/Samples/SamplePages/SampleWindow4.xaml.cs
+++ b/WinUIGallery/Samples/SamplePages/SampleWindow4.xaml.cs
@@ -26,6 +26,7 @@ public sealed partial class SampleWindow4 : Window
         presenter.IsMaximizable = false;
         appWindow.SetPresenter(presenter);
         appWindow.SetIcon("Assets/Tiles/GalleryIcon.ico");
+        appWindow.TitleBar.PreferredTheme = TitleBarTheme.UseDefaultAppMode;
     }
 
     private AppWindow GetAppWindowForCurrentWindow()

--- a/WinUIGallery/Samples/SamplePages/SampleWindow6.xaml.cs
+++ b/WinUIGallery/Samples/SamplePages/SampleWindow6.xaml.cs
@@ -15,6 +15,7 @@ public sealed partial class SampleWindow6 : Window
         this.InitializeComponent();
         appWindow = GetAppWindowForCurrentWindow();
         appWindow.SetIcon("Assets/Tiles/GalleryIcon.ico");
+        appWindow.TitleBar.PreferredTheme = TitleBarTheme.UseDefaultAppMode;
 
         // Set the window to Full-Screen mode
         appWindow.SetPresenter(AppWindowPresenterKind.FullScreen);

--- a/WinUIGallery/Samples/SamplePages/SampleWindow7.xaml.cs
+++ b/WinUIGallery/Samples/SamplePages/SampleWindow7.xaml.cs
@@ -17,6 +17,7 @@ public sealed partial class SampleWindow7 : Window
 
         appWindow = GetAppWindowForCurrentWindow();
         appWindow.SetIcon("Assets/Tiles/GalleryIcon.ico");
+        appWindow.TitleBar.PreferredTheme = TitleBarTheme.UseDefaultAppMode;
 
         presenter = CompactOverlayPresenter.Create();
         presenter.InitialSize = InitialSize switch


### PR DESCRIPTION
## Description
- Added a maximize then restore button.
- Showcased the `TitleBar.PreferredTheme` feature and set it to `UseDefaultAppMode` across all sample windows.
- Demonstrated the `SetTaskBarIcon` and `SetTitleBarIcon` methods.
- Updated the sample code to reflect these enhancements and added explanatory comments for better understanding.

## Motivation and Context
- This change introduces new features from WinAppSDK 1.7.
- Related to this https://github.com/microsoft/WinUI-Gallery/pull/1824#issuecomment-2772781823.

## How Has This Been Tested?
**Manually tested**

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
