### PR TITLE
Fix the wrong Microsoft Store link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This app demonstrates all of the WinUI 3 controls and styles available to make a
   <img src="./.github/assets/Screenshot-light.png" alt="WinUI 3 Gallery" width="400"/>
 </p>
 <p align="center">
-  <a style="text-decoration:none" href="https://apps.microsoft.com/detail/WinUI%203%20Gallery/9P3JFPWWDZRC?launch=true&mode=mini">
+  <a style="text-decoration:none" href="https://apps.microsoft.com/detail/9P3JFPWWDZRC?launch=true&mode=full">
     <picture>
       <source media="(prefers-color-scheme: light)" srcset="./.github/assets/StoreBadge-dark.png" width="220" />
       <img src="./.github/assets/StoreBadge-light.png" width="220" />

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This app demonstrates all of the WinUI 3 controls and styles available to make a
   <img src="./.github/assets/Screenshot-light.png" alt="WinUI 3 Gallery" width="400"/>
 </p>
 <p align="center">
-  <a style="text-decoration:none" href="https://apps.microsoft.com/detail/9NGHP3DX8HDX?launch=true&mode=full">
+  <a style="text-decoration:none" href="https://apps.microsoft.com/detail/WinUI%203%20Gallery/9P3JFPWWDZRC?launch=true&mode=mini">
     <picture>
       <source media="(prefers-color-scheme: light)" srcset="./.github/assets/StoreBadge-dark.png" width="220" />
       <img src="./.github/assets/StoreBadge-light.png" width="220" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR updates the README to fix the incorrect Microsoft Store link, which previously pointed to the File app instead of the WinUI 3 Gallery app.
Fixes #1910 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested the updated link.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
