### PR TITLE
Improve Mica/Acrylic descriptions on SystemBackdrops page

### DIFF
--- a/WinUIGallery/Samples/ControlPages/SystemBackdropsPage.xaml
+++ b/WinUIGallery/Samples/ControlPages/SystemBackdropsPage.xaml
@@ -26,18 +26,19 @@
             XamlSource="SystemBackdrops\SystemBackdropsSampleBackdropTypes_xaml.txt">
             <StackPanel>
                 <TextBlock TextWrapping="WrapWholeWords">
-                    There are three backdrop types:<LineBreak />
-                    1. SystemBackdrop (The base class of every backdrop type)<LineBreak />
-                    2. MicaBackdrop (A backdrop that uses the Mica material)<LineBreak />
-                    3. DesktopAcrylicBackdrop (A backdrop that uses the Acrylic material)<LineBreak /> <LineBreak />
-                    Mica is an opaque, dynamic material that incorporates theme and desktop wallpaper to paint the background of windows.
-                    Mica is specifically designed for app performance as it only samples the desktop wallpaper once to create its visualization.
-                    Mica Alt is a variant of Mica, with stronger tinting of the user's desktop background. Recommended when creating an app with a tabbed title bar.
-                    All variants of Mica are available for Windows 11 build 22000 or later.<LineBreak /> <LineBreak />
-                    Acrylic is a semi-transparent material that replicates the effect of frosted glass. It's used only for transient, light-dismiss surfaces such as flyouts and context menus.
-                    There are two acrylic blend types that change what's visible through the material:<LineBreak />
-                    Background acrylic reveals the desktop wallpaper and other windows that are behind the currently active app, adding depth between application windows while celebrating the user's personalization preferences.<LineBreak />
-                    In-app acrylic adds a sense of depth within the app frame, providing both focus and hierarchy. (Inplemented with a AcrylicBrush in XAML)</TextBlock>
+                    A window can use one of the following system backdrops:<LineBreak />
+                    1. <Run FontWeight="Bold">Mica</Run> — An opaque material that samples the desktop wallpaper once to tint the window background. Best for main app windows.<LineBreak />
+                    2. <Run FontWeight="Bold">Mica Alt</Run> — A variant of Mica with stronger tinting. Recommended for apps with a tabbed title bar.<LineBreak />
+                    3. <Run FontWeight="Bold">Desktop Acrylic (Base)</Run> — A semi-transparent material that shows a blurred view of the content behind the window.<LineBreak />
+                    4. <Run FontWeight="Bold">Desktop Acrylic (Thin)</Run> — A lighter variant of Desktop Acrylic with more transparency.<LineBreak /><LineBreak />
+                    <Run FontWeight="Bold">Mica vs. Acrylic:</Run> Mica is opaque and renders the desktop wallpaper within the window background.
+                    Desktop Acrylic is semi-transparent and reveals a blurred view of what is behind the window in real-time.
+                    Mica is more performant because it captures the wallpaper only once, while Acrylic updates continuously.<LineBreak /><LineBreak />
+                    There are three backdrop types in the API:<LineBreak />
+                    • <Run FontWeight="Bold">SystemBackdrop</Run> — The base class of every backdrop type.<LineBreak />
+                    • <Run FontWeight="Bold">MicaBackdrop</Run> — Applies the Mica material. Set the Kind property to switch between Base and Alt.<LineBreak />
+                    • <Run FontWeight="Bold">DesktopAcrylicBackdrop</Run> — Applies the Desktop Acrylic material (Base type only).<LineBreak /><LineBreak />
+                    All Mica variants require Windows 11 build 22000 or later. In-app acrylic (AcrylicBrush) is a separate XAML brush used within UI elements, not a window backdrop.</TextBlock>
                 <Button Margin="0,10,0,0" Click="createBuiltInWindow_Click" Content="Show window"/>
             </StackPanel>
         </controls:ControlExample>
@@ -45,11 +46,10 @@
         <controls:ControlExample CSharpSource="SystemBackdrops\SystemBackdropsSampleMicaController.txt" HeaderText="MicaController">
             <StackPanel>
                 <TextBlock TextWrapping="WrapWholeWords">
-                    Manages rendering and system policy for the mica material. The MicaController class provides a very customizable way to apply the Mica material to an app.
-                    This is a list of properties that can be modified: FallbackColor, Kind, LuminosityOpacity, TintColor and the TintOpacity.<LineBreak />
-                    There are 2 types of Mica:<LineBreak />
-                    1. Base (Lighter)<LineBreak />
-                    2. Alt (Darker)<LineBreak />
+                    MicaController provides a customizable way to apply the Mica material. You can modify: FallbackColor, Kind, LuminosityOpacity, TintColor, and TintOpacity.<LineBreak /><LineBreak />
+                    There are 2 kinds of Mica:<LineBreak />
+                    1. <Run FontWeight="Bold">Base</Run> — The default, lighter appearance.<LineBreak />
+                    2. <Run FontWeight="Bold">Alt</Run> — A darker appearance with stronger tinting of the desktop wallpaper.<LineBreak />
                 </TextBlock>
                 <Button Margin="0,10,0,0" Click="createCustomMicaWindow_Click" Content="Show window"/>
             </StackPanel>
