### PR TITLE
Add PipsPager.WrapMode option to PipsPager sample

### DIFF
--- a/WinUIGallery/Samples/PipsPager/PipsPagerPage.xaml
+++ b/WinUIGallery/Samples/PipsPager/PipsPagerPage.xaml
@@ -68,12 +68,21 @@
                         <x:String>VisibleOnPointerOver</x:String>
                         <x:String>Collapsed</x:String>
                     </ComboBox>
+                    <ComboBox
+                        x:Name="WrapModeComboBox"
+                        Header="Wrap Mode"
+                        SelectedValue="None"
+                        SelectionChanged="WrapModeComboBox_SelectionChanged">
+                        <x:String>None</x:String>
+                        <x:String>Wrap</x:String>
+                    </ComboBox>
                 </StackPanel>
             </controls:ControlExample.Options>
             <controls:ControlExample.Substitutions>
                 <controls:ControlExampleSubstitution Key="Orientation" Value="{x:Bind OrientationComboBox.SelectedValue, Mode=OneWay}" />
                 <controls:ControlExampleSubstitution Key="PrevButton" Value="{x:Bind PrevButtonComboBox.SelectedValue, Mode=OneWay}" />
                 <controls:ControlExampleSubstitution Key="NextButton" Value="{x:Bind NextButtonComboBox.SelectedValue, Mode=OneWay}" />
+                <controls:ControlExampleSubstitution Key="WrapMode" Value="{x:Bind WrapModeComboBox.SelectedValue, Mode=OneWay}" />
             </controls:ControlExample.Substitutions>
         </controls:ControlExample>
     </StackPanel>

--- a/WinUIGallery/Samples/PipsPager/PipsPagerPage.xaml.cs
+++ b/WinUIGallery/Samples/PipsPager/PipsPagerPage.xaml.cs
@@ -73,6 +73,23 @@ public sealed partial class PipsPagerPage : Page
         }
     }
 
+    private void WrapModeComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        string? wrapMode = e.AddedItems[0].ToString();
+
+        switch (wrapMode)
+        {
+            case "Wrap":
+                TestPipsPager2.WrapMode = PipsPagerWrapMode.Wrap;
+                break;
+
+            case "None":
+            default:
+                TestPipsPager2.WrapMode = PipsPagerWrapMode.None;
+                break;
+        }
+    }
+
     private void NextButtonComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         string? nextButtonVisibility = e.AddedItems[0].ToString();

--- a/WinUIGallery/Samples/PipsPager/PipspagerOptionsChangeOrientation.txt
+++ b/WinUIGallery/Samples/PipsPager/PipspagerOptionsChangeOrientation.txt
@@ -1,7 +1,8 @@
 --- header
-PipsPager with options to change its orientation and button visibility.
+PipsPager with options to change its orientation, button visibility, and wrap mode.
 --- xaml
 <PipsPager
     Orientation="$(Orientation)"
     PreviousButtonVisibility="$(PrevButton)"
-    NextButtonVisibility="$(NextButton)" />
+    NextButtonVisibility="$(NextButton)"
+    WrapMode="$(WrapMode)" />


### PR DESCRIPTION
Addresses [microsoft/microsoft-ui-xaml#10107](https://github.com/microsoft/microsoft-ui-xaml/issues/10107), which flags missing gallery coverage for Windows App SDK 1.6 APIs.

## Changes
- **`PipsPager.WrapMode`** (introduced in WASDK 1.6) — added a new **Wrap Mode** option (None / Wrap) to the existing PipsPager options example, along with the code-behind handler and the `WrapMode="$(WrapMode)"` substitution in the sample snippet.

## Note on `TabView.CanTearOutTabs`
The other API called out in the issue, `TabView.CanTearOutTabs` (also WASDK 1.6), is **already** demonstrated in `TabViewWindowingSamplePage` (launched from the TabView page), including the full tear-out event flow, so no change was needed there.

## Validation
`dotnet build WinUIGallery.csproj -c Debug -p:Platform=x64` succeeds with 0 errors.