### PR TITLE
Add warning for Fluent-only icons not available on Windows 10

### DIFF
--- a/WinUIGallery/Models/IconData.cs
+++ b/WinUIGallery/Models/IconData.cs
@@ -13,6 +13,7 @@ public class IconData
     public string Name { get; set; }
     public string Code { get; set; }
     public string[] Tags { get; set; } = [];
+    public bool IsSegoeFluentOnly { get; set; }
 
     public string Character => char.ConvertFromUtf32(Convert.ToInt32(Code, 16));
     public string CodeGlyph => "\\u" + Code;

--- a/WinUIGallery/Samples/ControlPages/Design/IconographyPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/Design/IconographyPage.xaml
@@ -52,6 +52,15 @@
                     BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                     BorderThickness="1"
                     CornerRadius="{StaticResource ControlCornerRadius}">
+
+                    <FontIcon FontSize="16"
+                              Margin="8"
+                              Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                              Glyph="&#xE7BA;"
+                              HorizontalAlignment="Right"
+                              VerticalAlignment="Top"
+                              Visibility="{Binding IsSegoeFluentOnly}"/>
+
                     <!--  Icon  -->
                     <Viewbox
                         Width="28"
@@ -192,19 +201,42 @@
                     Visibility="Collapsed">
                     <ScrollViewer>
                         <StackPanel Margin="16,16,8,16" Spacing="2">
-                            <Border
-                                Margin="0,0,0,24"
-                                Padding="8"
-                                HorizontalAlignment="Left"
-                                Background="{ThemeResource ControlFillColorDefaultBrush}"
-                                BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
-                                BorderThickness="1"
-                                CornerRadius="{StaticResource ControlCornerRadius}">
-                                <FontIcon
-                                    FontFamily="{StaticResource SymbolThemeFontFamily}"
-                                    FontSize="48"
-                                    Glyph="{Binding SelectedItem.Character, Mode=OneWay}" />
-                            </Border>
+                            <Grid Margin="0,0,0,24"
+                                  HorizontalAlignment="Stretch">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="auto" />
+                                    <ColumnDefinition />
+                                </Grid.ColumnDefinitions>
+                                <Border Margin="0,0,8,0"
+                                        Padding="8"
+                                        HorizontalAlignment="Left"
+                                        Background="{ThemeResource ControlFillColorDefaultBrush}"
+                                        BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
+                                        BorderThickness="1"
+                                        CornerRadius="{StaticResource ControlCornerRadius}">
+                                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}"
+                                              FontSize="48"
+                                              Glyph="{Binding SelectedItem.Character, Mode=OneWay}" />
+                                </Border>
+                                <Grid Grid.Column="1"
+                                      HorizontalAlignment="Stretch"
+                                      Visibility="{Binding SelectedItem.IsSegoeFluentOnly}">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="auto" />
+                                        <ColumnDefinition />
+                                    </Grid.ColumnDefinitions>
+                                    <FontIcon FontSize="16"
+                                              Margin="0,6,8,0"
+                                              Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                                              Glyph="&#xE7BA;"
+                                              VerticalAlignment="Top" />
+                                    <TextBlock Grid.Column="1"
+                                               Margin="0,0,8,0"
+                                               Text="This icon may not be available by default in Windows 10."
+                                               TextWrapping="Wrap"
+                                               Foreground="{ThemeResource SystemFillColorCriticalBrush}" />
+                                </Grid>
+                            </Grid>
                             <TextBlock
                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                 Style="{StaticResource CaptionTextBlockStyle}"

--- a/WinUIGallery/Samples/Data/IconsData.json
+++ b/WinUIGallery/Samples/Data/IconsData.json
@@ -505,7 +505,8 @@
       "permission",
       "access",
       "protection"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "E730",
