### PR TITLE
Modified custom password box implementation and added automation peer for narrator announcement.

### DIFF
--- a/WinUIGallery/Samples/ControlPages/Fundamentals/Controls/ValidatedPasswordBox.cs
+++ b/WinUIGallery/Samples/ControlPages/Fundamentals/Controls/ValidatedPasswordBox.cs
@@ -2,7 +2,10 @@
 // Licensed under the MIT License.
 
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Documents;
+using Microsoft.UI.Xaml.Media;
 using System.Linq;
 
 namespace WinUIGallery.Samples.ControlPages.Fundamentals.Controls;
@@ -86,7 +89,6 @@ public sealed class ValidatedPasswordBox : Control
             PasswordInput.PasswordChanged += (sender, e) =>
             {
                 Password = PasswordInput.Password;
-                UpdateValidationMessages();
             };
         }
 
@@ -106,26 +108,59 @@ public sealed class ValidatedPasswordBox : Control
         bool hasNumber = Password.Any(char.IsDigit);
 
         IsValid = hasMinLength && hasUppercase && hasNumber;
-
-        if (MissingUppercaseText is not null)
+        var validationRichText = GetTemplateChild("ValidationRichText") as RichTextBlock;
+        if (validationRichText != null)
         {
-            MissingUppercaseText.Visibility = (hasUppercase || string.IsNullOrEmpty(Password)) ? Visibility.Collapsed : Visibility.Visible;
-        }
+            validationRichText.Blocks.Clear();
 
-        if (MissingNumberText is not null)
-        {
-            MissingNumberText.Visibility = (hasNumber || string.IsNullOrEmpty(Password)) ? Visibility.Collapsed : Visibility.Visible;
-        }
-
-        if (TooShortText is not null)
-        {
-            TooShortText.Visibility = (hasMinLength || string.IsNullOrEmpty(Password)) ? Visibility.Collapsed : Visibility.Visible;
-        }
-
-        if (ValidPasswordText is not null)
-        {
-            ValidPasswordText.Visibility = IsValid ? Visibility.Visible : Visibility.Collapsed;
+            Paragraph paragraph = new();
+            if (!hasUppercase && !string.IsNullOrEmpty(Password))
+            {
+                AddValidationLine(paragraph, "\uEA39", "Missing uppercase", "SystemFillColorCriticalBrush");
+            }
+            if (!hasNumber && !string.IsNullOrEmpty(Password))
+            {
+                AddValidationLine(paragraph, "\uEA39", "Missing number", "SystemFillColorCriticalBrush");
+            }
+            if (!hasMinLength && !string.IsNullOrEmpty(Password))
+            {
+                AddValidationLine(paragraph, "\uEA39", "Too short!", "SystemFillColorCriticalBrush");
+            }
+            if (IsValid)
+            {
+                AddValidationLine(paragraph, "\uE930", "Password is valid", "SystemFillColorSuccessBrush");
+            }
+            if (paragraph.Inlines.Count > 0)
+            {
+                validationRichText.Blocks.Add(paragraph);
+                var peer = FrameworkElementAutomationPeer.FromElement(validationRichText)
+                            ?? FrameworkElementAutomationPeer.CreatePeerForElement(validationRichText);
+                peer.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
+            }
         }
     }
+    private void AddValidationLine(Paragraph paragraph, string iconGlyph, string message, string resourceBrushKey)
+    {
+        var icon = new FontIcon
+        {
+            Glyph = iconGlyph,
+            FontSize = 14,
+            Foreground = (Brush)Application.Current.Resources[resourceBrushKey]
+        };
+
+        InlineUIContainer iconContainer = new() { Child = icon };
+
+        paragraph.Inlines.Add(iconContainer);
+        paragraph.Inlines.Add(new Run { Text = " " });
+
+        paragraph.Inlines.Add(new Run
+        {
+            Text = message,
+            Foreground = (Brush)Application.Current.Resources[resourceBrushKey]
+        });
+
+        paragraph.Inlines.Add(new LineBreak());
+    }
 }
+
 

