### PR TITLE
Add `RepositionThemeTransition` to sample pages for smoother layout updates

### DIFF
--- a/WinUIGallery/Samples/ControlPages/Accessibility/AccessibilityKeyboardPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/Accessibility/AccessibilityKeyboardPage.xaml
@@ -31,6 +31,10 @@
     </Page.Resources>
 
     <StackPanel Spacing="12">
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <RichTextBlock>
             <Paragraph>
                 Accessibility is about building experiences that make your Windows application usable by people of

--- a/WinUIGallery/Samples/ControlPages/Accessibility/AccessibilityScreenReaderPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/Accessibility/AccessibilityScreenReaderPage.xaml
@@ -32,6 +32,10 @@
     </Page.Resources>
 
     <StackPanel Spacing="12">
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <RichTextBlock>
             <Paragraph>
                 Accessibility is about building experiences that make your Windows application usable by people of

--- a/WinUIGallery/Samples/ControlPages/AcrylicPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/AcrylicPage.xaml
@@ -36,6 +36,10 @@
         </ResourceDictionary>
     </Page.Resources>
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <RichTextBlock>
             <Paragraph>
                 Acrylic Brush might fall back to SolidColorbrush in certain scenarios.

--- a/WinUIGallery/Samples/ControlPages/AnimatedIconPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/AnimatedIconPage.xaml
@@ -9,6 +9,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample
             x:Name="AnimatedIconExample1"
             CSharpSource="Icons/AnimatedIconSample1_cs.txt"

--- a/WinUIGallery/Samples/ControlPages/AppBarButtonPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/AppBarButtonPage.xaml
@@ -18,6 +18,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="An AppBarButton with a symbol icon.">
             <StackPanel Orientation="Horizontal">
                 <!--  App bar button with symbol icon.  -->

--- a/WinUIGallery/Samples/ControlPages/AppBarToggleButtonPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/AppBarToggleButtonPage.xaml
@@ -18,6 +18,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="An AppBarToggleButton with a symbol icon.">
             <controls:ControlExample.Example>
                 <StackPanel Orientation="Horizontal">

--- a/WinUIGallery/Samples/ControlPages/AppNotificationPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/AppNotificationPage.xaml
@@ -9,6 +9,10 @@
       mc:Ignorable="d">
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <StackPanel Spacing="8"
                     Margin="0,16,0,0">
             <InfoBar IsOpen="True"

--- a/WinUIGallery/Samples/ControlPages/AppWindowPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/AppWindowPage.xaml
@@ -9,6 +9,10 @@
     mc:Ignorable="d">
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <TextBlock
             Margin="0,16,0,-16"
             Style="{ThemeResource SubtitleTextBlockStyle}"

--- a/WinUIGallery/Samples/ControlPages/AutoSuggestBoxPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/AutoSuggestBoxPage.xaml
@@ -8,6 +8,10 @@
     x:Name="pageRoot"
     mc:Ignorable="d">
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="A basic autosuggest box.">
             <StackPanel Orientation="Horizontal">
                 <AutoSuggestBox

--- a/WinUIGallery/Samples/ControlPages/BadgeNotificationManagerPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/BadgeNotificationManagerPage.xaml
@@ -10,6 +10,10 @@
     mc:Ignorable="d">
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <InfoBar Margin="0,10,0,0" IsOpen="True" IsClosable="False" Severity="Warning" Title="BadgeNotificationManager is not available in unpackaged mode." Message="This API requires the app to be running in packaged mode (MSIX)."/>
         <controls:ControlExample HeaderText="Setting badge notifications with count">
             <StackPanel Spacing="8">

--- a/WinUIGallery/Samples/ControlPages/BreadcrumbBarPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/BreadcrumbBarPage.xaml
@@ -19,6 +19,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="A BreadcrumbBar control">
             <controls:ControlExample.Example>
                 <BreadcrumbBar x:Name="BreadcrumbBar1" ItemsSource="{x:Bind FoldersString}"/>

--- a/WinUIGallery/Samples/ControlPages/ButtonPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/ButtonPage.xaml
@@ -18,6 +18,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="A simple Button with text content.">
             <controls:ControlExample.Example>
                 <Button

