### PR TITLE
[FIX] Bug in Teaching Tip

### DIFF
--- a/WinUIGallery/Samples/SampleCode/TeachingTip/TeachingTipSample1_cs.txt
+++ b/WinUIGallery/Samples/SampleCode/TeachingTip/TeachingTipSample1_cs.txt
@@ -1,4 +1,4 @@
 ﻿private void TestButtonClick1(object sender, RoutedEventArgs e)
 {
-    ToggleThemeTeachingTip1.IsOpen = true;
+    TestButton1TeachingTip.IsOpen = true;
 }

--- a/WinUIGallery/Samples/SampleCode/TeachingTip/TeachingTipSample1_cs.txt
+++ b/WinUIGallery/Samples/SampleCode/TeachingTip/TeachingTipSample1_cs.txt
@@ -1,4 +1,4 @@
-﻿private void TestButtonClick1(object sender, RoutedEventArgs e)
+﻿private void TestButton1Click(object sender, RoutedEventArgs e)
 {
     TestButton1TeachingTip.IsOpen = true;
 }

--- a/WinUIGallery/Samples/SampleCode/TeachingTip/TeachingTipSample2_cs.txt
+++ b/WinUIGallery/Samples/SampleCode/TeachingTip/TeachingTipSample2_cs.txt
@@ -1,4 +1,4 @@
 ﻿private void TestButtonClick2(object sender, RoutedEventArgs e)
 {
-    ToggleThemeTeachingTip2.IsOpen = true;
+    TestButton2TeachingTip.IsOpen = true;
 }

--- a/WinUIGallery/Samples/SampleCode/TeachingTip/TeachingTipSample2_cs.txt
+++ b/WinUIGallery/Samples/SampleCode/TeachingTip/TeachingTipSample2_cs.txt
@@ -1,4 +1,4 @@
-﻿private void TestButtonClick2(object sender, RoutedEventArgs e)
+﻿private void TestButton2Click(object sender, RoutedEventArgs e)
 {
     TestButton2TeachingTip.IsOpen = true;
 }

--- a/WinUIGallery/Samples/SampleCode/TeachingTip/TeachingTipSample3_cs.txt
+++ b/WinUIGallery/Samples/SampleCode/TeachingTip/TeachingTipSample3_cs.txt
@@ -1,4 +1,4 @@
 ﻿private void TestButtonClick3(object sender, RoutedEventArgs e)
 {
-    ToggleThemeTeachingTip3.IsOpen = true;
+    TestButton3TeachingTip.IsOpen = true;
 }

--- a/WinUIGallery/Samples/SampleCode/TeachingTip/TeachingTipSample3_cs.txt
+++ b/WinUIGallery/Samples/SampleCode/TeachingTip/TeachingTipSample3_cs.txt
@@ -1,4 +1,4 @@
-﻿private void TestButtonClick3(object sender, RoutedEventArgs e)
+﻿private void TestButton3Click(object sender, RoutedEventArgs e)
 {
     TestButton3TeachingTip.IsOpen = true;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Corrected a mismatch between the button name in the XAML and the code-behind file within the Teaching Tip section of the WinUI 3 Gallery app. The button and its associated TeachingTip control now use consistent naming.

## Motivation and Context
This change was required to resolve an inconsistency where the button name in the XAML did not match the reference in the C# code-behind. This caused issues with the TeachingTip functionality. 

## How Has This Been Tested?
Tested by running the WinUI 3 Gallery app and verifying that the TeachingTip now displays correctly when the button is clicked. Checked both the XAML and code-behind to ensure the names are consistent and the TeachingTip is triggered as expected.

## Screenshots:

XAML
```
<Button
    x:Name="TestButton1"
    Click="TestButton1Click"
    Content="Show TeachingTip" />
<TeachingTip
    x:Name="TestButton1TeachingTip"
    Title="This is the title"
    Subtitle="And this is the subtitle"
    Target="{x:Bind TestButton1}">
    <TeachingTip.IconSource>
        <SymbolIconSource Symbol="Refresh" />
    </TeachingTip.IconSource>
</TeachingTip>
```

C#
```
private void TestButtonClick1(object sender, RoutedEventArgs e)
{
    TestButton1TeachingTip.IsOpen = true;
}
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