@@ -58,11 +58,11 @@
         <controls:ControlExample CSharpSource="SystemBackdrops\SystemBackdropsSampleDesktopAcrylicController.txt" HeaderText="DesktopAcrylicController">
             <StackPanel>
                 <TextBlock TextWrapping="WrapWholeWords">
-                    Manages rendering and system policy for the background acrylic material. Acrylic has the same level of customization as Mica, but the type can't be changed using the DesktopAcrylicBackdrop class.<LineBreak />
-                    There are 2 types of Acrylic:<LineBreak />
-                    1. Base (Darker)<LineBreak />
-                    2. Thin (Lighter)<LineBreak />
-                    If you wan't to use Acrylic Thin in your app you have to use the DesktopAcrylicController class. The DesktopAcrylicBackdrop class uses the Base type.</TextBlock>
+                    DesktopAcrylicController provides a customizable way to apply the Desktop Acrylic material. It supports the same customization properties as MicaController.<LineBreak /><LineBreak />
+                    There are 2 kinds of Desktop Acrylic:<LineBreak />
+                    1. <Run FontWeight="Bold">Base</Run> — The default, darker appearance with less transparency.<LineBreak />
+                    2. <Run FontWeight="Bold">Thin</Run> — A lighter appearance with more transparency.<LineBreak /><LineBreak />
+                    Note: DesktopAcrylicBackdrop always uses the Base kind. To use the Thin kind, you must use DesktopAcrylicController directly.</TextBlock>
                 <Button Margin="0,10,0,0" Click="createCustomDesktopAcrylicWindow_Click" Content="Show window"/>
             </StackPanel>
         </controls:ControlExample>

--- a/WinUIGallery/Samples/Data/ControlInfoData.json
+++ b/WinUIGallery/Samples/Data/ControlInfoData.json
@@ -2585,7 +2585,7 @@
           "ApiNamespace": "Microsoft.UI.Composition.SystemBackdrops",
           "Subtitle": "System backdrops, like Mica and Acrylic, for app windows.",
           "ImagePath": "ms-appx:///Assets/ControlImages/Acrylic.png",
-          "Description": "System backdrops provide a transparency effect for the window background. Mica and Acrylic are the current supported backdrops. There are two options for applying a backdrop: first, to use built-in Mica/Acrylic types, which have no customization and are simple to apply. The second is to create a customizable backdrop, which requires more code.",
+          "Description": "System backdrops apply a material effect to the window background. Mica is opaque and samples the desktop wallpaper; Desktop Acrylic is semi-transparent and shows a blurred view of what is behind the window. Available backdrop kinds: Mica, Mica Alt, Desktop Acrylic Base, and Desktop Acrylic Thin. Use the built-in MicaBackdrop or DesktopAcrylicBackdrop types for simplicity, or use MicaController / DesktopAcrylicController for full customization.",
           "SourcePath": "/Materials",
           "BaseClasses": [
             "Object",


### PR DESCRIPTION
## Description

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot (AI). All changes should be reviewed carefully.

Fixes #1869

Rewrites the SystemBackdrops page descriptions to clearly explain the difference between Mica and Acrylic backdrops.

## Key improvements

- **Lists all 4 backdrop kinds** upfront: Mica, Mica Alt, Desktop Acrylic Base, Desktop Acrylic Thin
- **Adds Mica vs. Acrylic comparison**: Mica is opaque (wallpaper sampled once), Acrylic is semi-transparent (real-time blurred view)
- **Removes misleading text**: Old description said Acrylic is "used only for transient, light-dismiss surfaces" — this is true for in-app AcrylicBrush but not for DesktopAcrylicBackdrop window backdrops
- **Fixes typo**: "Inplemented" → clarified as separate AcrylicBrush concept
- **Uses consistent terminology**: "kinds" instead of "types" to match the API naming (`MicaKind`, `DesktopAcrylicKind`)
- **Updates ControlInfoData.json** description to match

## Files changed

- `SystemBackdropsPage.xaml` — Rewritten all three description TextBlocks
- `ControlInfoData.json` — Updated the Description field for SystemBackdrops

## Validation

1. Build: `dotnet build WinUIGallery\WinUIGallery.csproj /p:Platform=x64` — 0 errors
2. Navigate to System Backdrops page and verify descriptions are readable and accurate