--- a/WinUIGallery/Samples/ControlPages/CheckBoxPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/CheckBoxPage.xaml
@@ -18,6 +18,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="A 2-state CheckBox.">
             <controls:ControlExample.Example>
                 <StackPanel Orientation="Horizontal">

--- a/WinUIGallery/Samples/ControlPages/ClipboardPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/ClipboardPage.xaml
@@ -19,6 +19,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <!--  COPY TO CLIPBOARD  -->
         <controls:ControlExample x:Name="Example1" HeaderText="Copy text to the Clipboard">
 

--- a/WinUIGallery/Samples/ControlPages/ComboBoxPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/ComboBoxPage.xaml
@@ -19,6 +19,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample HeaderText="A ComboBox with items defined inline and its width set.">
             <controls:ControlExample.Example>
                 <StackPanel>

--- a/WinUIGallery/Samples/ControlPages/ConnectedAnimationPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/ConnectedAnimationPage.xaml
@@ -8,7 +8,10 @@
     x:Name="pageRoot"
     mc:Ignorable="d">
     <StackPanel>
-
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample
             CSharpSource="Motion/ConnectedAnimation/ConnectedAnimationSample1_cs.txt"
             HeaderText="A connected animation between a list page and a detail page"

--- a/WinUIGallery/Samples/ControlPages/ContentDialogPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/ContentDialogPage.xaml
@@ -7,6 +7,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample
             x:Name="Example1"
             CSharpSource="ContentDialog/ContentDialogSample1_cs.txt"

--- a/WinUIGallery/Samples/ControlPages/DatePickerPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/DatePickerPage.xaml
@@ -18,6 +18,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="A simple DatePicker with a header.">
             <controls:ControlExample.Example>
                 <DatePicker Header="Pick a date" />

--- a/WinUIGallery/Samples/ControlPages/DropDownButtonPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/DropDownButtonPage.xaml
@@ -8,6 +8,10 @@
     mc:Ignorable="d">
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample HeaderText="Simple DropDownButton" XamlSource="Buttons/DropDown/DropDownButton_Simple.txt">
             <StackPanel x:Name="Control1" Orientation="Horizontal">
                 <DropDownButton Content="Email">

--- a/WinUIGallery/Samples/ControlPages/EasingFunctionPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/EasingFunctionPage.xaml
@@ -10,6 +10,10 @@
     mc:Ignorable="d">
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <RichTextBlock Style="{ThemeResource BodyRichTextBlockStyle}">
             <Paragraph>- Use the Standard easing function for animating general property changes.</Paragraph>
             <Paragraph>- Use the Accelerate easing function to animate objects that are exiting the scene.</Paragraph>

--- a/WinUIGallery/Samples/ControlPages/ExpanderPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/ExpanderPage.xaml
@@ -19,6 +19,10 @@
     mc:Ignorable="d">
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="An Expander with text in the header and content areas">
             <controls:ControlExample.Example>
                 <Expander

--- a/WinUIGallery/Samples/ControlPages/FlipViewPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/FlipViewPage.xaml
@@ -17,6 +17,10 @@
     xmlns:models="using:WinUIGallery.Models"
     xmlns:pages="using:WinUIGallery.Pages">
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample
             x:Name="Example1"
             ExampleHeight="Auto"

--- a/WinUIGallery/Samples/ControlPages/FlyoutPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/FlyoutPage.xaml
@@ -25,6 +25,10 @@
         </Flyout>
     </Page.Resources>
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample HeaderText="A button with a flyout">
             <controls:ControlExample.Example>
                 <Button x:Name="Control1" Content="Empty cart">

--- a/WinUIGallery/Samples/ControlPages/Fundamentals/BindingPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/Fundamentals/BindingPage.xaml
@@ -9,6 +9,10 @@
     mc:Ignorable="d">
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <StackPanel Margin="0,12,0,0" Spacing="12">
             <RichTextBlock>
                 <Paragraph FontWeight="SemiBold">Key concepts</Paragraph>

--- a/WinUIGallery/Samples/ControlPages/Fundamentals/CustomUserControlsPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/Fundamentals/CustomUserControlsPage.xaml
@@ -10,6 +10,10 @@
     mc:Ignorable="d">
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <TextBlock Text="Custom (templated) control" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,8" />
         <StackPanel Spacing="8">
             <RichTextBlock>

