### PR TITLE
Fix placeholder text truncation for OneWay and TwoWay Binding

### DIFF
--- a/WinUIGallery/Samples/ControlPages/Fundamentals/BindingPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/Fundamentals/BindingPage.xaml
@@ -45,12 +45,12 @@
                             <TextBlock FontWeight="SemiBold" Text="OneWay binding" />
                             <TextBox
                                 x:Name="SourceTextBoxOneWay"
-                                Width="200"
+                                MinWidth="380"
                                 HorizontalAlignment="Left"
                                 PlaceholderText="Enter text here" />
                             <TextBox
                                 x:Name="TargetTextBoxOneWay"
-                                Width="200"
+                                MinWidth="380"
                                 HorizontalAlignment="Left"
                                 PlaceholderText="Mirrors above text"
                                 Text="{x:Bind SourceTextBoxOneWay.Text, Mode=OneWay}" />
@@ -62,12 +62,12 @@
                             <TextBlock FontWeight="SemiBold" Text="TwoWay binding" />
                             <TextBox
                                 x:Name="SourceTextBoxTwoWay"
-                                Width="200"
+                                MinWidth="380"
                                 HorizontalAlignment="Left"
                                 PlaceholderText="Enter text here" />
                             <TextBox
                                 x:Name="TargetTextBoxTwoWay"
-                                Width="200"
+                                MinWidth="380"
                                 HorizontalAlignment="Left"
                                 PlaceholderText="Mirrors and edits above text"
                                 Text="{x:Bind SourceTextBoxTwoWay.Text, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />


### PR DESCRIPTION
**Bug:** [[WinUI 3 Gallery: Fundamentals -> Binding]: On applying text scaling 200%, the placeholder text of OneWay Binding and TwoWay Binding are getting truncated.](https://microsoft.visualstudio.com/OS/_workitems/edit/58165989)

**Description:**
The placeholder text of the textbox in the binding page is getting truncated when the text scaling is set to 200%.

**Changes:**
Files changed
` WinUIGallery/Samples/ControlPages/Fundamentals/BindingPage.xaml`

Code changes:
`Width="200"` is changed to` MinWidth="380"`
```
 <TextBox
     x:Name="SourceTextBoxOneWay"
     MinWidth="380"
     HorizontalAlignment="Left"
     PlaceholderText="Enter text here" />
```
**Test:**
Tested in the gallery app. Attached the screenshots for reference.

**Screenshots:**

**Normal State:**

<img width="1382" height="829" alt="image" src="https://github.com/user-attachments/assets/354cd959-dddf-46ff-8c0f-5314df1be455" />

**Text Scaling Set to 200%:**

**Before fix:**
<img width="1280" height="715" alt="image" src="https://github.com/user-attachments/assets/677e858d-950d-475d-88a3-f2ccab0ef300" />

**After fix:**
<img width="1410" height="881" alt="image" src="https://github.com/user-attachments/assets/e1ad59c3-9844-41a3-9807-93e2a4fb7d00" />

