### PR TITLE
Teaching tool tip Bug Fix

### DIFF
--- a/WinUIGallery/Samples/SampleCode/TeachingTip/TeachingTipSample2_cs.txt
+++ b/WinUIGallery/Samples/SampleCode/TeachingTip/TeachingTipSample2_cs.txt
@@ -1,4 +1,4 @@
-﻿private void TestButtonClick2(object sender, RoutedEventArgs e)
+﻿private void TestButton2Click(object sender, RoutedEventArgs e)
 {
     ToggleThemeTeachingTip2.IsOpen = true;
 }


### PR DESCRIPTION
Teaching Tip Bug Fix

## Description
This pull request corrects a textual mismatch in the C# code snippet associated with the TeachingTip button in the WinU3 Gallery app. The XAML markup correctly referenced the Click="TestButton2Click" event, but the C# method was mistakenly named TestButtonClick2. The method name has been updated to TestButton2Click to match the XAML and ensure clarity in the codebase.

## Motivation and Context
Although the TeachingTip functionality was working as expected in the app, the discrepancy between the XAML and C# method name could cause confusion for future maintainers or contributors. 

## How Has This Been Tested?
No functional testing was required as the app behavior was already correct. The change was verified by reviewing the code to ensure the method name now matches the XAML event handler.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