--- a/WinUIGallery/Samples/ControlPages/Fundamentals/TemplatesPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/Fundamentals/TemplatesPage.xaml
@@ -19,6 +19,10 @@
     </Page.Resources>
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <StackPanel Margin="0,12,0,0" Spacing="12">
             <RichTextBlock>
                 <Paragraph FontWeight="SemiBold">Placement of Templates</Paragraph>

--- a/WinUIGallery/Samples/ControlPages/Fundamentals/XamlResourcesPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/Fundamentals/XamlResourcesPage.xaml
@@ -15,6 +15,10 @@
     </Page.Resources>
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <TextBlock
             Margin="0,12,0,4"
             Style="{ThemeResource SubtitleTextBlockStyle}"

--- a/WinUIGallery/Samples/ControlPages/Fundamentals/XamlStylesPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/Fundamentals/XamlStylesPage.xaml
@@ -9,6 +9,10 @@
     mc:Ignorable="d">
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <StackPanel Margin="0,12,0,0" Spacing="12">
             <RichTextBlock>
                 <Paragraph>The definition of styles is similiar to other resources: app-level, page-level, control-level.</Paragraph>

--- a/WinUIGallery/Samples/ControlPages/GridViewPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/GridViewPage.xaml
@@ -122,6 +122,10 @@
     </Page.Resources>
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample
             CSharpSource="GridView/GridViewSample1_cs.txt"
             HeaderText="Basic GridView with Simple DataTemplate"

--- a/WinUIGallery/Samples/ControlPages/HyperlinkButtonPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/HyperlinkButtonPage.xaml
@@ -19,6 +19,10 @@
     mc:Ignorable="d">
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="A hyperlink button that navigates to a URI.">
             <controls:ControlExample.Example>
                 <HyperlinkButton

--- a/WinUIGallery/Samples/ControlPages/IconElementPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/IconElementPage.xaml
@@ -8,6 +8,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="A BitmapIcon with a multicolor bitmap image">
             <controls:ControlExample.Example>
                 <StackPanel>

--- a/WinUIGallery/Samples/ControlPages/ImagePage.xaml
+++ b/WinUIGallery/Samples/ControlPages/ImagePage.xaml
@@ -7,6 +7,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="A basic image from a local file.">
 
             <Image Height="100" Source="/Assets/SampleMedia/treetops.jpg" />

--- a/WinUIGallery/Samples/ControlPages/ImplicitTransitionPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/ImplicitTransitionPage.xaml
@@ -13,6 +13,10 @@
         </Style>
     </Page.Resources>
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample HeaderText="Automatically animate changes to Opacity">
             <Rectangle
                 x:Name="OpacityRectangle"

--- a/WinUIGallery/Samples/ControlPages/InfoBadgePage.xaml
+++ b/WinUIGallery/Samples/ControlPages/InfoBadgePage.xaml
@@ -19,6 +19,10 @@
     mc:Ignorable="d">
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample
             x:Name="Example1"
             HorizontalContentAlignment="Stretch"

--- a/WinUIGallery/Samples/ControlPages/InfoBarPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/InfoBarPage.xaml
@@ -18,6 +18,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="A closable InfoBar with options to change its Severity.">
             <controls:ControlExample.Example>
                 <InfoBar

--- a/WinUIGallery/Samples/ControlPages/ItemsRepeaterPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/ItemsRepeaterPage.xaml
@@ -174,6 +174,10 @@
     </Page.Resources>
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample HeaderText="Basic, non-interactive items laid out by ItemsRepeater">
             <ScrollViewer
                 MaxHeight="500"

--- a/WinUIGallery/Samples/ControlPages/ItemsViewPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/ItemsViewPage.xaml
@@ -134,6 +134,10 @@
     </pages:ItemsPageBase.Resources>
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="Basic ItemsView">
             <StackPanel>
                 <TextBlock Margin="0,0,0,15">

--- a/WinUIGallery/Samples/ControlPages/LinePage.xaml
+++ b/WinUIGallery/Samples/ControlPages/LinePage.xaml
@@ -20,7 +20,10 @@
     mc:Ignorable="d">
 
     <StackPanel>
