### PR TITLE
Update `VersionHelper` for improved SDK version handling

### DIFF
--- a/WinUIGallery/Helpers/VersionHelper.cs
+++ b/WinUIGallery/Helpers/VersionHelper.cs
@@ -3,9 +3,8 @@ using Microsoft.Windows.ApplicationModel.WindowsAppRuntime;
 namespace WinUIGallery.Helpers;
 internal static class VersionHelper
 {
-    public static string WinAppSdkDetails =>
-        $"Windows App SDK {ReleaseInfo.AsString}" +
-        (string.IsNullOrEmpty(ReleaseInfo.VersionTag) ? "" : $" ({ReleaseInfo.VersionTag})");
+    public static string WinAppSdkDetails => 
+        $"Windows App SDK {ReleaseInfo.AsString}";
 
     public static string WinAppSdkRuntimeDetails => 
         WinAppSdkDetails + $", Windows App Runtime {RuntimeInfo.AsString}";  

--- a/WinUIGallery/Helpers/VersionHelper.cs
+++ b/WinUIGallery/Helpers/VersionHelper.cs
@@ -4,7 +4,7 @@ namespace WinUIGallery.Helpers;
 internal static class VersionHelper
 {
     public static string WinAppSdkDetails => 
-        $"Windows App SDK {ReleaseInfo.AsString}";
+        $"Windows App SDK {ReleaseInfo.Major}.{ReleaseInfo.Minor}";
 
     public static string WinAppSdkRuntimeDetails => 
         WinAppSdkDetails + $", Windows App Runtime {RuntimeInfo.AsString}";  

--- a/WinUIGallery/Helpers/VersionHelper.cs
+++ b/WinUIGallery/Helpers/VersionHelper.cs
@@ -1,35 +1,12 @@
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using WASDK = Microsoft.WindowsAppSDK;
+using Microsoft.Windows.ApplicationModel.WindowsAppRuntime;
 
 namespace WinUIGallery.Helpers;
 internal static class VersionHelper
 {
-    public static string WinAppSdkDetails
-    {
-        // TODO: restore patch number and version tag when WinAppSDK supports them both
-        get => string.Format("Windows App SDK {0}.{1}",
-            WASDK.Release.Major, WASDK.Release.Minor);
-    }
+    public static string WinAppSdkDetails =>
+        $"Windows App SDK {ReleaseInfo.AsString}" +
+        (string.IsNullOrEmpty(ReleaseInfo.VersionTag) ? "" : $" ({ReleaseInfo.VersionTag})");
 
-    public static string WinAppSdkRuntimeDetails
-    {
-        get
-        {
-            try
-            {
-                // Retrieve Windows App Runtime version info dynamically
-                IEnumerable<FileVersionInfo> windowsAppRuntimeVersion =
-                    from module in Process.GetCurrentProcess().Modules.OfType<ProcessModule>()
-                    where module.FileName.EndsWith("Microsoft.WindowsAppRuntime.Insights.Resource.dll")
-                    select FileVersionInfo.GetVersionInfo(module.FileName);
-                return WinAppSdkDetails + ", Windows App Runtime " + windowsAppRuntimeVersion.First().FileVersion;
-            }
-            catch
-            {
-                return WinAppSdkDetails + $", Windows App Runtime {WASDK.Runtime.Version.Major}.{WASDK.Runtime.Version.Minor}";
-            }
-        }
-    }
+    public static string WinAppSdkRuntimeDetails => 
+        WinAppSdkDetails + $", Windows App Runtime {RuntimeInfo.AsString}";  
 }


### PR DESCRIPTION
## Description
This PR simplifies SDK versioning by using `ReleaseInfo` and `RuntimeInfo` (new APIs introduced in WinAppSDK 1.7), main changes are:
- Updated `WinAppSdkDetails` to use `ReleaseInfo.AsString`.
- Simplified `WinAppSdkRuntimeDetails` to directly use `RuntimeInfo.AsString`, removing the previous dynamic retrieval logic.

## Motivation and Context
Providing both cleaner code and more complete version details.

## How Has This Been Tested?
Manually tested

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
