### PR TITLE
add border to icon

### DIFF
--- a/WinUIGallery/Samples/ControlPages/Design/IconographyPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/Design/IconographyPage.xaml
@@ -109,7 +109,8 @@
                             How to get the font
                         </Paragraph>
                         <Paragraph>
-                            Segoe Fluent Icons comes preinstalled on Windows 11. On Windows 10, it requires a manual installation. You can download it <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/downloads/#fonts">here</Hyperlink>.</Paragraph>
+                            Segoe Fluent Icons comes preinstalled on Windows 11. On Windows 10, it requires a manual installation. You can download it <Hyperlink NavigateUri="https://learn.microsoft.com/windows/apps/design/downloads/#fonts">here</Hyperlink>.
+                        </Paragraph>
                     </RichTextBlock>
                 </toolkit:SettingsCard>
                 <toolkit:SettingsCard
@@ -186,55 +187,58 @@
                     Grid.Column="1"
                     Padding="16,16,8,16"
                     Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
                     BorderThickness="1,0,0,0"
                     DataContext="{x:Bind}"
                     Visibility="Collapsed">
                     <StackPanel Spacing="2">
-                        <FontIcon
+                        <Border
                             Margin="0,0,0,24"
                             HorizontalAlignment="Left"
-                            VerticalAlignment="Center"
-                            FontFamily="{StaticResource SymbolThemeFontFamily}"
-                            FontSize="48"
-                            Glyph="{Binding SelectedItem.Character, Mode=OneWay}" />
+                            BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
+                            BorderThickness="1">
+                            <FontIcon
+                                FontFamily="{StaticResource SymbolThemeFontFamily}"
+                                FontSize="48"
+                                Glyph="{Binding SelectedItem.Character, Mode=OneWay}" />
+                        </Border>
                         <TextBlock
-                            FontSize="12"
+                            Style="{StaticResource CaptionTextBlockStyle}"
                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                             Text="Icon name" />
                         <controls:SampleCodePresenter Code="{Binding SelectedItem.Name, Mode=OneWay}" Style="{StaticResource CodeValuePresenterStyle}" />
                         <TextBlock
-                            FontSize="12"
+                            Style="{StaticResource CaptionTextBlockStyle}"
                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                             Text="Text glyph" />
                         <controls:SampleCodePresenter Code="{Binding SelectedItem.TextGlyph, Mode=OneWay}" Style="{StaticResource CodeValuePresenterStyle}" />
                         <TextBlock
-                            FontSize="12"
+                            Style="{StaticResource CaptionTextBlockStyle}"
                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                             Text="Code glyph" />
                         <controls:SampleCodePresenter Code="{Binding SelectedItem.CodeGlyph, Mode=OneWay}" Style="{StaticResource CodeValuePresenterStyle}" />
                         <TextBlock
-                            FontSize="12"
+                            Style="{StaticResource CaptionTextBlockStyle}"
                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                             Text="XAML" />
                         <controls:SampleCodePresenter x:Name="XAMLCodePresenter" Style="{StaticResource CodeValuePresenterStyle}" />
                         <TextBlock
-                            FontSize="12"
+                            Style="{StaticResource CaptionTextBlockStyle}"
                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                             Text="C#" />
                         <controls:SampleCodePresenter x:Name="CSharpCodePresenter" Style="{StaticResource CodeValuePresenterStyle}" />
                         <TextBlock
                             Margin="0,4,0,0"
-                            FontSize="12"
+                            Style="{StaticResource CaptionTextBlockStyle}"
                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                             Text="Tags" />
                         <ItemsView
                             x:Name="TagsItemsView"
                             Margin="0,8,0,4"
-                            x:Load="{x:Bind SelectedItem.Tags, Mode=OneWay, Converter={StaticResource emptyCollectionToFalseConverter}}"
+                            x:Load="{x:Bind SelectedItem.Tags, Converter={StaticResource emptyCollectionToFalseConverter}}"
                             IsItemInvokedEnabled="True"
                             ItemInvoked="TagsItemsView_ItemInvoked"
-                            ItemsSource="{x:Bind SelectedItem.Tags, Mode=OneWay}"
+                            ItemsSource="{x:Bind SelectedItem.Tags}"
                             SelectionMode="None">
                             <ItemsView.Layout>
                                 <toolkit:WrapLayout HorizontalSpacing="4" VerticalSpacing="4" />
@@ -246,15 +250,15 @@
                                         AutomationProperties.Name="{x:Bind}"
                                         CornerRadius="12">
                                         <Grid
-                                            Padding="8,3,8,4"
+                                            Padding="8,0"
+                                            Height="24"
                                             Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                                             BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                                             BorderThickness="1"
                                             CornerRadius="12">
                                             <TextBlock
-                                                Grid.Column="1"
                                                 VerticalAlignment="Center"
-                                                FontSize="12"
+                                                Style="{StaticResource CaptionTextBlockStyle}"
                                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                                 Text="{x:Bind}"
                                                 TextTrimming="CharacterEllipsis" />

--- a/WinUIGallery/Samples/ControlPages/Design/IconographyPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/Design/IconographyPage.xaml
@@ -195,6 +195,7 @@
                         <Border
                             Margin="0,0,0,24"
                             HorizontalAlignment="Left"
+                            Background="{ThemeResource ControlFillColorDefaultBrush}"
                             BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
                             BorderThickness="1">
                             <FontIcon


### PR DESCRIPTION
## Description

Adds a border and background to the larger icon in the SidePanel. This shows how any "overlay icons" are placed inside the available area.

Closes #1854

## Motivation and Context

Clarity. May help finding the right icon.

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/05f00033-c819-4eee-abcd-b481b21242b7) ![image](https://github.com/user-attachments/assets/cfe64ed7-7c1f-474a-aecf-be4b2af5de0c)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
