### PR TITLE
fix: correct corner radius of options display in ControlExample

### DIFF
--- a/WinUIGallery/Controls/ControlExample.xaml
+++ b/WinUIGallery/Controls/ControlExample.xaml
@@ -149,6 +149,7 @@
                         Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                         BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
                         BorderThickness="1,0,0,0"
+                        CornerRadius="0,8,0,0"
                         Content="{x:Bind Options}"
                         IsTabStop="False"
                         Visibility="{x:Bind Options, Converter={StaticResource nullToVisibilityConverter}}" />


### PR DESCRIPTION
## Screenshots:
Before
<img width="187" height="182" alt="image" src="https://github.com/user-attachments/assets/2a458b81-78e6-4001-badc-4509e5587d44" />
After
<img width="167" height="176" alt="image" src="https://github.com/user-attachments/assets/0aa3c0d2-281d-4070-a9ac-643d3c7b44f9" />

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
