### PR TITLE
Add TextWrapping to high contrast theme description

### DIFF
--- a/WinUIGallery/Controls/DesignGuidance/ColorSections/HighContrastSection.xaml
+++ b/WinUIGallery/Controls/DesignGuidance/ColorSections/HighContrastSection.xaml
@@ -12,7 +12,7 @@
 
     <!--  Colors section  -->
     <StackPanel Margin="0,12,0,0" Spacing="{StaticResource ColorSectionSpacing}">
-        <TextBlock Text="Below are the default highcontrast themes shown. The brush names are the same, and the OS will chose the right colors based on the selected theme." />
+        <TextBlock Text="Below are the default highcontrast themes shown. The brush names are the same, and the OS will chose the right colors based on the selected theme." TextWrapping="Wrap" />
         <!--  Aquatic  -->
         <TextBlock
             Margin="0,12,0,0"


### PR DESCRIPTION
## Description
I added `TextWrapping="Wrap"` to the TextBox at the top of the high contrast page.

## Motivation and Context
This change will solve issue #2071 (Wrong text wrapping in High Contrast color page).

## How Has This Been Tested?
It wasn't tested, but I think it will be OK.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
