### PR TITLE
Fix Custom PasswordBox validation messages not updating with theme

### DIFF
--- a/WinUIGallery/Samples/ControlPages/Fundamentals/Controls/ValidatedPasswordBox.cs
+++ b/WinUIGallery/Samples/ControlPages/Fundamentals/Controls/ValidatedPasswordBox.cs
@@ -7,6 +7,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Documents;
 using Microsoft.UI.Xaml.Media;
 using System.Linq;
+using Windows.UI;
 
 namespace WinUIGallery.Samples.ControlPages.Fundamentals.Controls;
 
@@ -32,73 +33,38 @@ public sealed partial class ValidatedPasswordBox : Control
         this.DefaultStyleKey = typeof(ValidatedPasswordBox);
     }
 
-    public string Password
-    {
-        get => (string)GetValue(PasswordProperty);
-        set => SetValue(PasswordProperty, value);
-    }
-
-    public bool IsValid
-    {
-        get => (bool)GetValue(IsValidProperty);
-        set => SetValue(IsValidProperty, value);
-    }
-
-    public int MinLength
-    {
-        get => (int)GetValue(MinLengthProperty);
-        set => SetValue(MinLengthProperty, value);
-    }
-
-    public string Header
-    {
-        get => (string)GetValue(HeaderProperty);
-        set => SetValue(HeaderProperty, value);
-    }
-
-    public string PlaceholderText
-    {
-        get => (string)GetValue(PlaceholderTextProperty);
-        set => SetValue(PlaceholderTextProperty, value);
-    }
+    public string Password { get => (string)GetValue(PasswordProperty); set => SetValue(PasswordProperty, value); }
+    public bool IsValid { get => (bool)GetValue(IsValidProperty); set => SetValue(IsValidProperty, value); }
+    public int MinLength { get => (int)GetValue(MinLengthProperty); set => SetValue(MinLengthProperty, value); }
+    public string Header { get => (string)GetValue(HeaderProperty); set => SetValue(HeaderProperty, value); }
+    public string PlaceholderText { get => (string)GetValue(PlaceholderTextProperty); set => SetValue(PlaceholderTextProperty, value); }
 
     private PasswordBox PasswordInput { get; set; }
-    private StackPanel MissingUppercaseText { get; set; }
-    private StackPanel MissingNumberText { get; set; }
-    private StackPanel TooShortText { get; set; }
-    private StackPanel ValidPasswordText { get; set; }
+    private RichTextBlock ValidationRichText { get; set; }
 
     protected override void OnApplyTemplate()
     {
         base.OnApplyTemplate();
 
         PasswordInput = GetTemplateChild(nameof(PasswordInput)) as PasswordBox;
+        ValidationRichText = GetTemplateChild("ValidationRichText") as RichTextBlock;
+
         if (PasswordInput != null)
         {
             PasswordInput.Header = Header;
             PasswordInput.PlaceholderText = PlaceholderText;
+            PasswordInput.PasswordChanged += (_, _) => Password = PasswordInput.Password;
         }
 
-        MissingUppercaseText = GetTemplateChild(nameof(MissingUppercaseText)) as StackPanel;
-        MissingNumberText = GetTemplateChild(nameof(MissingNumberText)) as StackPanel;
-        TooShortText = GetTemplateChild(nameof(TooShortText)) as StackPanel;
-        ValidPasswordText = GetTemplateChild(nameof(ValidPasswordText)) as StackPanel;
-
-        if (PasswordInput is not null)
-        {
-            PasswordInput.PasswordChanged += (sender, e) =>
-            {
-                Password = PasswordInput.Password;
-            };
-        }
+        if (ValidationRichText != null)
+            ValidationRichText.ActualThemeChanged += (_, _) => UpdateValidationMessages();
 
         UpdateValidationMessages();
     }
 
     private static void OnPasswordChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
-        var control = (ValidatedPasswordBox)d;
-        control.UpdateValidationMessages();
+        ((ValidatedPasswordBox)d).UpdateValidationMessages();
     }
 
     private void UpdateValidationMessages()
@@ -108,64 +74,55 @@ public sealed partial class ValidatedPasswordBox : Control
         bool hasNumber = Password.Any(char.IsDigit);
 
         IsValid = hasMinLength && hasUppercase && hasNumber;
