### PR TITLE
Switch icons tags layout from `WrapLayout` to `FlowLayout`

### DIFF
--- a/WinUIGallery/Samples/ControlPages/Design/IconographyPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/Design/IconographyPage.xaml
@@ -19,7 +19,6 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:helpers="using:WinUIGallery.Helpers"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:toolkit="using:CommunityToolkit.WinUI.Controls" 
     xmlns:models="using:WinUIGallery.Models"
     helpers:PageScrollBehaviorHelper.SuppressHostScrolling="True"
     mc:Ignorable="d">

--- a/WinUIGallery/Samples/ControlPages/Design/IconographyPage.xaml.cs
+++ b/WinUIGallery/Samples/ControlPages/Design/IconographyPage.xaml.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using CommunityToolkit.WinUI.Controls;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System;


### PR DESCRIPTION
## Description
Replaced `WrapLayout` with `FlowLayout` for tag display in `IconographyPage`, updating both XAML and code-behind to use `LineSpacing` and `MinItemSpacing` instead of `HorizontalSpacing` and `VerticalSpacing`.

This change may improve the visual arrangement and spacing of tag items.