### PR TITLE
Fix TabView windowing sample launch failure

### DIFF
--- a/WinUIGallery/Samples/ControlPages/TabViewPage.xaml.cs
+++ b/WinUIGallery/Samples/ControlPages/TabViewPage.xaml.cs
@@ -268,7 +268,6 @@ public sealed partial class TabViewPage : Page
         newWindow.Content = tabViewSample;
         newWindow.AppWindow.SetIcon("Assets/Tiles/GalleryIcon.ico");
         tabViewSample.LoadDemoData();
-        tabViewSample.SetupWindowMinSize(newWindow);
 
         newWindow.Activate();
     }

--- a/WinUIGallery/Samples/SamplePages/TabViewWindowingSamplePage.xaml.cs
+++ b/WinUIGallery/Samples/SamplePages/TabViewWindowingSamplePage.xaml.cs
@@ -11,8 +11,6 @@ namespace WinUIGallery.SamplePages;
 
 public sealed partial class TabViewWindowingSamplePage : Page
 {
-    private const string DataIdentifier = "MyTabItem";
-    private Win32WindowHelper? win32WindowHelper;
     private Window? tabTearOutWindow = null;
 
     public TabViewWindowingSamplePage()
@@ -20,12 +18,6 @@ public sealed partial class TabViewWindowingSamplePage : Page
         this.InitializeComponent();
 
         Loaded += TabViewWindowingSamplePage_Loaded;
-    }
-
-    public void SetupWindowMinSize(Window window)
-    {
-        win32WindowHelper = new Win32WindowHelper(window);
-        win32WindowHelper.SetWindowMinMaxSize(new Win32WindowHelper.POINT() { x = 500, y = 300 });
     }
 
     private void TabViewWindowingSamplePage_Loaded(object sender, RoutedEventArgs e)
@@ -38,6 +30,9 @@ public sealed partial class TabViewWindowingSamplePage : Page
         currentWindow.ExtendsContentIntoTitleBar = true;
         currentWindow.SetTitleBar(CustomDragRegion);
         CustomDragRegion.MinWidth = 188;
+
+        // Set minimum window size using OverlappedPresenter (requires XamlRoot, so must be done after Loaded).
+        WindowHelper.SetWindowMinSize(currentWindow, 500, 300);
     }
 
     public void LoadDemoData()
@@ -64,7 +59,6 @@ public sealed partial class TabViewWindowingSamplePage : Page
         tabTearOutWindow.ExtendsContentIntoTitleBar = true;
         tabTearOutWindow.Content = newPage;
         tabTearOutWindow.AppWindow.SetIcon("Assets/Tiles/GalleryIcon.ico");
-        newPage.SetupWindowMinSize(tabTearOutWindow);
 
         args.NewWindowId = tabTearOutWindow.AppWindow.Id;
     }


### PR DESCRIPTION
## Description

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot (AI). All changes should be reviewed carefully.

Fixes #2154

The "Click here to launch the sample" button on the TabView page fails to open the windowing sample window.

## Root cause

`TabViewWindowingSamplePage` uses `Win32WindowHelper` to set minimum window size via P/Invoke (`SetWindowLongPtr` to subclass the window procedure). This class uses **static fields** for `oldWndProc` and `newWndProc`, which causes crashes when multiple windows are involved — the same bug that PR #2007 fixed for other pages by introducing `WindowHelper.SetWindowMinSize`.

## Fix

- Replace `Win32WindowHelper.SetWindowMinMaxSize()` with `WindowHelper.SetWindowMinSize()` (uses `OverlappedPresenter.PreferredMinimumWidth/Height`)
- Move the min-size setup to the `Loaded` event handler where `XamlRoot` is available
- Remove the `SetupWindowMinSize` method and its callers
- Remove unused `DataIdentifier` constant and `Win32WindowHelper` field

## Validation

1. Build: `dotnet build WinUIGallery\WinUIGallery.csproj /p:Platform=x64` — 0 errors
2. Navigate to TabView page → click "Click here to launch the sample" → window should open with 3 tabs
3. Try resizing the sample window below 500x300 — it should enforce the minimum size
