### PR TITLE
Fix light theme caption button hover, cleanup TitleBarHelper

### DIFF
--- a/WinUIGallery/Helpers/TitleBarHelper.cs
+++ b/WinUIGallery/Helpers/TitleBarHelper.cs
@@ -3,6 +3,8 @@
 
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
+using System;
+using Windows.UI;
 
 namespace WinUIGallery.Helpers;
 
@@ -10,36 +12,16 @@ internal partial class TitleBarHelper
 {
     // workaround as AppWindow TitleBar doesn't update caption button colors correctly when changed while app is running
     // https://task.ms/44172495
-    public static Windows.UI.Color ApplySystemThemeToCaptionButtons(Window window, ElementTheme currentTheme)
-    {
-        var color = currentTheme == ElementTheme.Dark ? Colors.White : Colors.Black;
-        SetCaptionButtonColors(window, color);
-        return color;
-    }
-
-    public static void SetCaptionButtonColors(Window window, Windows.UI.Color color)
+    public static void ApplySystemThemeToCaptionButtons(Window window, ElementTheme currentTheme)
     {
         if (window.AppWindow != null)
         {
-            window.AppWindow.TitleBar.ButtonForegroundColor = color;
+            var foregroundColor = currentTheme == ElementTheme.Dark ? Colors.White : Colors.Black;
+            window.AppWindow.TitleBar.ButtonForegroundColor = foregroundColor;
+            window.AppWindow.TitleBar.ButtonHoverForegroundColor = foregroundColor;
+
+            var backgroundHoverColor = currentTheme == ElementTheme.Dark ? Color.FromArgb(24, 255, 255, 255) : Color.FromArgb(24, 0, 0, 0);
+            window.AppWindow.TitleBar.ButtonHoverBackgroundColor = backgroundHoverColor;
         }
-    }
-
-    public static void SetCaptionButtonBackgroundColors(Window window, Windows.UI.Color? color)
-    {
-        var titleBar = window.AppWindow.TitleBar;
-        titleBar.ButtonBackgroundColor = color;
-    }
-
-    public static void SetForegroundColor(Window window, Windows.UI.Color? color)
-    {
-        var titleBar = window.AppWindow.TitleBar;
-        titleBar.ForegroundColor = color;
-    }
-
-    public static void SetBackgroundColor(Window window, Windows.UI.Color? color)
-    {
-        var titleBar = window.AppWindow.TitleBar;
-        titleBar.BackgroundColor = color;
     }
 }

--- a/WinUIGallery/Helpers/TitleBarHelper.cs
+++ b/WinUIGallery/Helpers/TitleBarHelper.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
-using System;
 using Windows.UI;
 
 namespace WinUIGallery.Helpers;

--- a/WinUIGallery/Pages/SettingsPage.xaml.cs
+++ b/WinUIGallery/Pages/SettingsPage.xaml.cs
@@ -85,26 +85,14 @@ public sealed partial class SettingsPage : Page
     {
         var selectedTheme = ((ComboBoxItem)themeMode.SelectedItem)?.Tag?.ToString();
         var window = WindowHelper.GetWindowForElement(this);
-        string color;
         if (selectedTheme != null)
         {
             ThemeHelper.RootTheme = EnumHelper.GetEnum<ElementTheme>(selectedTheme);
-            if (selectedTheme == "Dark")
-            {
-                TitleBarHelper.SetCaptionButtonColors(window, Colors.White);
-                color = selectedTheme;
-            }
-            else if (selectedTheme == "Light")
-            {
-                TitleBarHelper.SetCaptionButtonColors(window, Colors.Black);
-                color = selectedTheme;
-            }
-            else
-            {
-                color = TitleBarHelper.ApplySystemThemeToCaptionButtons(window, this.ActualTheme) == Colors.White ? "Dark" : "Light";
-            }
+            var elementThemeResolved = ThemeHelper.RootTheme == ElementTheme.Default ? ThemeHelper.ActualTheme : ThemeHelper.RootTheme;
+            TitleBarHelper.ApplySystemThemeToCaptionButtons(window, elementThemeResolved);
+
             // announce visual change to automation
-            UIHelper.AnnounceActionForAccessibility(sender as UIElement, $"Theme changed to {color}",
+            UIHelper.AnnounceActionForAccessibility(sender as UIElement, $"Theme changed to {elementThemeResolved}",
                                                                             "ThemeChangedNotificationActivityId");
         }
     }

--- a/WinUIGallery/Samples/SamplePages/SampleBuiltInSystemBackdropsWindow.xaml.cs
+++ b/WinUIGallery/Samples/SamplePages/SampleBuiltInSystemBackdropsWindow.xaml.cs
@@ -127,8 +127,7 @@ public sealed partial class SampleBuiltInSystemBackdropsWindow : Window
     private void ThemeComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         ((FrameworkElement)Content).RequestedTheme = Enum.GetValues<ElementTheme>()[themeComboBox.SelectedIndex];
-
-        TitleBarHelper.SetCaptionButtonColors(this, ((FrameworkElement)Content).ActualTheme == ElementTheme.Dark ? Colors.White : Colors.Black);
+        TitleBarHelper.ApplySystemThemeToCaptionButtons(this, ((FrameworkElement)Content).ActualTheme);
         SetNoneBackdropBackground();
     }
 

--- a/WinUIGallery/Samples/SamplePages/SampleSystemBackdropsWindow.xaml.cs
+++ b/WinUIGallery/Samples/SamplePages/SampleSystemBackdropsWindow.xaml.cs
@@ -215,8 +215,7 @@ public sealed partial class SampleSystemBackdropsWindow : Window
     private void ThemeComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         ((FrameworkElement)Content).RequestedTheme = Enum.GetValues<ElementTheme>()[themeComboBox.SelectedIndex];
-
-        TitleBarHelper.SetCaptionButtonColors(this, ((FrameworkElement)Content).ActualTheme == ElementTheme.Dark ? Colors.White : Colors.Black);
+        TitleBarHelper.ApplySystemThemeToCaptionButtons(this, ((FrameworkElement)Content).ActualTheme);
         SetNoneBackdropBackground();
     }
 


### PR DESCRIPTION
This PR fixes an issue where setting the app to light mode while system theme is dark would result in over for caption buttons being white on white.

As part of this, I cleaned up the TitleBar helper and switched to one function to be called by everyone instead of the segmented functions.