-        var validationRichText = GetTemplateChild("ValidationRichText") as RichTextBlock;
-        if (validationRichText != null)
-        {
-            validationRichText.Blocks.Clear();
 
-            Paragraph paragraph = new();
-            if (IsValid)
-            {
-                AddValidationLine(paragraph, "\uE930", "Password is valid", "SystemFillColorSuccessBrush");
-            }
-            else
-            {
-                if (!hasUppercase && !string.IsNullOrEmpty(Password))
-                {
-                    AddValidationLine(paragraph, "\uEA39", "Missing uppercase", "SystemFillColorCriticalBrush");
-                }
-                if (!hasNumber && !string.IsNullOrEmpty(Password))
-                {
-                    AddValidationLine(paragraph, "\uEA39", "Missing number", "SystemFillColorCriticalBrush");
-                }
-                if (!hasMinLength && !string.IsNullOrEmpty(Password))
-                {
-                    AddValidationLine(paragraph, "\uEA39", "Too short!", "SystemFillColorCriticalBrush");
-                }
-            }
-            if (paragraph.Inlines.Count > 0)
-            {
-                validationRichText.Blocks.Add(paragraph);
-                var peer = FrameworkElementAutomationPeer.FromElement(validationRichText)
-                            ?? FrameworkElementAutomationPeer.CreatePeerForElement(validationRichText);
-                peer.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
-            }
+        if (ValidationRichText is null)
+            return;
+
+        ValidationRichText.Visibility = string.IsNullOrEmpty(Password) ? Visibility.Collapsed : Visibility.Visible;
+
+        ValidationRichText.Blocks.Clear();
+
+        if (string.IsNullOrEmpty(Password))
+            return;
+
+        var paragraph = new Paragraph();
+
+        if (IsValid)
+        {
+            AddValidationLine(paragraph, "\uE930", "Password is valid", false);
+        }
+        else
+        {
+            if (!hasUppercase) AddValidationLine(paragraph, "\uEA39", "Missing uppercase", true);
+            if (!hasNumber) AddValidationLine(paragraph, "\uEA39", "Missing number", true);
+            if (!hasMinLength) AddValidationLine(paragraph, "\uEA39", "Too short!", true);
+        }
+
+        if (paragraph.Inlines.Count > 0)
+        {
+            ValidationRichText.Blocks.Add(paragraph);
+            (FrameworkElementAutomationPeer.FromElement(ValidationRichText)
+                 ?? FrameworkElementAutomationPeer.CreatePeerForElement(ValidationRichText))
+                .RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
         }
     }
-    private void AddValidationLine(Paragraph paragraph, string iconGlyph, string message, string resourceBrushKey)
+
+    private void AddValidationLine(Paragraph paragraph, string iconGlyph, string message, bool isCritical)
     {
-        if(paragraph.Inlines.Any())
-        {
+        if (paragraph.Inlines.Any())
             paragraph.Inlines.Add(new LineBreak());
-        }
-        var icon = new FontIcon
+
+        var color = new SolidColorBrush(
+            isCritical
+                ? (ActualTheme == ElementTheme.Light ? Color.FromArgb(255, 196, 43, 28) : Color.FromArgb(255, 255, 153, 164))
+                : (ActualTheme == ElementTheme.Light ? Color.FromArgb(255, 15, 123, 15) : Color.FromArgb(255, 108, 203, 95)));
+
+        paragraph.Inlines.Add(new InlineUIContainer
         {
-            Glyph = iconGlyph,
-            FontSize = 14,
-            Foreground = (Brush)Application.Current.Resources[resourceBrushKey]
-        };
-
-        InlineUIContainer iconContainer = new() { Child = icon };
-
-        paragraph.Inlines.Add(iconContainer);
-        paragraph.Inlines.Add(new Run { Text = " " });
-
-        paragraph.Inlines.Add(new Run
-        {
-            Text = message,
-            Foreground = (Brush)Application.Current.Resources[resourceBrushKey]
+            Child = new FontIcon { Glyph = iconGlyph, FontSize = 14, Foreground = color }
         });
+
+        paragraph.Inlines.Add(new Run { Text = " ", });
+        paragraph.Inlines.Add(new Run { Text = message, Foreground = color });
     }
 }
-
-

--- a/WinUIGallery/Samples/ControlPages/Fundamentals/Controls/ValidatedPasswordBox.xaml
+++ b/WinUIGallery/Samples/ControlPages/Fundamentals/Controls/ValidatedPasswordBox.xaml
@@ -14,7 +14,8 @@
                         <RichTextBlock x:Name="ValidationRichText"
                             AutomationProperties.LiveSetting="Polite"
                             TextWrapping="Wrap"
-                            IsTextSelectionEnabled="False"/>
+                            IsTextSelectionEnabled="False"
+                            Visibility="Collapsed"/>
                     </StackPanel>
                 </ControlTemplate>
             </Setter.Value>