--- a/WinUIGallery/Samples/ControlPages/Fundamentals/Controls/ValidatedPasswordBox.xaml
+++ b/WinUIGallery/Samples/ControlPages/Fundamentals/Controls/ValidatedPasswordBox.xaml
@@ -10,50 +10,10 @@
                 <ControlTemplate TargetType="local:ValidatedPasswordBox">
                     <StackPanel Spacing="4">
                         <PasswordBox x:Name="PasswordInput" />
-
-                        <!-- Uppercase Validation -->
-                        <StackPanel x:Name="MissingUppercaseText"
-                                    Orientation="Horizontal"
-                                    Spacing="4">
-                            <FontIcon Glyph="&#xEA39;"
-                                      Foreground="{ThemeResource SystemFillColorCriticalBrush}"
-                                      FontSize="14"/>
-                            <TextBlock Text="Missing uppercase"
-                                       Foreground="{ThemeResource SystemFillColorCriticalBrush}" />
-                        </StackPanel>
-
-                        <!-- Number Validation -->
-                        <StackPanel x:Name="MissingNumberText"
-                                    Orientation="Horizontal"
-                                    Spacing="4">
-                            <FontIcon Glyph="&#xEA39;"
-                                      Foreground="{ThemeResource SystemFillColorCriticalBrush}"
-                                      FontSize="14" />
-                            <TextBlock Text="Missing number"
-                                       Foreground="{ThemeResource SystemFillColorCriticalBrush}" />
-                        </StackPanel>
-
-                        <!-- Length Validation -->
-                        <StackPanel x:Name="TooShortText"
-                                    Orientation="Horizontal"
-                                    Spacing="4">
-                            <FontIcon Glyph="&#xEA39;"
-                                      Foreground="{ThemeResource SystemFillColorCriticalBrush}"
-                                      FontSize="14" />
-                            <TextBlock Text="Too short!"
-                                       Foreground="{ThemeResource SystemFillColorCriticalBrush}" />
-                        </StackPanel>
-
-                        <!-- Valid Password -->
-                        <StackPanel x:Name="ValidPasswordText"
-                                    Orientation="Horizontal"
-                                    Spacing="4">
-                            <FontIcon Glyph="&#xE930;"
-                                      Foreground="{ThemeResource SystemFillColorSuccessBrush}"
-                                      FontSize="14" />
-                            <TextBlock Text="Password is valid"
-                                       Foreground="{ThemeResource SystemFillColorSuccessBrush}" />
-                        </StackPanel>
+                        <RichTextBlock x:Name="ValidationRichText"
+                            AutomationProperties.LiveSetting="Polite"
+                            TextWrapping="Wrap"
+                            IsTextSelectionEnabled="False"/>
                     </StackPanel>
                 </ControlTemplate>
             </Setter.Value>


### PR DESCRIPTION
**Bug:** [[WinUI 3 Gallery: Fundamentals-> Custom &user controls]: Screen reader fails to announce appeared suggestions to the user.](https://microsoft.visualstudio.com/OS/_workitems/edit/58168275)

**Description:** 
Custom password box in Custom & user controls page failed to announce suggestion via screen reader.

**Fix:** 
The current design of the password suggestion box works with changing the visibility of the text blocks. However, this design doesn't allow the combined text to be provided for screen reader for announcements and also ` AutomationProperties.LiveSetting` doesn't work with visibility change. So, the current design is migrated with `RichEditTextBlock` with ` AutomationProperties.LiveSetting` for screen reader to announce the text changes in the password change event.

**File Changes:**
```
WinUIGallery/Samples/ControlPages/Fundamentals/Controls/ValidatedPasswordBox.cs
WinUIGallery/Samples/ControlPages/Fundamentals/Controls/ValidatedPasswordBox.xaml
```
**Code Changes:**

- Switched from multiple visible StackPanel elements to a RichTextBlock
- Added message builder for the RichTextBlock to display the validation messages along with the icons and text colors.
- Added calls to `FrameworkElementAutomationPeer.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged) `after validation updates to notify screen readers of content changes.
- Fixed redundant event triggers causing duplicate narrator announcements by removing unwanted update calls.

**Tests:**
Tested the changes via NarratorBuddy and Narrator.

**Screenshots:**
<img width="1843" height="790" alt="Screenshot 2025-07-23 164721" src="https://github.com/user-attachments/assets/6e8d73b2-c31a-4ed4-8737-a3655ac823f0" />

