### PR TITLE
Automation property added for the info button in fundamentals\resources page - source popup.

### DIFF
--- a/WinUIGallery/Controls/PageHeader.xaml
+++ b/WinUIGallery/Controls/PageHeader.xaml
@@ -153,7 +153,8 @@
                                         <Button
                                             Padding="6,5,6,6"
                                             Style="{ThemeResource SubtleButtonStyle}"
-                                            ToolTipService.ToolTip="Source code of this control in the WinUI repository. For some controls only the XAML file is available">
+                                            ToolTipService.ToolTip="Source code of this control in the WinUI repository. For some controls only the XAML file is available"
+                                            AutomationProperties.Name="Info">
                                             <FontIcon
                                                 VerticalAlignment="Center"
                                                 FontSize="14"


### PR DESCRIPTION
**Bug Link:** 
[[WinUI 3 Gallery: Fundamentals: Resources]: Name property is not defined for Informational button icon present inside the 'Source code' popup](https://microsoft.visualstudio.com/OS/_workitems/edit/58151866)

**Description:** 
The **info icon** in the source popup in the **fundamentals\resources page** doesn't have an automation property - name which restricts the user who uses narrator to use the button. This is happening across the entire application. 

**Code changes**
Changes made in the file - WinUIGallery/Controls/PageHeader.xaml , `AutomationProperties.Name` is set to `"Info"` for the button for both Sample page source code and Control source code. 

```
<Button
          Padding="6,5,6,6"
          Style="{ThemeResource SubtleButtonStyle}"
          ToolTipService.ToolTip="Source code of this sample page in the WinUI Gallery repository"
          AutomationProperties.Name="Info">
```
**Note**
Since this is a page header custom control and used across all pages, fixing at the control level will fix the issue across the entire application.

**Testing**
Tested the changes with the Accessibility insights.

**Screenshots**
<img width="1253" height="620" alt="Screenshot 2025-07-17 162520" src="https://github.com/user-attachments/assets/f9585ec2-861b-4c31-90b4-a6abb882614d" />
