### PR TITLE
add warning to AnimatedIcon page

### DIFF
--- a/WinUIGallery/Samples/ControlPages/AnimatedIconPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/AnimatedIconPage.xaml
@@ -22,7 +22,10 @@
                             Lottie-Windows
                         </Hyperlink>
                         .
-                        For guidance on how to properly structure your animation file see the AnimatedIcon Guidance page.<LineBreak />
+                        For guidance on how to properly structure your animation file see the AnimatedIcon Guidance page.
+                        Warning: <Hyperlink NavigateUri="https://github.com/microsoft/microsoft-ui-xaml/issues/10243">
+                            AnimatedChevronRightDownSmallVisualSource and AnimatedChevronUpDownSmallVisualSource don't work properly
+                        </Hyperlink>.<LineBreak />
                     </TextBlock>
                     <Button
                         Width="75"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add the warning to the AnimatedIcon page until https://github.com/microsoft/microsoft-ui-xaml/issues/10243 is resolved.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
AnimatedChevronRightDownSmallVisualSource and AnimatedChevronUpDownSmallVisualSource don't work properly (https://github.com/microsoft/microsoft-ui-xaml/issues/10243). Add the warning to the AnimatedIcon page until https://github.com/microsoft/microsoft-ui-xaml/issues/10243 is resolved.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The WinUI-Gallery was built and run.
![s](https://github.com/user-attachments/assets/f9bd94ed-29e2-4e49-9779-864449d6b4d4)

## Screenshots (if appropriate):
![s](https://github.com/user-attachments/assets/f9bd94ed-29e2-4e49-9779-864449d6b4d4)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other