-
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <!--  LINE SAMPLE  -->
         <controls:ControlExample x:Name="Example4" HeaderText="Line">
             <Canvas Width="100" Height="200">

--- a/WinUIGallery/Samples/ControlPages/ListBoxPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/ListBoxPage.xaml
@@ -19,6 +19,10 @@
     xmlns:helper="using:WinUIGallery.Helpers"
     mc:Ignorable="d">
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="A ListBox with items defined inline and its minimum width set.">
             <controls:ControlExample.Example>
                 <StackPanel>

--- a/WinUIGallery/Samples/ControlPages/ListViewPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/ListViewPage.xaml
@@ -107,7 +107,10 @@
 
     </Page.Resources>
     <StackPanel>
-
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample
             CSharpSource="ListView\ListViewSample1_cs.txt"
             HeaderText="Basic ListView with Simple DataTemplate"

--- a/WinUIGallery/Samples/ControlPages/MapControlPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/MapControlPage.xaml
@@ -18,6 +18,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <TextBlock Margin="0,0,0,12" TextWrapping="Wrap">
             <Span xml:space="preserve"><Run>Follow instructions </Run> <Hyperlink NavigateUri="https://learn.microsoft.com/azure/azure-maps/how-to-manage-account-keys">here</Hyperlink><Run> to obtain your MapServiceToken.</Run></Span>
 

--- a/WinUIGallery/Samples/ControlPages/MediaPlayerElementPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/MediaPlayerElementPage.xaml
@@ -7,6 +7,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="A MediaPlayerElement with transport controls.">
             <controls:ControlExample.Example>
                 <MediaPlayerElement

--- a/WinUIGallery/Samples/ControlPages/MenuBarPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/MenuBarPage.xaml
@@ -7,6 +7,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample HeaderText="A simple MenuBar" XamlSource="MenuBar\MenuBarSample1.txt">
             <StackPanel>
                 <TextBlock x:Name="SelectedOptionText" Text="" />

--- a/WinUIGallery/Samples/ControlPages/MenuFlyoutPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/MenuFlyoutPage.xaml
@@ -18,6 +18,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="An AppBarButton with a MenuFlyout.">
             <StackPanel x:Name="Control1" Orientation="Horizontal">
                 <AppBarButton

--- a/WinUIGallery/Samples/ControlPages/NavigationViewPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/NavigationViewPage.xaml
@@ -24,6 +24,10 @@
     </Page.Resources>
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <!--  Example on how to override NavView acrylic  -->
         <StackPanel.Resources>
             <ResourceDictionary>

--- a/WinUIGallery/Samples/ControlPages/NumberBoxPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/NumberBoxPage.xaml
@@ -19,6 +19,10 @@
     mc:Ignorable="d">
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample HeaderText="A NumberBox that evaluates expressions." XamlSource="NumberBox/NumberBoxSample1_xaml.txt">
             <controls:ControlExample.Example>
                 <NumberBox

--- a/WinUIGallery/Samples/ControlPages/ParallaxViewPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/ParallaxViewPage.xaml
@@ -6,6 +6,10 @@
     xmlns:models="using:WinUIGallery.Models"
     xmlns:pages="using:WinUIGallery.Pages">
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample
             x:Name="Example1"
             Height="750"

--- a/WinUIGallery/Samples/ControlPages/PasswordBoxPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/PasswordBoxPage.xaml
@@ -19,6 +19,10 @@
     mc:Ignorable="d">
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="A simple PasswordBox.">
             <StackPanel>
                 <PasswordBox

--- a/WinUIGallery/Samples/ControlPages/PipsPagerPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/PipsPagerPage.xaml
@@ -8,6 +8,10 @@
     mc:Ignorable="d">
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="PipsPager integrated with a FlipView">
             <controls:ControlExample.Example>
                 <StackPanel>

--- a/WinUIGallery/Samples/ControlPages/ProgressBarPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/ProgressBarPage.xaml
@@ -18,6 +18,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="An indeterminate progress bar.">
 
             <ProgressBar

--- a/WinUIGallery/Samples/ControlPages/ProgressRingPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/ProgressRingPage.xaml
@@ -18,7 +18,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     <StackPanel>
-
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <!--  INDETERMINATE PROGRESS RING  -->
         <controls:ControlExample HeaderText="An indeterminate progress ring.">
             <ProgressRing

