### PR TITLE
Fix ControlExamples not stretching properly on multiple pages

### DIFF
--- a/WinUIGallery/Samples/ControlPages/FlipViewPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/FlipViewPage.xaml
@@ -16,7 +16,7 @@
     xmlns:controls="using:WinUIGallery.Controls"
     xmlns:models="using:WinUIGallery.Models"
     xmlns:pages="using:WinUIGallery.Pages">
-    <StackPanel HorizontalAlignment="Left">
+    <StackPanel>
         <controls:ControlExample
             x:Name="Example1"
             ExampleHeight="Auto"

--- a/WinUIGallery/Samples/ControlPages/FlyoutPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/FlyoutPage.xaml
@@ -24,7 +24,7 @@
             </StackPanel>
         </Flyout>
     </Page.Resources>
-    <StackPanel HorizontalAlignment="Left">
+    <StackPanel>
         <controls:ControlExample HeaderText="A button with a flyout">
             <controls:ControlExample.Example>
                 <Button x:Name="Control1" Content="Empty cart">

--- a/WinUIGallery/Samples/ControlPages/NumberBoxPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/NumberBoxPage.xaml
@@ -18,7 +18,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <StackPanel HorizontalAlignment="Left">
+    <StackPanel>
         <controls:ControlExample HeaderText="A NumberBox that evaluates expressions." XamlSource="NumberBox/NumberBoxSample1_xaml.txt">
             <controls:ControlExample.Example>
                 <NumberBox

--- a/WinUIGallery/Samples/ControlPages/RelativePanelPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/RelativePanelPage.xaml
@@ -19,7 +19,6 @@
     mc:Ignorable="d">
 
     <controls:ControlExample
-        HorizontalAlignment="Left"
         VerticalAlignment="Top"
         ExampleHeight="Auto"
         HeaderText="A RelativePanel control.">

--- a/WinUIGallery/Samples/ControlPages/TeachingTipPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/TeachingTipPage.xaml
@@ -17,7 +17,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
-    <StackPanel HorizontalAlignment="Left">
+    <StackPanel>
         <controls:ControlExample
             CSharpSource="TeachingTip/TeachingTipSample1_cs.txt"
             HeaderText="Show a targeted TeachingTip on a button."


### PR DESCRIPTION
## Description  
Adjusted the layout of `ControlExamples` on `FlipViewPage`, `FlyoutPage`, `TeachingTipPage`, `RelativePanelPage`, and `NumberBoxPage` to ensure proper stretching and alignment with the design of other pages.

## Motivation and Context  
- Fixes #1855

## How Has This Been Tested?  
Manually tested.

## Screenshots:  
![image](https://github.com/user-attachments/assets/d63443ec-4688-44fd-9e17-c30ff3266dc8)

## Types of changes  
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)