### PR TITLE
Adding additional tags to F140

### DIFF
--- a/WinUIGallery/Samples/Data/IconsData.json
+++ b/WinUIGallery/Samples/Data/IconsData.json
@@ -11321,7 +11321,10 @@
     "Code": "F140",
     "Name": "StatusCircleBlock",
     "Tags": [
-      "restrict"
+      "restrict",
+      "stop",
+      "cancel",
+      "end"
     ]
   },
   {


### PR DESCRIPTION
I had to manually find this icon for the 3rd time in the last week as I couldn't find it :). So I've added additional tags, as this icon is used communicate ending a process too.

<img width="171" height="33" alt="image" src="https://github.com/user-attachments/assets/78eba528-c717-46c8-bab5-56636f05f120" />

<img width="385" height="111" alt="image" src="https://github.com/user-attachments/assets/9a9c14b9-09e9-4e0b-bde5-a62bc81cfe31" />
