### PR TITLE
Updating Color overview foreground colors to meet contrast ratios

### DIFF
--- a/WinUIGallery/Controls/DesignGuidance/ColorSections/FillSection.xaml
+++ b/WinUIGallery/Controls/DesignGuidance/ColorSections/FillSection.xaml
@@ -202,7 +202,7 @@
                     ColorExplanation="Disabled only (not accessible)"
                     ColorName="Control Strong / Disabled"
                     ColorValue="#FFFFFF (51, 31.73%)"
-                    Foreground="{ThemeResource TextFillColorInverseBrush}"
+                    Foreground="{ThemeResource TextFillColorPrimary}"
                     ShowSeparator="False" />
             </Grid>
 

--- a/WinUIGallery/Controls/DesignGuidance/ColorSections/TextSection.xaml
+++ b/WinUIGallery/Controls/DesignGuidance/ColorSections/TextSection.xaml
@@ -54,7 +54,7 @@
                     ColorExplanation="Pressed only (not accessible)"
                     ColorName="Text / Tertiary"
                     ColorValue="#000000 (72, 44.58%)"
-                    Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+                    Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
                     ShowSeparator="False" />
                 <local:ColorTile
                     Grid.Column="3"
@@ -174,7 +174,7 @@
                     ColorExplanation="Disabled only (not accessible)"
                     ColorName="Text on Accent / Disabled"
                     ColorValue="#FFFFFF (FF, 100%)"
-                    Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
+                    Foreground="Black" />
                 <local:ColorTile
                     Grid.Column="2"
                     Background="{ThemeResource TextOnAccentFillColorSelectedTextBrush}"


### PR DESCRIPTION
**Fixes #1948 :**
Before:
<img width="546" height="230" alt="image" src="https://github.com/user-attachments/assets/a415ef95-4c03-4726-8bca-d75e1ad270e7" />

After:
<img width="536" height="217" alt="image" src="https://github.com/user-attachments/assets/4405f400-73ea-4752-95b8-f3b599eb8e04" />

**Fixes #1949
Fixes #1950**

Before:
<img width="286" height="235" alt="image" src="https://github.com/user-attachments/assets/351060dd-b908-472e-bb2a-b0dfde72dd1c" />
<img width="540" height="219" alt="image" src="https://github.com/user-attachments/assets/f70d4189-c58f-4784-8322-df6a50167df9" />

After:
<img width="272" height="255" alt="image" src="https://github.com/user-attachments/assets/c5dd68c1-ffa3-483a-bcd8-11e77aafb2fa" />
<img width="549" height="215" alt="image" src="https://github.com/user-attachments/assets/2fa97745-2a17-4243-b6c6-9a2e87c67957" />