--- a/WinUIGallery/Samples/SampleCode/CustomUserControls/CustomUserControlsSample2_cs.txt
+++ b/WinUIGallery/Samples/SampleCode/CustomUserControls/CustomUserControlsSample2_cs.txt
@@ -1,11 +1,15 @@
-﻿using System.Linq;
-using Microsoft.UI.Xaml;
+﻿using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Documents;
+using Microsoft.UI.Xaml.Media;
+using System.Linq;
+using Windows.UI;
 
 namespace YourNamespace;
 
 // Custom control for a validated password box
-public sealed class ValidatedPasswordBox : Control
+public sealed partial class ValidatedPasswordBox : Control
 {
     // Register a dependency property for the Password value.
     // Note: The PropertyMetadata includes a callback (OnPasswordChanged) so that the UI updates
@@ -39,31 +43,24 @@ public sealed class ValidatedPasswordBox : Control
 
     // Template parts for password input and validation messages
     private PasswordBox PasswordInput { get; set; }
-    private StackPanel MissingUppercaseText { get; set; }
-    private StackPanel MissingNumberText { get; set; }
-    private StackPanel TooShortText { get; set; }
-    private StackPanel ValidPasswordText { get; set; }
+    private RichTextBlock ValidationRichText { get; set; }
 
     protected override void OnApplyTemplate()
     {
         base.OnApplyTemplate();
 
         PasswordInput = GetTemplateChild(nameof(PasswordInput)) as PasswordBox;
+        ValidationRichText = GetTemplateChild("ValidationRichText") as RichTextBlock;
+
         if (PasswordInput != null)
         {
             PasswordInput.Header = Header;
             PasswordInput.PlaceholderText = PlaceholderText;
-            PasswordInput.PasswordChanged += (sender, e) =>
-            {
-                Password = PasswordInput.Password;
-                UpdateValidationMessages();
-            };
+            PasswordInput.PasswordChanged += (_, _) => Password = PasswordInput.Password;
         }
 
-        MissingUppercaseText = GetTemplateChild(nameof(MissingUppercaseText)) as StackPanel;
-        MissingNumberText = GetTemplateChild(nameof(MissingNumberText)) as StackPanel;
-        TooShortText = GetTemplateChild(nameof(TooShortText)) as StackPanel;
-        ValidPasswordText = GetTemplateChild(nameof(ValidPasswordText)) as StackPanel;
+        if (ValidationRichText != null)
+            ValidationRichText.ActualThemeChanged += (_, _) => UpdateValidationMessages();
 
         UpdateValidationMessages();
     }
@@ -82,13 +79,54 @@ public sealed class ValidatedPasswordBox : Control
 
         IsValid = hasMinLength && hasUppercase && hasNumber;
 
-        if (MissingUppercaseText != null)
-            MissingUppercaseText.Visibility = (hasUppercase || string.IsNullOrEmpty(Password)) ? Visibility.Collapsed : Visibility.Visible;
-        if (MissingNumberText != null)
-            MissingNumberText.Visibility = (hasNumber || string.IsNullOrEmpty(Password)) ? Visibility.Collapsed : Visibility.Visible;
-        if (TooShortText != null)
-            TooShortText.Visibility = (hasMinLength || string.IsNullOrEmpty(Password)) ? Visibility.Collapsed : Visibility.Visible;
-        if (ValidPasswordText != null)
-            ValidPasswordText.Visibility = IsValid ? Visibility.Visible : Visibility.Collapsed;
+        if (ValidationRichText is null)
+            return;
+
+        ValidationRichText.Visibility = string.IsNullOrEmpty(Password) ? Visibility.Collapsed : Visibility.Visible;
+
+        ValidationRichText.Blocks.Clear();
+
+        if (string.IsNullOrEmpty(Password))
+            return;
+
+        var paragraph = new Paragraph();
+
+        if (IsValid)
+        {
+            AddValidationLine(paragraph, "\uE930", "Password is valid", false);
+        }
+        else
+        {
+            if (!hasUppercase) AddValidationLine(paragraph, "\uEA39", "Missing uppercase", true);
+            if (!hasNumber) AddValidationLine(paragraph, "\uEA39", "Missing number", true);
+            if (!hasMinLength) AddValidationLine(paragraph, "\uEA39", "Too short!", true);
+        }
+
+        if (paragraph.Inlines.Count > 0)
+        {
+            ValidationRichText.Blocks.Add(paragraph);
+            (FrameworkElementAutomationPeer.FromElement(ValidationRichText)
+                 ?? FrameworkElementAutomationPeer.CreatePeerForElement(ValidationRichText))
+                .RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
+        }
+    }
+
+    private void AddValidationLine(Paragraph paragraph, string iconGlyph, string message, bool isCritical)
+    {
+        if (paragraph.Inlines.Any())
+            paragraph.Inlines.Add(new LineBreak());
+
+        var color = new SolidColorBrush(
+            isCritical
+                ? (ActualTheme == ElementTheme.Light ? Color.FromArgb(255, 196, 43, 28) : Color.FromArgb(255, 255, 153, 164))
+                : (ActualTheme == ElementTheme.Light ? Color.FromArgb(255, 15, 123, 15) : Color.FromArgb(255, 108, 203, 95)));
+
+        paragraph.Inlines.Add(new InlineUIContainer
+        {
+            Child = new FontIcon { Glyph = iconGlyph, FontSize = 14, Foreground = color }
+        });
+
+        paragraph.Inlines.Add(new Run { Text = " ", });
+        paragraph.Inlines.Add(new Run { Text = message, Foreground = color });
     }
 }

