### PR TITLE
TextBlock on ListView sample now wraps

### DIFF
--- a/WinUIGallery/Samples/ControlPages/ListViewPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/ListViewPage.xaml
@@ -13,9 +13,9 @@
     x:Class="WinUIGallery.ControlPages.ListViewPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:models="using:WinUIGallery.Models"
     xmlns:controls="using:WinUIGallery.Controls"
     xmlns:local="using:WinUIGallery.ControlPages"
+    xmlns:models="using:WinUIGallery.Models"
     xmlns:pages="using:WinUIGallery.Pages">
     <Page.Resources>
         <DataTemplate x:Key="ImageTextListMailFolderTemplate" x:DataType="models:ControlInfoDataItem">
@@ -113,9 +113,10 @@
             HeaderText="Basic ListView with Simple DataTemplate"
             XamlSource="ListView\ListViewSample1_xaml.txt">
             <StackPanel>
-                <TextBlock Margin="0,0,0,15">
-                    This is a basic ListView that has the full source code below.<LineBreak />
-                    Other samples on this page display only the additional markup needed to customize a simple ListView like this one.</TextBlock>
+                <TextBlock
+                    Margin="0,0,0,16"
+                    Text="This is a basic ListView that has the full source code below. Other samples on this page display only the additional markup needed to customize a simple ListView like this one."
+                    TextWrapping="Wrap" />
                 <ListView
                     x:Name="BaseExample"
                     Width="350"


### PR DESCRIPTION
Addressing ADO item: 58166123

Before:
<img width="817" height="90" alt="image" src="https://github.com/user-attachments/assets/e2a9def2-ee54-49c3-aed8-3db32490d825" />

After:
<img width="865" height="235" alt="image" src="https://github.com/user-attachments/assets/106f0de1-d2f2-433c-b4e3-ea6c13f1fadb" />