@@ -1383,7 +1384,8 @@
   {
     "Code": "E794",
     "Name": "Effects",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "E799",
@@ -1393,7 +1395,8 @@
   {
     "Code": "E7A1",
     "Name": "Contrast",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "E7A5",
@@ -1431,7 +1434,8 @@
   {
     "Code": "E7AA",
     "Name": "PhotoCollection",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "E7AC",
@@ -5508,7 +5512,8 @@
   {
     "Code": "E9A4",
     "Name": "TextBulletListSquare",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "E9A6",
@@ -6593,27 +6598,32 @@
   {
     "Code": "EAC7",
     "Name": "DesktopLeafTwo",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EAD4",
     "Name": "Emojiplay",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EAD5",
     "Name": "EmojiBrush",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EAD6",
     "Name": "EyeTracking",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EAD7",
     "Name": "EyeTrackingText",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EADF",
@@ -6674,17 +6684,20 @@
   {
     "Code": "EB19",
     "Name": "ClicktoDoOff",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EB1D",
     "Name": "ClicktoDo",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EB3B",
     "Name": "GenericApp",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EB3C",
@@ -8506,7 +8519,8 @@
   {
     "Code": "EC83",
     "Name": "UpdateStatusDot2",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EC87",
@@ -8546,7 +8560,8 @@
   {
     "Code": "EC91",
     "Name": "Uninstall",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EC92",
@@ -8569,7 +8584,8 @@
   {
     "Code": "EC9C",
     "Name": "CloudNotSynced",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "ECA5",
@@ -8920,7 +8936,8 @@
   {
     "Code": "ED21",
     "Name": "RestartUpdate2",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "ED25",
@@ -9742,27 +9759,32 @@
   {
     "Code": "EE41",
     "Name": "FullHiraganaPrivateMode",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EE42",
     "Name": "FullKatakanaPrivateMode",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EE43",
     "Name": "HalfAlphaPrivateMode",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EE44",
     "Name": "HalfKatakanaPrivateMode",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EE45",
     "Name": "FullAlphaPrivateMode",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EE47",
@@ -9884,7 +9906,8 @@
   {
     "Code": "EE7E",
     "Name": "FIDOPasskey",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EE92",
@@ -9912,17 +9935,20 @@
   {
     "Code": "EE95",
     "Name": "StopSolid",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EEA0",
     "Name": "RAM",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EEA1",
     "Name": "CPU",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EEA3",
@@ -10152,7 +10178,8 @@
   {
     "Code": "EF60",
     "Name": "TextEdit",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EF6B",
@@ -10204,12 +10231,14 @@
   {
     "Code": "EFDA",
     "Name": "AppIconDefaultAdd",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EFFF",
     "Name": "CRMScheduleReports",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F000",
@@ -11775,82 +11804,98 @@
   {
     "Code": "F112",
     "Name": "ReadOutLoud",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F117",
     "Name": "ProjectToDevice",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F120",
     "Name": "TaskManagerApp",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F196",
     "Name": "Beaker",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F1B1",
     "Name": "PowerButtonUpdate2",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F1E8",
     "Name": "LeafTwo",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F232",
     "Name": "GridViewSmall",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F27C",
     "Name": "Earbudsingle",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F27F",
     "Name": "HearingAid",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F285",
     "Name": "MobSnooze",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F2A3",
     "Name": "MobNotificationBell",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F2A5",
     "Name": "MobNotificationBellFilled",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F2A8",
     "Name": "MobSnoozeFilled",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F2C7",
     "Name": "BulletedList2",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F2C8",
     "Name": "BulletedList2Mirrored",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F2D9",
     "Name": "CirclePause",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F32A",
@@ -12027,7 +12072,8 @@
   {
     "Code": "F432",
     "Name": "BatterySaver",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F439",
@@ -12237,7 +12283,8 @@
   {
     "Code": "F4BD",
     "Name": "Snooze",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F4BE",
@@ -13380,27 +13427,32 @@
   {
     "Code": "F67B",
     "Name": "Pen",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F683",
     "Name": "TextSelect",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F684",
     "Name": "TextNavigate",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F698",
     "Name": "PinyinIMELogo2",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F69B",
     "Name": "UserRemove",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F69E",
@@ -13446,17 +13498,20 @@
   {
     "Code": "F6C4",
     "Name": "PhoneScreen",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F6C5",
     "Name": "AlertUrgent",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F6C6",
     "Name": "PhoneDesktop",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F6FA",
@@ -14243,66 +14298,79 @@
   {
     "Code": "F8C0",
     "Name": "VPNOverlay",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F8C1",
     "Name": "VPNRoamingOverly",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F8C2",
     "Name": "WifiVPN3",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F8C3",
     "Name": "WifiVPN4",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F8C4",
     "Name": "WifiVPN5",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F8C5",
     "Name": "SignalBarsVPN2",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F8C6",
     "Name": "SignalBarsVPN3",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F8C7",
     "Name": "SignalBarsVPN4",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F8C8",
     "Name": "SignalBarsVPN5",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F8C9",
     "Name": "SignalBarsVPNRoaming3",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F8CA",
     "Name": "SignalBarsVPNRoaming4",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F8CB",
     "Name": "SignalBarsVPNRoaming5",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F8CC",
     "Name": "EthernetVPN",
-    "Tags": []
+    "Tags": [],
+    "IsSegoeFluentOnly": true
   }
 ]

--- a/WinUIGallery/Samples/Data/IconsDataSchema.json
+++ b/WinUIGallery/Samples/Data/IconsDataSchema.json
@@ -1,28 +1,36 @@
 ﻿{
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "type": "array",
-    "items": {
-        "type": "object",
-        "properties": {
-            "Code": {
-                "type": "string",
-                "description": "Glyph code",
-                "uniqueItems": true
-            },
-            "Name": {
-                "type": "string",
-                "description": "Name of the glyph",
-                "uniqueItems": true
-            },
-            "Tags": {
-                "type": "array",
-                "description": "Array of tags related to this glyph",
-                "uniqueItems": true,
-                "items": {
-                    "type": "string"
-                }
-            }
-        },
-        "required": ["Code", "Name"]
-    }
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "Code": {
+        "type": "string",
+        "description": "Glyph code",
+        "uniqueItems": true
+      },
+      "Name": {
+        "type": "string",
+        "description": "Name of the glyph",
+        "uniqueItems": true
+      },
+      "Tags": {
+        "type": "array",
+        "description": "Array of tags related to this glyph",
+        "uniqueItems": true,
+        "items": {
+          "type": "string"
+        }
+      },
+      "IsSegoeFluentOnly": {
+        "type": "boolean",
+        "default": false,
+        "description": "Determines whether the icon is only available in Segoe Fluent Icons and not in Segoe MDL2 Assets."
+      }
+    },
+    "required": [
+      "Code",
+      "Name"
+    ]
+  }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a warning to indicate that some icons may not be available by default on Windows 10, especially those only included in the **Segoe Fluent Icons** set used by Windows 11. Main changes are:
- Added `IsSegoeFluentOnly` property to both the `IconDataSchema` and `IconData` class.
- Marked Fluent-only icons in the JSON data.
- Displayed a warning icon and message on the Iconography page for Fluent-only icons.

## Motivation and Context
- This change helps clarify icon availability across different Windows versions.
- Closes #1557.

## How Has This Been Tested?
Tested by manually setting the font to **Segoe MDL2 Assets** to simulate the default icon set on Windows 10 and verifying which icons fail to appear.

## Screenshots (if appropriate):
<img width="991" height="428" alt="image" src="https://github.com/user-attachments/assets/8c9dfe89-8c86-4f2d-ac1e-3ea85f642326" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
