### PR TITLE
Fix jumping of SplitView pane in right aligned layout via min width

### DIFF
--- a/WinUIGallery/Samples/ControlPages/SplitViewPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/SplitViewPage.xaml
@@ -22,12 +22,13 @@
     <StackPanel>
         <controls:ControlExample HeaderText="A basic SplitView.">
 
-            <Grid Height="300" VerticalAlignment="Top">
+            <Grid Height="300" Width="400" VerticalAlignment="Top">
                 <SplitView
                     x:Name="splitView"
                     CompactPaneLength="{x:Bind compactPaneLengthSlider.Value, Mode=OneWay}"
                     DisplayMode="CompactOverlay"
                     IsPaneOpen="{x:Bind togglePaneButton.IsChecked, Mode=TwoWay, Converter={StaticResource nullableBooleanToBooleanConverter}}"
+                    Width="400" 
                     IsTabStop="False"
                     OpenPaneLength="{x:Bind openPaneLengthSlider.Value, Mode=OneWay}"
                     PaneBackground="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}">


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixes jumping by fixing width.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1897
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
