### PR TITLE
Add two other NavigationTransitionInfos

### DIFF
--- a/WinUIGallery/Samples/ControlPages/PageTransitionPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/PageTransitionPage.xaml
@@ -1,4 +1,4 @@
-<Page
+﻿<Page
     x:Class="WinUIGallery.ControlPages.PageTransitionPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -47,6 +47,16 @@
                         AutomationProperties.Name="SlideNavigationTransitionInfo From Left"
                         Checked="TransitionRadioButton_Checked"
                         Content="Slide from Left" />
+                    <RadioButton
+                        x:Name="Common"
+                        AutomationProperties.Name="CommonNavigationTransitionInfo"
+                        Checked="TransitionRadioButton_Checked"
+                        Content="Common" />
+                    <RadioButton
+                        x:Name="Continuum"
+                        AutomationProperties.Name="ContinuumNavigationTransitionInfo"
+                        Checked="TransitionRadioButton_Checked"
+                        Content="Continuum" />
                 </RadioButtons>
 
                 <TextBlock Margin="0,12,0,8">Navigate</TextBlock>

--- a/WinUIGallery/Samples/ControlPages/PageTransitionPage.xaml.cs
+++ b/WinUIGallery/Samples/ControlPages/PageTransitionPage.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using Microsoft.UI.Xaml;
@@ -73,6 +73,14 @@ public sealed partial class PageTransitionPage : Page
             {
                 _transitionInfo = new SlideNavigationTransitionInfo() { Effect = SlideNavigationTransitionEffect.FromLeft };
                 pageTransitionString = ", new SlideNavigationTransitionInfo() { Effect = SlideNavigationTransitionEffect.FromLeft }";
+            }
+            else if (senderTransitionString == "Common")
+            {
+                _transitionInfo = new CommonNavigationTransitionInfo();
+            }
+            else if(senderTransitionString == "Continuum")
+            {
+                _transitionInfo = new ContinuumNavigationTransitionInfo();
             }
         }
         else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds other 2 missing [NavigationTransitionInfos](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.media.animation.navigationtransitioninfo?view=windows-app-sdk-1.8) so it's now complete.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manual.

## Screenshots (if appropriate):
![page-transition](https://github.com/user-attachments/assets/a22d9e62-31ed-4986-ac6d-4ad3a990395d)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
