### PR TITLE
Disable WindowsAppSdkAutoInitialize for windows 10 compatibility

### DIFF
--- a/WinUIGallery/WinUIGallery.csproj
+++ b/WinUIGallery/WinUIGallery.csproj
@@ -43,6 +43,7 @@
     <ApplicationIcon>Assets\Tiles\GalleryIcon.ico</ApplicationIcon>
     <Nullable>enable</Nullable>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
+	<WindowsAppSdkAutoInitialize>false</WindowsAppSdkAutoInitialize>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Packaged)' != 'true' and '$(SingleProject)'=='true'">


### PR DESCRIPTION
## Description
This PR fixed compatibility for older windows 10 (especially for windows 10 17763, and possibly other old versions above as well)

## Motivation and Context
I found the winui 3 gallery recently (like within one or two months) stopped working recently on my PC with windows 10 17763 (I keep this old version for testing my own winui 3 project).  After some digging, I found #2171 breaks it. Previously the app released to store seems to be packaged with that WAP project, so the `WindowsAppSdkAutoInitialize` is not needed and not affecting the compatibility (but it IS needed for developing winui 3 gallery directly since it is packaged project).

I raised [the issue to wasdk repo, but still does not get a true solution](https://github.com/microsoft/WindowsAppSDK/issues/6117)

## How Has This Been Tested?
Manual.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
