### PR TITLE
Remove ToolTip from each icon on the Iconography page

### DIFF
--- a/WinUIGallery/Samples/ControlPages/Design/IconographyPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/Design/IconographyPage.xaml
@@ -43,8 +43,7 @@
                 Width="96"
                 Height="96"
                 AutomationProperties.Name="{Binding Name}"
-                CornerRadius="{StaticResource ControlCornerRadius}"
-                ToolTipService.ToolTip="{Binding Name}">
+                CornerRadius="{StaticResource ControlCornerRadius}">
                 <Grid
                     Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                     BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR removes the `ToolTip` from each icon on the Iconography page.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The `ToolTip` just shows the icon name, which you can see it on the icon itself or on the left pane.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran the app and verified the change.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
