### PR TITLE
Fix: sync titlebar button colors with app theme changes

### DIFF
--- a/WinUIGallery/Helpers/TitleBarHelper.cs
+++ b/WinUIGallery/Helpers/TitleBarHelper.cs
@@ -19,8 +19,6 @@ internal partial class TitleBarHelper
 
     public static void SetCaptionButtonColors(Window window, Windows.UI.Color color)
     {
-        var res = Application.Current.Resources;
-        res["WindowCaptionForeground"] = color;
         window.AppWindow.TitleBar.ButtonForegroundColor = color;
     }
 

--- a/WinUIGallery/MainWindow.xaml.cs
+++ b/WinUIGallery/MainWindow.xaml.cs
@@ -14,7 +14,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Windows.Foundation;
-using Windows.UI.ViewManagement;
 using WinUIGallery.Helpers;
 using WinUIGallery.Models;
 using WinUIGallery.Pages;
@@ -25,7 +24,6 @@ public sealed partial class MainWindow : Window
 {
     public Windows.System.VirtualKey ArrowKey;
     public Microsoft.UI.Dispatching.DispatcherQueue dispatcherQueue;
-    private UISettings _settings;
 
     public NavigationView NavigationView
     {
@@ -38,14 +36,14 @@ public sealed partial class MainWindow : Window
     {
         this.InitializeComponent();
         SetWindowProperties();
+        RootGrid.ActualThemeChanged += (_,_) => TitleBarHelper.ApplySystemThemeToCaptionButtons(this, RootGrid.ActualTheme);
         dispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
     }
 
     private void RootGrid_Loaded(object sender, RoutedEventArgs e)
     {
         NavigationOrientationHelper.UpdateNavigationViewForElement(NavigationOrientationHelper.IsLeftMode());
-        _settings = new UISettings();
-        _settings.ColorValuesChanged += _settings_ColorValuesChanged; // cannot use FrameworkElement.ActualThemeChanged event because the triggerTitleBarRepaint workaround no longer works
+        TitleBarHelper.ApplySystemThemeToCaptionButtons(this, RootGrid.ActualTheme);
     }
 
     private void SetWindowProperties()
@@ -98,16 +96,6 @@ public sealed partial class MainWindow : Window
     void OnNavigationFailed(object sender, NavigationFailedEventArgs e)
     {
         throw new Exception("Failed to load Page " + e.SourcePageType.FullName);
-    }
-    // this handles updating the caption button colors correctly when windows system theme is changed
-    // while the app is open
-    private void _settings_ColorValuesChanged(UISettings sender, object args)
-    {
-        // This calls comes off-thread, hence we will need to dispatch it to current app's thread
-        dispatcherQueue.TryEnqueue(() =>
-        {
-            _ = TitleBarHelper.ApplySystemThemeToCaptionButtons(this, rootFrame.ActualTheme);
-        });
     }
 
     // Wraps a call to rootFrame.Navigate to give the Page a way to know which NavigationRootPage is navigating.


### PR DESCRIPTION
## Description
When the app theme is set to Light or Dark (not “Use system setting”) and the app theme differs from the system theme, the app initially opens in the system theme and then switches to the chosen app theme.
Previously, the titlebar button colors were not updated during this theme change, resulting in low contrast.
This fix updates the button colors whenever the root grid theme changes and removes the old broken logic.

## Motivation and Context
- Fixes #1605 
- Fixes #1970 

## How Has This Been Tested?
Manually tested

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
