### PR TITLE
Fix: TitleBar page changing window TitleBar buttons colors

### DIFF
--- a/WinUIGallery/Helpers/TitleBarHelper.cs
+++ b/WinUIGallery/Helpers/TitleBarHelper.cs
@@ -19,7 +19,10 @@ internal partial class TitleBarHelper
 
     public static void SetCaptionButtonColors(Window window, Windows.UI.Color color)
     {
-        window.AppWindow.TitleBar.ButtonForegroundColor = color;
+        if (window.AppWindow != null)
+        {
+            window.AppWindow.TitleBar.ButtonForegroundColor = color;
+        }
     }
 
     public static void SetCaptionButtonBackgroundColors(Window window, Windows.UI.Color? color)

--- a/WinUIGallery/Samples/ControlPages/TitleBarPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/TitleBarPage.xaml
@@ -37,10 +37,12 @@
                     BorderThickness="1"
                     CornerRadius="{StaticResource OverlayCornerRadius}">
                     <TitleBar
+                        x:Name="TitleBarControl"
                         Title="{Binding ElementName=TitleBox, Path=Text, Mode=OneWay}"
                         IsBackButtonVisible="{Binding ElementName=BackButtonToggle, Path=IsOn, Mode=OneWay}"
                         IsPaneToggleButtonVisible="{Binding ElementName=PaneToggle, Path=IsOn, Mode=OneWay}"
-                        Subtitle="{Binding ElementName=SubtitleBox, Path=Text, Mode=OneWay}">
+                        Subtitle="{Binding ElementName=SubtitleBox, Path=Text, Mode=OneWay}"
+                        LayoutUpdated="TitleBar_LayoutUpdated">
                         <TitleBar.IconSource>
                             <ImageIconSource ImageSource="/Assets/Tiles/GalleryIcon.ico" />
                         </TitleBar.IconSource>

--- a/WinUIGallery/Samples/ControlPages/TitleBarPage.xaml.cs
+++ b/WinUIGallery/Samples/ControlPages/TitleBarPage.xaml.cs
@@ -24,6 +24,5 @@ public sealed partial class TitleBarPage : Page
     private void TitleBar_LayoutUpdated(object sender, object e)
     {
         TitleBarHelper.ApplySystemThemeToCaptionButtons(App.MainWindow, this.ActualTheme);
-       //itleBarControl.LayoutUpdated -= TitleBar_LayoutUpdated; // Unsubscribe to avoid multiple calls
     }
 }

--- a/WinUIGallery/Samples/ControlPages/TitleBarPage.xaml.cs
+++ b/WinUIGallery/Samples/ControlPages/TitleBarPage.xaml.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using WinUIGallery.Helpers;
 using WinUIGallery.Samples.SamplePages;
 
 namespace WinUIGallery.ControlPages;
@@ -18,5 +19,11 @@ public sealed partial class TitleBarPage : Page
     {
         TitleBarWindow titleBarWindow = new TitleBarWindow();
         titleBarWindow.Activate();
+    }
+
+    private void TitleBar_LayoutUpdated(object sender, object e)
+    {
+        TitleBarHelper.ApplySystemThemeToCaptionButtons(App.MainWindow, this.ActualTheme);
+       //itleBarControl.LayoutUpdated -= TitleBar_LayoutUpdated; // Unsubscribe to avoid multiple calls
     }
 }


### PR DESCRIPTION
## Description
The window TitleBar button colors were being changed when navigating to the TitleBar page while the app theme differed from the system theme.
The exact root cause couldn’t be identified, so the button colors were explicitly set in the control’s `LayoutUpdated` event (the last event triggered in the control’s lifecycle).
Setting the colors in the `Loaded` event didn’t work, whereas setting them during `LayoutUpdated` resolved the issue.

## Motivation and Context
- Closes #2022

## How Has This Been Tested?
Manually tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
