### PR TITLE
Remove deprecated icon (E18A: Placeholder) from IconsData.json

### DIFF
--- a/WinUIGallery/Samples/Data/IconsData.json
+++ b/WinUIGallery/Samples/Data/IconsData.json
@@ -1,15 +1,5 @@
 [
   {
-    "Code": "E18A",
-    "Name": "Placeholder",
-    "Tags": [
-      "diamond",
-      "rhombus",
-      "shape",
-      "symbol-icon"
-    ]
-  },
-  {
     "Code": "E620",
     "Name": "StopSlideShow",
     "Tags": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove deprecated icon `E18A: Placeholder` from IconsData.json.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It's mentioned in the doc below that `E18A: Placeholder` is deprecated.

> [!NOTE]
> Glyphs with prefixes ranging from E0- to E5- (e.g. E001, E5B1) are currently marked as legacy and are therefore deprecated.
>

https://learn.microsoft.com/windows/apps/design/style/segoe-fluent-icons-font#icon-list

See #2008 for context.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran the app and checked the changes.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
