### PR TITLE
Update Windows App SDK to 2.2.0

### DIFF
--- a/standalone.props
+++ b/standalone.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- The NuGet versions of dependencies to build against. -->
     <WindowsSdkPackageVersion>10.0.22621.42</WindowsSdkPackageVersion>
-    <WindowsAppSdkPackageVersion>2.1.3</WindowsAppSdkPackageVersion>
+    <WindowsAppSdkPackageVersion>2.2.0</WindowsAppSdkPackageVersion>
     <MicrosoftNETCoreUniversalWindowsPlatformVersion>6.2.11</MicrosoftNETCoreUniversalWindowsPlatformVersion>
     <GraphicsWin2DVersion>1.4.0</GraphicsWin2DVersion>
     <ColorCodeVersion>2.0.15</ColorCodeVersion>


### PR DESCRIPTION
Update Windows App SDK to 2.2.0
Bump WindowsAppSdkPackageVersion from 2.1.3 to 2.2.0 (latest stable).