### PR TITLE
Fix `TextBlock` words spacing in TextBlock sample

### DIFF
--- a/WinUIGallery/Samples/ControlPages/TextBlockPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/TextBlockPage.xaml
@@ -76,19 +76,18 @@
                     <Run FontFamily="Times New Roman" Foreground="DarkGray">Text in a TextBlock doesn't have to be a simple string.</Run>
                     <LineBreak />
                     <Span>
-                        Text can be<Bold>bold</Bold>
-                        ,<Italic>italic</Italic>
-                        , or<Underline>underlined</Underline>
-                        .</Span></TextBlock>
+                        Text can be <Bold>bold</Bold>, <Italic>italic</Italic>, or <Underline>underlined</Underline>.
+                    </Span>
+                </TextBlock>
             </controls:ControlExample.Example>
             <controls:ControlExample.Xaml>
                 <x:String xml:space="preserve">
 &lt;TextBlock&gt;
-    &lt;Run FontFamily="Times New Roman" Foreground="DarkGray"&gt;
-        Text in a TextBlock doesn't have to be a simple string.&lt;/Run&gt;
-    &lt;LineBreak/&gt;
-    &lt;Span&gt;Text can be &lt;Bold&gt;bold&lt;/Bold&gt;,
-        &lt;Italic&gt;italic&lt;/Italic&gt;, or &lt;Underline&gt;underlined&lt;/Underline&gt;. &lt;/Span&gt;
+    &lt;Run FontFamily="Times New Roman" Foreground="DarkGray"&gt;Text in a TextBlock doesn't have to be a simple string.&lt;/Run&gt;
+    &lt;LineBreak /&gt;
+    &lt;Span&gt;
+        Text can be &lt;Bold&gt;bold&lt;/Bold&gt;, &lt;Italic&gt;italic&lt;/Italic&gt;, or &lt;Underline&gt;underlined&lt;/Underline&gt;.
+    &lt;/Span&gt;
 &lt;/TextBlock&gt;
                 </x:String>
             </controls:ControlExample.Xaml>


### PR DESCRIPTION
## Motivation and Context
- Fixes #2065

## Screenshots (if appropriate):
<img width="395" height="159" alt="image" src="https://github.com/user-attachments/assets/76caf049-8892-4ac5-b534-b3036708ec59" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
