### PR TITLE
Replace MainWindow with plain Window in sample projects

### DIFF
--- a/WinUIGallery/Helpers/WindowHelper.cs
+++ b/WinUIGallery/Helpers/WindowHelper.cs
@@ -19,7 +19,7 @@ public partial class WindowHelper
 {
     static public Window CreateWindow()
     {
-        MainWindow newWindow = new MainWindow();
+        var newWindow = new Window();
         TrackWindow(newWindow);
         return newWindow;
     }

--- a/WinUIGallery/Samples/ControlPages/CreateMultipleWindowsPage.xaml.cs
+++ b/WinUIGallery/Samples/ControlPages/CreateMultipleWindowsPage.xaml.cs
@@ -3,8 +3,9 @@
 
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+using Windows.Graphics;
 using WinUIGallery.Helpers;
-using WinUIGallery.Pages;
 
 namespace WinUIGallery.ControlPages;
 
@@ -17,12 +18,29 @@ public sealed partial class CreateMultipleWindowsPage : Page
 
     private void createNewWindow_Click(object sender, RoutedEventArgs e)
     {
-        var newWindow = new MainWindow();
+        var newWindow = new Window
+        {
+            ExtendsContentIntoTitleBar = true,
+            SystemBackdrop = new MicaBackdrop(),
+            Content = new Page
+            {
+                // The TreeHelper is a helper class in the WinUIGallery project
+                // that allows us to find the current theme of the app.
+                RequestedTheme = ThemeHelper.RootTheme,
+                Content = new TextBlock
+                {
+                    Text = "New Window!",
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center,
+                },
+            }
+        };
+
+        newWindow.AppWindow.ResizeClient(new SizeInt32(500, 500));
+
+        // The WindowHelper is a helper class in the WinUIGallery project
+        // that helps us close child windows when the main window closes.
         WindowHelper.TrackWindow(newWindow);
         newWindow.Activate();
-
-        var targetPageType = typeof(HomePage);
-        string targetPageArguments = string.Empty;
-        newWindow.Navigate(targetPageType, targetPageArguments);
     }
 }

--- a/WinUIGallery/Samples/SampleCode/Window/CreateWindowSample1.txt
+++ b/WinUIGallery/Samples/SampleCode/Window/CreateWindowSample1.txt
@@ -1,11 +1,24 @@
-﻿// C# code to create a new window
-var newWindow = WindowHelper.CreateWindow();
-var rootPage = new NavigationRootPage();
-rootPage.RequestedTheme = ThemeHelper.RootTheme;
-newWindow.Content = rootPage;
-newWindow.Activate();
+﻿var childWindow = new Window
+{
+    ExtendsContentIntoTitleBar = true,
+    SystemBackdrop = new MicaBackdrop(),
+    Content = new Page
+    {
+        // The TreeHelper is a helper class in the WinUIGallery project
+        // that allows us to find the current theme of the app.
+        RequestedTheme = ThemeHelper.RootTheme,
+        Content = new TextBlock
+        {
+            Text = "New Window!",
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+        },
+    }
+};
 
-// C# code to navigate in the new window
-var targetPageType = typeof(HomePage);
-string targetPageArguments = string.Empty;
-rootPage.Navigate(targetPageType, targetPageArguments);
+childWindow.AppWindow.ResizeClient(new SizeInt32(500, 500));
+
+// The WindowHelper is a helper class in the WinUIGallery project
+// that helps us close child windows when the main window closes.
+WindowHelper.TrackWindow(childWindow);
+childWindow.Activate();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR updates `WindowHelper.CreateWindow()` to return a plain `Window` instead of `MainWindow`, which was tightly coupled to several static members.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #2062.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested.

## Screenshots (if appropriate):

<img width="1115" height="793" alt="image" src="https://github.com/user-attachments/assets/ecd95d4d-a550-4d58-9a85-ec5243f304f2" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
