### PR TITLE
[a11y] 58165987 - Add conditional ToolTip to description textblock

### DIFF
--- a/WinUIGallery/Styles/ItemTemplates.xaml
+++ b/WinUIGallery/Styles/ItemTemplates.xaml
@@ -5,16 +5,17 @@
     xmlns:models="using:WinUIGallery.Models">
 
     <DataTemplate x:Key="ControlItemTemplate" x:DataType="models:ControlInfoDataItem">
-        <Grid x:Name="controlRoot"
-              Width="300"
-              Height="96"
-              Padding="8"
-              HorizontalAlignment="Stretch"
-              ColumnSpacing="16"
-              CornerRadius="{StaticResource OverlayCornerRadius}"
-              Background="{ThemeResource ControlFillColorDefaultBrush}"
-              BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-              BorderThickness="1">
+        <Grid
+            x:Name="controlRoot"
+            Width="300"
+            Height="96"
+            Padding="8"
+            HorizontalAlignment="Stretch"
+            Background="{ThemeResource ControlFillColorDefaultBrush}"
+            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+            BorderThickness="1"
+            ColumnSpacing="16"
+            CornerRadius="{StaticResource OverlayCornerRadius}">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
@@ -26,31 +27,38 @@
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
                 <Image
-                        x:Name="gridImage"
-                        Grid.RowSpan="2"
-                        Width="32"
-                        Margin="8,12,16,0"
-                        VerticalAlignment="Top"
-                        AutomationProperties.Name="{x:Bind Title}"
-                        Source="{x:Bind ImagePath}"
-                        Stretch="Uniform" />
+                    x:Name="gridImage"
+                    Grid.RowSpan="2"
+                    Width="32"
+                    Margin="8,12,16,0"
+                    VerticalAlignment="Top"
+                    AutomationProperties.Name="{x:Bind Title}"
+                    Source="{x:Bind ImagePath}"
+                    Stretch="Uniform" />
                 <TextBlock
-                        x:Name="titleText"
-                        Grid.Column="1"
-                        Margin="0,12,0,0"
-                        VerticalAlignment="Bottom"
-                        Style="{StaticResource BodyStrongTextBlockStyle}"
-                        Text="{x:Bind Title}"
-                        TextLineBounds="TrimToCapHeight"
-                        TextWrapping="NoWrap" />
+                    x:Name="titleText"
+                    Grid.Column="1"
+                    Margin="0,12,0,0"
+                    VerticalAlignment="Bottom"
+                    Style="{StaticResource BodyStrongTextBlockStyle}"
+                    Text="{x:Bind Title}"
+                    TextLineBounds="TrimToCapHeight"
+                    TextWrapping="NoWrap" />
                 <TextBlock
-                        Grid.Row="1"
-                        Grid.Column="1"
-                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                        RelativePanel.Below="titleText"
-                        Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="{x:Bind Subtitle}"
-                        TextTrimming="CharacterEllipsis" />
+                    x:Name="subtitleText"
+                    Grid.Row="1"
+                    Grid.Column="1"
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    RelativePanel.Below="titleText"
+                    Style="{StaticResource CaptionTextBlockStyle}"
+                    Text="{x:Bind Subtitle}"
+                    TextTrimming="WordEllipsis">
+                    <ToolTipService.ToolTip>
+                        <ToolTip Visibility="{Binding ElementName=subtitleText, Path=IsTextTrimmed}">
+                            <TextBlock Text="{x:Bind Subtitle}" TextWrapping="Wrap" />
+                        </ToolTip>
+                    </ToolTipService.ToolTip>
+                </TextBlock>
             </Grid>
             <VisualStateManager.VisualStateGroups>
                 <VisualStateGroup x:Name="LayoutVisualStates">


### PR DESCRIPTION
When text-scaling is high, the description textblock will show a tooltip using the same UX that e.g. the Store app uses.

Addressing ADO item: 58165987 

<img width="331" height="200" alt="image" src="https://github.com/user-attachments/assets/cfb6d00d-9efd-4d11-a266-9246e348a404" />
