### PR TITLE
Fix keyboard accessibility for SplitButton color picker flyouts (MAS 2.1.1)

### DIFF
--- a/WinUIGallery/Samples/ControlPages/SplitButtonPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/SplitButtonPage.xaml
@@ -84,7 +84,8 @@
                     MinHeight="0"
                     Padding="5"
                     VerticalAlignment="Top"
-                    AutomationProperties.Name="Font color with text">
+                    AutomationProperties.Name="Font color with text"
+                    Click="myColorButtonReveal_Click">
                     Choose color
                     <SplitButton.Flyout>
                         <Flyout Placement="Bottom">

--- a/WinUIGallery/Samples/ControlPages/SplitButtonPage.xaml.cs
+++ b/WinUIGallery/Samples/ControlPages/SplitButtonPage.xaml.cs
@@ -43,6 +43,11 @@ public sealed partial class SplitButtonPage : Page
         myColorButtonReveal.Flyout.Hide();
     }
 
+    private void myColorButtonReveal_Click(SplitButton sender, SplitButtonClickEventArgs args)
+    {
+        sender.Flyout.ShowAt(sender);
+    }
+
     private void myColorButton_Click(Microsoft.UI.Xaml.Controls.SplitButton sender, Microsoft.UI.Xaml.Controls.SplitButtonClickEventArgs args)
     {
         var border = (Border)sender.Content;
@@ -50,6 +55,8 @@ public sealed partial class SplitButtonPage : Page
 
         myRichEditBox.Document.Selection.CharacterFormat.ForegroundColor = color;
         currentColor = color;
+
+        sender.Flyout.ShowAt(sender);
     }
 
     private void MyRichEditBox_TextChanged(object sender, RoutedEventArgs e)

--- a/WinUIGallery/Samples/SampleCode/Buttons/SplitButton/SplitButtonSample2.txt
+++ b/WinUIGallery/Samples/SampleCode/Buttons/SplitButton/SplitButtonSample2.txt
@@ -1,4 +1,4 @@
-﻿<SplitButton x:Name="myColorButton">
+﻿<SplitButton x:Name="myColorButton" Click="myColorButton_Click">
     Choose color
     <SplitButton.Flyout>
         <Flyout Placement="Bottom">


### PR DESCRIPTION
## Description
Fixed keyboard accessibility for SplitButton color picker flyouts on the SplitButton sample page. Both SplitButton controls ("Font color" and "Choose color") now open their color picker flyouts when activated via keyboard (Enter/Space). Previously, keyboard and assistive technology users could not expand the flyouts to access the color options.

### Changes:
- Added `Click="myColorButtonReveal_Click"` to the "Choose color" SplitButton in XAML
- Added `myColorButtonReveal_Click` handler that programmatically opens the flyout via `sender.Flyout.ShowAt(sender)`
- Updated `myColorButton_Click` to also open the flyout after applying the selected color
- Updated `SplitButtonSample2.txt` sample code to include the `Click` handler for consistency

## Motivation and Context
Keyboard and assistive technology users were unable to expand the color picker flyouts on the SplitButton page. When navigating to either SplitButton and pressing Enter/Space, nothing happened — the flyout would not open, preventing users from selecting a color. This is a violation of **MAS 2.1.1 – Keyboard** (Trap ID: 2.1 - Physical Challenge), which requires all functionality to be operable via keyboard.

## How Has This Been Tested?
- Navigated to the SplitButton page using keyboard only
- Verified that pressing Enter/Space on both SplitButtons opens the color picker flyout
- Verified that color selection still works correctly via both mouse and keyboard
- Confirmed no regressions in existing flyout dismiss behavior

<img width="1342" height="1025" alt="image" src="https://github.com/user-attachments/assets/dd3493ae-1cda-4743-bd2d-685da1d754ad" />


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)