### PR TITLE
Replace "Controls" header with a separator in app navigation

### DIFF
--- a/WinUIGallery/MainWindow.xaml
+++ b/WinUIGallery/MainWindow.xaml
@@ -272,7 +272,7 @@
                             Tag="AccessibilityColorContrast" />
                     </NavigationViewItem.MenuItems>
                 </NavigationViewItem>
-                <NavigationViewItemHeader Content="Controls" />
+                <NavigationViewItemSeparator />
                 <NavigationViewItem x:Name="AllControlsItem" Content="All">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE8A9;" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR replaces the "Controls" header with a separator in app navigation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, it's not just "controls" under the header.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran the app and confirmed the change.

## Screenshots (if appropriate):
Current:

<img width="642" height="524" alt="image" src="https://github.com/user-attachments/assets/48e6e7a0-28cd-4f17-b7c5-e9e7ff2eb514" />

New:

<img width="642" height="490" alt="image" src="https://github.com/user-attachments/assets/37b27cd9-ddd2-494d-b981-4864d25d466a" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
