### PR TITLE
Fix: a workaround for window resizing issue caused by setting TitleBar.IconSource

### DIFF
--- a/WinUIGallery/Samples/ControlPages/TitleBarPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/TitleBarPage.xaml
@@ -41,9 +41,13 @@
                         IsBackButtonVisible="{Binding ElementName=BackButtonToggle, Path=IsOn, Mode=OneWay}"
                         IsPaneToggleButtonVisible="{Binding ElementName=PaneToggle, Path=IsOn, Mode=OneWay}"
                         Subtitle="{Binding ElementName=SubtitleBox, Path=Text, Mode=OneWay}">
-                        <TitleBar.IconSource>
-                            <ImageIconSource ImageSource="/Assets/Tiles/GalleryIcon.ico" />
-                        </TitleBar.IconSource>
+                        <!--  This is a workaround for https://github.com/microsoft/microsoft-ui-xaml/issues/10374, once fixed we should just be using IconSource  -->
+                        <TitleBar.LeftHeader>
+                            <ImageIcon
+                                Height="16"
+                                Margin="16,0,8,0"
+                                Source="/Assets/Tiles/GalleryIcon.ico" />
+                        </TitleBar.LeftHeader>
                         <TitleBar.RightHeader>
                             <PersonPicture
                                 Width="30"


### PR DESCRIPTION
## Description
Replaced `TitleBar.IconSource` with `TitleBar.LeftHeader` to show an `ImageIcon` as a workaround

## Motivation and Context
- a workaround for https://github.com/microsoft/microsoft-ui-xaml/issues/10374

## How Has This Been Tested?
Manually tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