--- a/WinUIGallery/Samples/ControlPages/PullToRefreshPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/PullToRefreshPage.xaml
@@ -7,6 +7,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">   
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="Basic PullToRefresh">
             <controls:ControlExample.Example>
                 <Grid>

--- a/WinUIGallery/Samples/ControlPages/RatingControlPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/RatingControlPage.xaml
@@ -7,6 +7,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="A simple RatingControl">
 
             <StackPanel VerticalAlignment="Top">

--- a/WinUIGallery/Samples/ControlPages/RichEditBoxPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/RichEditBoxPage.xaml
@@ -19,7 +19,10 @@
     mc:Ignorable="d">
 
     <StackPanel>
-
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample VerticalAlignment="Top"
                                  HorizontalContentAlignment="Stretch"
                                  HeaderText="A simple text editor using RichEditBox.">

--- a/WinUIGallery/Samples/ControlPages/RichTextBlockPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/RichTextBlockPage.xaml
@@ -18,6 +18,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="A simple RichTextBlock.">
             <controls:ControlExample.Example>
                 <RichTextBlock>

--- a/WinUIGallery/Samples/ControlPages/ScrollViewPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/ScrollViewPage.xaml
@@ -15,6 +15,10 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:WinUIGallery.Controls">
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="Content inside of a ScrollView.">
             <StackPanel Spacing="16">
                 <TextBlock

--- a/WinUIGallery/Samples/ControlPages/SelectorBarPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/SelectorBarPage.xaml
@@ -20,6 +20,10 @@
     </Page.Resources>
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="A Basic SelectorBar">
             <SelectorBar x:Name="SelectorBar1">
                 <SelectorBarItem

--- a/WinUIGallery/Samples/ControlPages/ShapePage.xaml
+++ b/WinUIGallery/Samples/ControlPages/ShapePage.xaml
@@ -19,6 +19,10 @@
     xmlns:wuxdata="using:Microsoft.UI.Xaml.Data"
     mc:Ignorable="d">
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <!--  ELLIPSE SAMPLE  -->
         <controls:ControlExample x:Name="Example1" HeaderText="Ellipse">
             <Ellipse

--- a/WinUIGallery/Samples/ControlPages/SliderPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/SliderPage.xaml
@@ -20,6 +20,10 @@
 
     <!--  SIMPLE SLIDER  -->
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="A simple Slider.">
             <StackPanel Orientation="Horizontal">
                 <Slider

--- a/WinUIGallery/Samples/ControlPages/SoundPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/SoundPage.xaml
@@ -19,6 +19,10 @@
     mc:Ignorable="d">
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="Toggling Sound">
             <ToggleSwitch
                 x:Name="soundToggle"

--- a/WinUIGallery/Samples/ControlPages/SplitButtonPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/SplitButtonPage.xaml
@@ -12,6 +12,10 @@
     </Page.Resources>
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample
             x:Name="Example1"
             HeaderText="A SplitButton controlling text color in a RichEditBox"

--- a/WinUIGallery/Samples/ControlPages/SwipeControlPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/SwipeControlPage.xaml
@@ -26,6 +26,10 @@
         </StackPanel.Resources>
 
         <StackPanel>
+            <StackPanel.ChildrenTransitions>
+                <RepositionThemeTransition />
+            </StackPanel.ChildrenTransitions>
+            
             <controls:ControlExample x:Name="Example1" HeaderText="Swipe right to reveal actions">
                 <controls:ControlExample.Example>
                     <Border>

--- a/WinUIGallery/Samples/ControlPages/SystemBackdropsPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/SystemBackdropsPage.xaml
@@ -20,6 +20,10 @@
     mc:Ignorable="d">
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample
             CSharpSource="SystemBackdrops\SystemBackdropsSampleBackdropTypes_cs.txt"
             HeaderText="Backdrop types"

--- a/WinUIGallery/Samples/ControlPages/TabViewPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/TabViewPage.xaml
@@ -13,6 +13,10 @@
     </Page.Resources>
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample CSharpSource="TabView\TabViewBasicSample_cs.txt" HeaderText="A TabView with support for adding, closing, and rearranging tabs">
             <controls:ControlExample.Example>
                 <TabView

