### PR TITLE
Remove the GetAppWindow method from the WindowHelper class

### DIFF
--- a/WinUIGallery/Helpers/WindowHelper.cs
+++ b/WinUIGallery/Helpers/WindowHelper.cs
@@ -45,13 +45,6 @@ public class WindowHelper
         _activeWindows.Add(window);
     }
 
-    static public AppWindow GetAppWindow(Window window)
-    {
-        IntPtr hWnd = WindowNative.GetWindowHandle(window);
-        WindowId wndId = Win32Interop.GetWindowIdFromWindow(hWnd);
-        return AppWindow.GetFromWindowId(wndId);
-    }
-
     static public Window GetWindowForElement(UIElement element)
     {
         if (element.XamlRoot != null)

--- a/WinUIGallery/Pages/NavigationRootPage.xaml.cs
+++ b/WinUIGallery/Pages/NavigationRootPage.xaml.cs
@@ -101,7 +101,7 @@ public sealed partial class NavigationRootPage : Page
             window.Activated += Window_Activated;
             window.SetTitleBar(this.AppTitleBar);
 
-            AppWindow appWindow = WindowHelper.GetAppWindow(window);
+            AppWindow appWindow = window.AppWindow;
             appWindow.SetIcon("Assets/Tiles/GalleryIcon.ico");
             appWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Tall;
             _settings = new UISettings();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR removes the `GetAppWindow` method from the `WindowHelper` class and gets the `AppWindow` directly from the window.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran the app and confirmed the changes.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
