### PR TITLE
Missing glyph in IconsData

### DIFF
--- a/WinUIGallery/Samples/Data/IconsData.json
+++ b/WinUIGallery/Samples/Data/IconsData.json
@@ -494,6 +494,20 @@
     ]
   },
   {
+    "Code": "E72F",
+    "Name": "BlockedSite",
+    "Tags": [
+      "private",
+      "security",
+      "access",
+      "protected",
+      "safety",
+      "permission",
+      "access",
+      "protection"
+    ]
+  },
+  {
     "Code": "E730",
     "Name": "ReportHacked",
     "Tags": [


### PR DESCRIPTION
Compared to https://learn.microsoft.com/en-us/windows/apps/design/style/segoe-fluent-icons-font