--- a/WinUIGallery/Samples/ControlPages/TeachingTipPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/TeachingTipPage.xaml
@@ -18,6 +18,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample
             CSharpSource="TeachingTip/TeachingTipSample1_cs.txt"
             HeaderText="Show a targeted TeachingTip on a button."

--- a/WinUIGallery/Samples/ControlPages/TextBlockPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/TextBlockPage.xaml
@@ -24,6 +24,10 @@
         </Style>
     </Page.Resources>
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="A simple TextBlock.">
             <controls:ControlExample.Example>
                 <TextBlock Text="I am a TextBlock." />

--- a/WinUIGallery/Samples/ControlPages/TextBoxPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/TextBoxPage.xaml
@@ -18,6 +18,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="A simple TextBox.">
             <TextBox AutomationProperties.Name="simple TextBox" />
             <controls:ControlExample.Xaml>

--- a/WinUIGallery/Samples/ControlPages/ThemeTransitionPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/ThemeTransitionPage.xaml
@@ -8,6 +8,10 @@
     mc:Ignorable="d">
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample HeaderText="Use the EntranceThemeTransition when adding items to your page.">
             <StackPanel x:Name="EntranceStackPanel" Orientation="Horizontal">
                 <StackPanel.ChildrenTransitions>

--- a/WinUIGallery/Samples/ControlPages/TimePickerPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/TimePickerPage.xaml
@@ -19,6 +19,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="A simple TimePicker.">
             <TimePicker />
             <controls:ControlExample.Xaml>

--- a/WinUIGallery/Samples/ControlPages/TitleBarPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/TitleBarPage.xaml
@@ -20,6 +20,10 @@
     xmlns:wuxdata="using:Microsoft.UI.Xaml.Data"
     mc:Ignorable="d">
     <StackPanel Margin="0,12,0,0">
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <RichTextBlock>
             <Paragraph>
                 <Run>For full title bar customization without using the TitleBar control, see the</Run>

--- a/WinUIGallery/Samples/ControlPages/ToggleSwitchPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/ToggleSwitchPage.xaml
@@ -19,6 +19,10 @@
     mc:Ignorable="d">
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="A simple ToggleSwitch.">
             <ToggleSwitch AutomationProperties.Name="simple ToggleSwitch" />
             <controls:ControlExample.Xaml>

--- a/WinUIGallery/Samples/ControlPages/ToolTipPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/ToolTipPage.xaml
@@ -19,6 +19,10 @@
     mc:Ignorable="d">
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample x:Name="Example1" HeaderText="A button with a simple ToolTip.">
             <controls:ControlExample.Example>
                 <Button Content="Button with a simple ToolTip." ToolTipService.ToolTip="Simple ToolTip" />

--- a/WinUIGallery/Samples/ControlPages/TreeViewPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/TreeViewPage.xaml
@@ -40,6 +40,10 @@
     </Page.Resources>
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample CSharpSource="TreeView\TreeViewSample1_cs.txt" HeaderText="A simple TreeView with drag and drop support">
             <controls:ControlExample.Example>
                 <Grid

--- a/WinUIGallery/Samples/ControlPages/XamlCompInteropPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/XamlCompInteropPage.xaml
@@ -8,6 +8,10 @@
     mc:Ignorable="d">
 
     <StackPanel>
+        <StackPanel.ChildrenTransitions>
+            <RepositionThemeTransition />
+        </StackPanel.ChildrenTransitions>
+        
         <controls:ControlExample
             CSharpSource="Motion/AnimationInterop/AnimationInteropSample1_cs.txt"
             HeaderText="Use a natural motion composition animation on a UIElement"


### PR DESCRIPTION
## Description
Added `RepositionThemeTransition` to sample pages with many control examples for smoother layout updates.

## Motivation and Context
Improves visual consistency.

## How Has This Been Tested?
**Manually verified** across affected sample pages to ensure transitions apply correctly without breaking layout.

## Screenshots (if appropriate):
![Screen Recording 2025-09-15 222054](https://github.com/user-attachments/assets/4e44b9b5-208b-4f61-86a2-4cd61e5cae29)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

