### PR TITLE
Line break is moved from the end of the line to start with Paragraph line count check in custom control passwordbox.

### DIFF
--- a/WinUIGallery/Samples/ControlPages/Fundamentals/Controls/ValidatedPasswordBox.cs
+++ b/WinUIGallery/Samples/ControlPages/Fundamentals/Controls/ValidatedPasswordBox.cs
@@ -144,6 +144,10 @@ public sealed class ValidatedPasswordBox : Control
     }
     private void AddValidationLine(Paragraph paragraph, string iconGlyph, string message, string resourceBrushKey)
     {
+        if(paragraph.Inlines.Any())
+        {
+            paragraph.Inlines.Add(new LineBreak());
+        }
         var icon = new FontIcon
         {
             Glyph = iconGlyph,
@@ -161,8 +165,6 @@ public sealed class ValidatedPasswordBox : Control
             Text = message,
             Foreground = (Brush)Application.Current.Resources[resourceBrushKey]
         });
-
-        paragraph.Inlines.Add(new LineBreak());
     }
 }
 


### PR DESCRIPTION
**PR Review follow-up:** [https://github.com/microsoft/WinUI-Gallery/pull/1930](https://github.com/microsoft/WinUI-Gallery/pull/1930)

**File Changes:**
`WinUIGallery/Samples/ControlPages/Fundamentals/Controls/ValidatedPasswordBox.cs`

**Code changes:**
Line break is removed at the end of the function and added at the start with line count check.
```
 if(paragraph.Inlines.Any())
 {
     paragraph.Inlines.Add(new LineBreak());
 }
```

**Screenshots:**
Before:
<img width="796" height="403" alt="image" src="https://github.com/user-attachments/assets/64d35ba9-440f-4285-8fc8-c7718076d108" />

After:
<img width="699" height="358" alt="image" src="https://github.com/user-attachments/assets/3d8b962e-6a18-444d-a51c-f0e126d64818" />
