### PR TITLE
Updating icons

### DIFF
--- a/WinUIGallery/Samples/ControlPages/Design/IconographyPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/Design/IconographyPage.xaml
@@ -156,26 +156,20 @@
                                               FontSize="48"
                                               Glyph="{x:Bind SelectedItem.Character, Mode=OneWay}" />
                                 </Border>
-                                <Grid Grid.Column="1"
-                                      HorizontalAlignment="Stretch"
+                                <StackPanel Grid.Column="1"
+                                      Orientation="Horizontal" Margin="0,4,0,0" Spacing="8" VerticalAlignment="Top"
                                       Visibility="{x:Bind SelectedItem.IsSegoeFluentOnly, Mode=OneWay}"
                                       ToolTipService.ToolTip="This icon is only available in Segoe Fluent Icons (the default icon font on Windows 11). On Windows 10, Segoe MDL2 Assets is used by default, so the icon may not appear unless Segoe Fluent Icons is installed.">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition />
-                                    </Grid.ColumnDefinitions>
-                                    <FontIcon FontSize="16"
-                                              Margin="0,6,8,0"
-                                              Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                                    <FontIcon FontSize="12"
+                                              Foreground="{ThemeResource SystemFillColorCautionBrush}"
                                               Glyph="&#xE7BA;"
-                                              VerticalAlignment="Top" />
-                                    <TextBlock Grid.Column="1"
-                                               Margin="0,0,8,0"
+                                              VerticalAlignment="Center" />
+                                    <TextBlock
                                                Text="Only supported in Segoe Fluent Icons"
-                                               TextWrapping="Wrap"
-                                               Foreground="{ThemeResource SystemFillColorCriticalBrush}"
-                                               VerticalAlignment="Top" />
-                                </Grid>
+                                               TextWrapping="Wrap" FontSize="12"
+                                               Foreground="{ThemeResource SystemFillColorCautionBrush}"
+                                               VerticalAlignment="Center" />
+                                </StackPanel>
                             </Grid>
                             <TextBlock
                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"