--- a/WinUIGallery/Samples/SampleCode/CustomUserControls/CustomUserControlsSample2_xaml.txt
+++ b/WinUIGallery/Samples/SampleCode/CustomUserControls/CustomUserControlsSample2_xaml.txt
@@ -1,46 +1,26 @@
-﻿<!-- Generic.xaml -->
-<ResourceDictionary
+﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:YourNamespace">
     
     <Style TargetType="local:ValidatedPasswordBox">
+        <Setter Property="IsTabStop" Value="False" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:ValidatedPasswordBox">
                     <StackPanel Spacing="4">
                         <PasswordBox x:Name="PasswordInput" />
-
-                        <!-- Uppercase Validation -->
-                        <StackPanel x:Name="MissingUppercaseText" Orientation="Horizontal" Spacing="4">
-                            <FontIcon Glyph="&#xEA39;" Foreground="{ThemeResource SystemFillColorCriticalBrush}" FontSize="14" />
-                            <TextBlock Text="Missing uppercase" Foreground="{ThemeResource SystemFillColorCriticalBrush}" />
-                        </StackPanel>
-
-                        <!-- Number Validation -->
-                        <StackPanel x:Name="MissingNumberText" Orientation="Horizontal" Spacing="4">
-                            <FontIcon Glyph="&#xEA39;" Foreground="{ThemeResource SystemFillColorCriticalBrush}" FontSize="14" />
-                            <TextBlock Text="Missing number" Foreground="{ThemeResource SystemFillColorCriticalBrush}" />
-                        </StackPanel>
-
-                        <!-- Length Validation -->
-                        <StackPanel x:Name="TooShortText" Orientation="Horizontal" Spacing="4">
-                            <FontIcon Glyph="&#xEA39;" Foreground="{ThemeResource SystemFillColorCriticalBrush}" FontSize="14" />
-                            <TextBlock Text="Too short!" Foreground="{ThemeResource SystemFillColorCriticalBrush}" />
-                        </StackPanel>
-
-                        <!-- Valid Password -->
-                        <StackPanel x:Name="ValidPasswordText" Orientation="Horizontal" Spacing="4">
-                            <FontIcon Glyph="&#xE930;" Foreground="{ThemeResource SystemFillColorSuccessBrush}" FontSize="14" />
-                            <TextBlock Text="Password is valid" Foreground="{ThemeResource SystemFillColorSuccessBrush}" />
-                        </StackPanel>
+                        <RichTextBlock x:Name="ValidationRichText"
+                            AutomationProperties.LiveSetting="Polite"
+                            TextWrapping="Wrap"
+                            IsTextSelectionEnabled="False"
+                            Visibility="Collapsed"/>
                     </StackPanel>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
 </ResourceDictionary>
-
 
 <!-- YourPage.xaml -->
 <Page ...


### PR DESCRIPTION
## Description
Main Changes
- Validation messages now update according to the active theme
- `ValidationRichText` is collapsed when no password has been entered
- Updated the sample code accordingly

## Motivation and Context
- Closes #2019

## How Has This Been Tested?
Manually tested

## Screenshots (if appropriate):
<img width="253" height="110" alt="image" src="https://github.com/user-attachments/assets/7d9681f8-c35a-4246-9d41-2792031c165c" />
<img width="265" height="172" alt="image" src="https://github.com/user-attachments/assets/d9647fba-4ccf-4c4c-b5fa-cc438dbefac7" />
<img width="259" height="169" alt="image" src="https://github.com/user-attachments/assets/bb82ae24-f772-4858-9131-a2ca7b616db5" />
<img width="256" height="136" alt="image" src="https://github.com/user-attachments/assets/9e690e6b-bd11-4c29-8ff1-0020dc0937bd" />
<img width="270" height="131" alt="image" src="https://github.com/user-attachments/assets/b22100e4-bb8f-4138-8f9a-1a990fcb141b" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
