### PR TITLE
Implement support for high contrast in mica controller sample

### DIFF
--- a/WinUIGallery/Samples/SamplePages/SampleSystemBackdropsWindow.xaml.cs
+++ b/WinUIGallery/Samples/SamplePages/SampleSystemBackdropsWindow.xaml.cs
@@ -8,6 +8,8 @@ using Microsoft.UI.Windowing;
 using Microsoft.UI;
 using Microsoft.UI.Composition;
 using System;
+using Windows.UI.ViewManagement;
+using Microsoft.UI.System;
 
 namespace WinUIGallery.SamplePages;
 
@@ -125,6 +127,7 @@ public sealed partial class SampleSystemBackdropsWindow : Window
         {
             // Hooking up the policy object.
             configurationSource = new SystemBackdropConfiguration();
+            configurationSource.IsHighContrast = ThemeSettings.CreateForWindowId(this.AppWindow.Id).HighContrast;
             Activated += Window_Activated;
             Closed += Window_Closed;
             ((FrameworkElement)Content).ActualThemeChanged += Window_ThemeChanged;
@@ -200,6 +203,7 @@ public sealed partial class SampleSystemBackdropsWindow : Window
 
     private void SetConfigurationSourceTheme()
     {
+        configurationSource.IsHighContrast = ThemeSettings.CreateForWindowId(this.AppWindow.Id).HighContrast;
         configurationSource.Theme = (SystemBackdropTheme)((FrameworkElement)Content).ActualTheme;
     }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
We were not properly respecting high contrast in the Mica Controller sample.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1763
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Before: See #1763
After:
![Screenshot of the sample window respecting high contrast like the applications behind it.](https://github.com/user-attachments/assets/a1173890-e92a-4530-9f50-b7bf2c7ebbac)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