--- a/WinUIGallery/Samples/Data/IconsData.json
+++ b/WinUIGallery/Samples/Data/IconsData.json
@@ -2020,7 +2020,8 @@
     "Tags": [
       "map",
       "navigation"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "E802",
@@ -4729,7 +4730,8 @@
     "Tags": [
       "clock",
       "time"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "E91B",
@@ -5027,7 +5029,8 @@
       "mini",
       "expand",
       "fullscreen"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "E93C",
@@ -5828,7 +5831,8 @@
       "square",
       "sparkle",
       "ai"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "E9A4",
@@ -6928,7 +6932,8 @@
       "signal",
       "bars",
       "ani1"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EAA2",
@@ -6937,7 +6942,8 @@
       "signal",
       "bars",
       "ani2"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EAA3",
@@ -6946,7 +6952,8 @@
       "signal",
       "bars",
       "ani3"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EAA4",
@@ -6956,7 +6963,8 @@
       "ani1",
       "internet",
       "connectivity"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EAA5",
@@ -6965,7 +6973,8 @@
       "wifi",
       "ani1",
       "connectivity"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EAA8",
@@ -6974,7 +6983,8 @@
       "wifi",
       "ani2",
       "connectivity"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EAAA",
@@ -6983,7 +6993,8 @@
       "emoji",
       "edit",
       "smiley"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EAAE",
@@ -6992,7 +7003,8 @@
       "surface",
       "typecover",
       "keyboard"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EAB7",
@@ -7001,7 +7013,8 @@
       "chat",
       "sparkle",
       "ai"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EABB",
@@ -7011,7 +7024,8 @@
       "flow",
       "vertical",
       "wireframe"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EABC",
@@ -7021,7 +7035,8 @@
       "studio",
       "effects",
       "ai"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EABE",
@@ -7032,7 +7047,8 @@
       "filter",
       "photo",
       "video"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EAC2",
@@ -7104,7 +7120,8 @@
       "captions",
       "sparkle",
       "ai"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EADF",
@@ -7171,7 +7188,8 @@
       "unknown",
       "charging",
       "empty"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EB19",
@@ -7193,7 +7211,8 @@
       "unknown",
       "charging",
       "empty"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EB1D",
@@ -7213,7 +7232,8 @@
     "Tags": [
       "glasses",
       "read"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EB33",
@@ -7223,7 +7243,8 @@
       "square",
       "outer",
       "rectangle"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EB34",
@@ -7232,7 +7253,8 @@
       "status",
       "square",
       "pause"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EB3B",
@@ -7636,7 +7658,8 @@
       "summarize",
       "sparkle",
       "ai"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EB7E",
@@ -8205,7 +8228,8 @@
       "system",
       "in",
       "private"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EBC9",
@@ -8215,7 +8239,8 @@
       "in",
       "private",
       "filled"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EBD2",
@@ -9785,7 +9810,8 @@
       "search",
       "sparkle",
       "looking glass"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "ED39",
@@ -11027,7 +11053,8 @@
       "voice",
       "clock",
       "time"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "EFA5",
@@ -11116,7 +11143,8 @@
       "widget",
       "app",
       "card"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F035",
@@ -11125,7 +11153,8 @@
       "widget",
       "gear",
       "settings"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F036",
@@ -11133,7 +11162,8 @@
     "Tags": [
       "widget",
       "add"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F03D",
@@ -11143,7 +11173,8 @@
       "sparkle",
       "ai",
       "clipboard"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F03E",
@@ -11152,7 +11183,8 @@
       "advanced",
       "paste",
       "clipboard"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F06C",
@@ -11163,7 +11195,8 @@
       "filter",
       "photo",
       "video"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F080",
@@ -12452,7 +12485,8 @@
       "status",
       "diamond",
       "outer"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F179",
@@ -12461,7 +12495,8 @@
       "status",
       "diamond",
       "inner"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F17F",
@@ -12579,7 +12614,8 @@
       "sparkle",
       "ai",
       "selection"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F1BA",
@@ -12589,7 +12625,8 @@
       "sparkle",
       "ai",
       "selection"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F1BB",
@@ -12598,7 +12635,8 @@
       "text",
       "cursor",
       "mouse"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F1BE",
@@ -12606,7 +12644,8 @@
     "Tags": [
       "lasso",
       "selection"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F1CB",
@@ -12640,7 +12679,8 @@
       "sparkle",
       "ai",
       "language"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F1D5",
@@ -12650,7 +12690,8 @@
       "sparkle",
       "ai",
       "list"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F1D6",
@@ -12660,7 +12701,8 @@
       "sparkle",
       "ai",
       "grid"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F1D8",
@@ -12704,7 +12746,8 @@
       "group",
       "grid",
       "selection"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F20C",
@@ -12910,7 +12953,8 @@
       "action",
       "framework",
       "ai"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F27C",
@@ -13035,7 +13079,8 @@
       "restart",
       "reboot",
       "refresh"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F32A",
@@ -13056,7 +13101,8 @@
     "Tags": [
       "emoji",
       "add"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F354",
@@ -13103,7 +13149,8 @@
       "nfc",
       "badge",
       "connectivity"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F3B1",
@@ -13124,7 +13171,8 @@
     "Tags": [
       "like",
       "solid"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F3C0",
@@ -13132,7 +13180,8 @@
     "Tags": [
       "dislike",
       "solid"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F3CC",
@@ -13255,7 +13304,8 @@
       "speed",
       "high",
       "speedometer"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F432",
@@ -13378,7 +13428,8 @@
       "phone",
       "resume",
       "alert"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F473",
@@ -14233,7 +14284,8 @@
     "Tags": [
       "shield",
       "lock"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F5B5",
@@ -14241,7 +14293,8 @@
     "Tags": [
       "chess",
       "game"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F5CA",
@@ -14250,7 +14303,8 @@
       "poi",
       "location",
       "found"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F5E7",
@@ -14823,7 +14877,8 @@
       "sparkle",
       "ai",
       "write"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F6FA",
@@ -14941,7 +14996,8 @@
       "warning",
       "solid",
       "error"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F738",
@@ -15082,7 +15138,8 @@
       "shield",
       "task",
       "check"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F763",
@@ -15342,7 +15399,8 @@
       "learning",
       "tools",
       "book"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F7EC",
@@ -15350,7 +15408,8 @@
     "Tags": [
       "task",
       "clipboard"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F7ED",
@@ -15654,7 +15713,8 @@
       "ai",
       "microphone",
       "audio"
-    ]
+    ],
+    "IsSegoeFluentOnly": true
   },
   {
     "Code": "F8C0",


### PR DESCRIPTION
Closing: #2077

This PR introduces the following changes:

- Removing deprecated icons
- Adding new icons shipping as part of `Segoe Fluent Icons`.
- Adding tags to icons that had no tags
- Changing the Foreground for the 'only works with Segoe Fluent Icons' to `SystemFillColorCautionBrush`
- Replaced the warning `Grid` with a `StackPanel` and made the warning smaller.

<img width="437" height="214" alt="image" src="https://github.com/user-attachments/assets/af898f60-de74-495d-bac2-8c280ff647c7" />


# IconsData.json — Changes Summary

## Icons Removed (2)

| Code | Name |
|------|------|
| E620 | StopSlideShow |
| E72F | BlockedSite |

## Icons Added (60)

| Code | Name | Tags |
|------|------|------|
| E800 | Nav2DMapView | map, navigation |
| E917 | Clock | clock, time |
| E93A | MiniExpand | mini, expand, fullscreen |
| E9A3 | TextBulletListSquareSparkle | text, bullet, list, square, sparkle, ai |
| EAA1 | SignalBarsAni1 | signal, bars, ani1 |
| EAA2 | SignalBarsAni2 | signal, bars, ani2 |
| EAA3 | SignalBarsAni3 | signal, bars, ani3 |
| EAA4 | EthernetAni1 | ethernet, ani1, internet, connectivity |
| EAA5 | WifiAni1 | wifi, ani1, connectivity |
| EAA8 | WifiAni2 | wifi, ani2, connectivity |
| EAAA | EmojiEdit | emoji, edit, smiley |
| EAAE | SurfaceTypecover | surface, typecover, keyboard |
| EAB7 | ChatSparkle | chat, sparkle, ai |
| EABB | CellFlowVertical | cell, flow, vertical, wireframe |
| EABC | WindowsStudioEffects | windows, studio, effects, ai |
| EABE | PortraitBlur | portrait, blur, filter, photo, video |
| EAD8 | LiveCaptionsSparkle | live, captions, sparkle, ai |
| EB17 | MobBatteryUnknownCharging | mob, battery, unknown, charging, empty |
| EB1A | BatteryUnknownCharging | battery, unknown, charging, empty |
| EB25 | Glasses2 | glasses, read |
| EB33 | StatusSquareOuter | status, square, outer, rectangle |
| EB34 | StatusSquarePause | status, square, pause |
| EB78 | SummarizeSparkle | summarize, sparkle, ai |
| EBC8 | SystemInPrivate | system, in, private |
| EBC9 | SystemInPrivateFilled | system, in, private, filled |
| ED37 | SearchSparkle | search, sparkle, looking glass |
| EF91 | PauseDurationVoice | pause, duration, voice, clock, time |
| F034 | Widget | widget, app, card |
| F035 | WidgetGear | widget, gear, settings |
| F036 | WidgetAdd | widget, add |
| F03D | PasteSparkle | paste, sparkle, ai, clipboard |
| F03E | AdvancedPaste | advanced, paste, clipboard |
| F06C | PortraitLight | portrait, light, filter, photo, video |
| F178 | StatusDiamondOuter | status, diamond, outer |
| F179 | StatusDiamondInner | status, diamond, inner |
| F1B9 | LassoSparkle | lasso, sparkle, ai, selection |
| F1BA | SquareSparkle | square, sparkle, ai, selection |
| F1BB | TextCursor2 | text, cursor, mouse |
| F1BE | Lasso | lasso, selection |
| F1D4 | TranslateSparkle | translate, sparkle, ai, language |
| F1D5 | RefineSparkle | refine, sparkle, ai, list |
| F1D6 | ReformatSparkle | reformat, sparkle, ai, grid |
| F207 | GridviewGroup | gridview, group, grid, selection |
| F277 | ActionFramework | action, framework, ai |
| F305 | Restart3 | restart, reboot, refresh |
| F353 | Emoji4 | emoji, add |
| F39B | NFCBadge | nfc, badge, connectivity |
| F3BF | LikeSolid | like, solid |
| F3C0 | DislikeSolid | dislike, solid |
| F42F | SpeedHigh2 | speed, high, speedometer |
| F470 | PhoneResumeAlert | phone, resume, alert |
| F5B4 | ShieldLock | shield, lock |
| F5B5 | Chess | chess, game |
| F5CA | POILocationFound | poi, location, found |
| F6C7 | PenSparkle | pen, sparkle, ai, write |
| F736 | WarningSolid | warning, solid, error |
| F760 | ShieldTask | shield, task, check |
| F7DB | LearningTools | learning, tools, book |
| F7EC | Task | task, clipboard |
| F8B4 | CopilotVoice | copilot, voice, ai, microphone, audio |

## Icons with Tags Updated (109)

Previously had empty tag arrays; tags were added.

| Code | Name | Tags |
|------|------|------|
| E733 | Blocked | blocked, cancel, stop |
| E759 | SIPMove | sip, move |
| E75A | SIPUndock | sip, undock, redock |
| E75B | SIPRedock | sip, redock, taskbar, dock |
| E799 | AspectRatio | aspect, ratio, size |
| E7A1 | Contrast | contrast, brightness, black, white |
| E7AA | PhotoCollection | photo, collection, photos, image |
| E83B | DirectAccess | direct, access, database |
| E911 | DullSound | dull, sound |
| E97C | Type | type, orientation, rotate, square, rectangle |
| E9A4 | TextBulletListSquare | text, bullet, list, square, check |
| EA85 | VolumeDisabled | volume, disabled, audio, speaker |
| EAC7 | DesktopLeafTwo | desktop, leaf, two, computer, pc, device, energy |
| EAD4 | Emojiplay | emoji, play |
| EAD5 | EmojiBrush | emoji, brush |
| EAD6 | EyeTracking | eye, tracking, hello, identity |
| EAD7 | EyeTrackingText | eye, tracking, text, identity |
| EB19 | ClicktoDoOff | clickto, do, off, ai, selection |
| EB1D | ClicktoDo | clickto, do, ai, rectangle, selection |
| EB3B | GenericApp | generic, app, widget, application, title bar, window |
| EB82 | NUIFPStartSlideHand | nuifp, start, slide, hand |
| EB83 | NUIFPStartSlideAction | nuifp, start, slide, action |
| EB84 | NUIFPContinueSlideHand | nuifp, continue, slide, hand |
| EB85 | NUIFPContinueSlideAction | nuifp, continue, slide, action |
| EB86 | NUIFPRollRightHand | nuifp, roll, right, hand |
| EB87 | NUIFPRollRightHandAction | nuifp, roll, right, hand, action |
| EB88 | NUIFPRollLeftHand | nuifp, roll, left, hand |
| EB89 | NUIFPRollLeftAction | nuifp, roll, left, action |
| EB8A | NUIFPPressHand | nuifp, press, hand |
| EB8B | NUIFPPressAction | nuifp, press, action |
| EB8C | NUIFPPressRepeatHand | nuifp, press, repeat, hand |
| EB8D | NUIFPPressRepeatAction | nuifp, press, repeat, action |
| EC09 | Groceries | groceries, bag |
| EC34 | FormatText | format, text, font |
| EC6D | SwipeRevealArt | swipe, reveal, art |
| EC83 | UpdateStatusDot2 | update, status, dot2 |
| EC91 | Uninstall | uninstall, app, application |
| EC9C | CloudNotSynced | cloud, not, synced, cancel |
| ED21 | RestartUpdate2 | restart, update, refresh |
| EDE0 | Strikethrough | strikethrough, text, font |
| EDE5 | PinyinIMELogo | pinyin, ime, logo |
| EE41 | FullHiraganaPrivateMode | full, hiragana, private, mode, shield |
| EE42 | FullKatakanaPrivateMode | full, katakana, private, mode, shield |
| EE43 | HalfAlphaPrivateMode | half, alpha, private, mode, shield |
| EE44 | HalfKatakanaPrivateMode | half, katakana, private, mode, shield |
| EE45 | FullAlphaPrivateMode | full, alpha, private, mode, shield |
| EE7E | FIDOPasskey | fido, passkey |
| EE94 | Wheel | wheel, database, circle |
| EE95 | StopSolid | stop, solid, square, rectangle, filled |
| EEA0 | RAM | ram, memory, device |
| EEA1 | CPU | cpu, processor |
| EF60 | TextEdit | text, edit, font |
| EFDA | AppIconDefaultAdd | app, icon, default, add, application |
| EFFF | CRMScheduleReports | crm, schedule, reports |
| F093 | ButtonA | button, a, controller, xbox |
| F094 | ButtonB | button, b, controller, xbox |
| F095 | ButtonY | button, y, controller, xbox |
| F096 | ButtonX | button x, controller, xbox |
| F0AD | ArrowUp8 | arrow, up |
| F0AE | ArrowDown8 | arrow, down |
| F0AF | ArrowRight8 | arrow, right |
| F0B0 | ArrowLeft8 | arrow, left |
| F112 | ReadOutLoud | read, out, loud |
| F117 | ProjectToDevice | project, device, share, screen |
| F11B | CtrlSpatialRight | ctrl, spatial, right, controller |
| F120 | TaskManagerApp | task, manager, app, performance |
| F136 | StatusCircleOuter | status, circle, outer, filled |
| F137 | StatusCircleInner | status, circle, inner, filled |
| F138 | StatusCircleRing | status, circle, ring |
| F139 | StatusTriangleOuter | status, triangle, outer, filled |
| F13A | StatusTriangleInner | status, triangle, inner, filled |
| F196 | Beaker | beaker, test, experiment, lab |
| F1B1 | PowerButtonUpdate2 | power, button, update, shutdown |
| F1E8 | LeafTwo | leaf, energy, battery |
| F232 | GridViewSmall | grid, view, small, square |
| F27C | Earbudsingle | earbuds, audio |
| F27F | HearingAid | hearing, aid |
| F285 | MobSnooze | mob, snooze |
| F2A3 | MobNotificationBell | mob, notification, bell |
| F2A5 | MobNotificationBellFilled | mob, notification, bell, filled |
| F2A8 | MobSnoozeFilled | mob, snooze, filled |
| F2C7 | BulletedList2 | bulleted, list |
| F2C8 | BulletedList2Mirrored | bulleted, list, mirrored |
| F2D9 | CirclePause | circle, pause, stop |
| F3E7 | CtrlSpatialLeft | ctrl, spatial, left, controller |
| F432 | BatterySaver | battery, saver |
| F4BD | Snooze | snooze, alarm, alert, mute |
| F63C | CircleShapeSolid | circle, shape, solid |
| F67B | Pen | pen, ink, write |
| F683 | TextSelect | text, select |
| F684 | TextNavigate | text, navigate, pan |
| F698 | PinyinIMELogo2 | pinyin, ime |
| F69B | UserRemove | user, remove, person, cancel |
| F6C4 | PhoneScreen | phone, screen, device, share |
| F6C5 | AlertUrgent | alert, urgent, alarm, notification |
| F6C6 | PhoneDesktop | phone, desktop, pc, computer, device |
| F8C0 | VPNOverlay | vpn |
| F8C1 | VPNRoamingOverly | vpn, roaming |
| F8C2 | WifiVPN3 | wifi, vpn |
| F8C3 | WifiVPN4 | wifi, vpn |
| F8C4 | WifiVPN5 | wifi, vpn |
| F8C5 | SignalBarsVPN2 | signal, bars, vpn |
| F8C6 | SignalBarsVPN3 | signal, bars, vpn |
| F8C7 | SignalBarsVPN4 | signal, bars, vpn |
| F8C8 | SignalBarsVPN5 | signal, bars, vpn |
| F8C9 | SignalBarsVPNRoaming3 | signal, bars, vpn, roaming |
| F8CA | SignalBarsVPNRoaming4 | signal, bars, vpn, roaming |
| F8CB | SignalBarsVPNRoaming5 | signal, bars, vpn, roaming |
| F8CC | EthernetVPN | ethernet, vpn, internet, computer, pc |
