### PR TITLE
Patching to unblock bumping referenced version of WinUI Gallery

### DIFF
--- a/WinUIGallery/WinUIGallery.csproj
+++ b/WinUIGallery/WinUIGallery.csproj
@@ -142,6 +142,10 @@
     <PackageReference Include="System.Private.Uri" />
 	<ProjectReference Include="..\WinUIGallery.SourceGenerator\WinUIGallery.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(IsInWinUIRepo)' == 'true'">
+    <PackageReference Update="Microsoft.Graphics.Win2D" VersionOverride="$(GraphicsWin2DVersion)" />
+  </ItemGroup>
 	
   <ItemGroup Condition="'$(IsInWinUIRepo)' != 'true'">
     <PackageReference Update="Microsoft.WindowsAppSDK" Version="$(WindowsAppSdkPackageVersion)" />

--- a/tests/WinUIGallery.UnitTests/WinUIGallery.UnitTests.csproj
+++ b/tests/WinUIGallery.UnitTests/WinUIGallery.UnitTests.csproj
@@ -21,6 +21,11 @@
         <SelfContained>true</SelfContained>
     </PropertyGroup>
 
+	<!-- WinUI Repo build support -->
+    <PropertyGroup>
+        <WindowSdkMSIXVersion Condition="'$(WindowSdkMSIXVersion)' == ''">1.7.260316102</WindowSdkMSIXVersion>
+    </PropertyGroup>
+
     <ItemGroup>
         <Page Remove="UnitTestApp.xaml" />
         <ApplicationDefinition Include="UnitTestApp.xaml" />
@@ -33,7 +38,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Windows.SDK.BuildTools.MSIX" Version="1.7.260316102">
+        <PackageReference Include="Microsoft.Windows.SDK.BuildTools.MSIX" Version="$(WindowSdkMSIXVersion)">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
Some changes necessary to ensure bumping referenced WinUI Gallery commit in dependent infrastructure.