### PR TITLE
Fix Canvas slider narrator announcement

### DIFF
--- a/WinUIGallery/Samples/Canvas/CanvasPage.xaml
+++ b/WinUIGallery/Samples/Canvas/CanvasPage.xaml
@@ -83,7 +83,8 @@
                             Header="Canvas.ZIndex"
                             Maximum="4"
                             Minimum="0"
-                            StepFrequency="1" />
+                            StepFrequency="1"
+                            ValueChanged="ZSlider_ValueChanged" />
                     </StackPanel>
                 </StackPanel>
             </controls:ControlExample.Options>

--- a/WinUIGallery/Samples/Canvas/CanvasPage.xaml.cs
+++ b/WinUIGallery/Samples/Canvas/CanvasPage.xaml.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Automation;
 
 namespace WinUIGallery.ControlPages;
 
@@ -10,5 +12,21 @@ public sealed partial class CanvasPage : Page
     public CanvasPage()
     {
         this.InitializeComponent();
+        UpdateZSliderAutomationName();
+    }
+
+    private void ZSlider_ValueChanged(object sender, RangeBaseValueChangedEventArgs e)
+    {
+        UpdateZSliderAutomationName();
+    }
+
+    private void UpdateZSliderAutomationName()
+    {
+        int currentValue = (int)ZSlider.Value;
+        int minimumValue = (int)ZSlider.Minimum;
+        int maximumValue = (int)ZSlider.Maximum;
+
+        string automationName = $"Canvas.ZIndex value {currentValue} of range {minimumValue} to {maximumValue}";
+        AutomationProperties.SetName(ZSlider, automationName);
     }
 }

--- a/tests/WinUIGallery.UnitTests/UnitTests.cs
+++ b/tests/WinUIGallery.UnitTests/UnitTests.cs
@@ -4,6 +4,7 @@
 using Microsoft.UI;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Media;
@@ -16,6 +17,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Windows.Foundation;
+using WinUIGallery.ControlPages;
 using WinUIGallery.Helpers;
 
 namespace WinUIGallery.UnitTests;
@@ -96,6 +98,29 @@ public class UnitTests
             var actualLayout = LayoutInformation.GetLayoutSlot(wrapPanel.Children[i] as FrameworkElement);
             Assert.AreEqual(expectedLayouts[i], actualLayout);
         }
+    }
+
+    [UITestMethod]
+    public void TestCanvasZSliderAutomationNameIncludesCurrentValueAndRange()
+    {
+        CanvasPage canvasPage = new();
+
+        UnitTestApp.UnitTestAppWindow.AddToVisualTree(canvasPage);
+        canvasPage.UpdateLayout();
+
+        Slider zSlider = canvasPage.FindName("ZSlider") as Slider;
+        Assert.IsNotNull(zSlider);
+
+        string expectedName = "Canvas.ZIndex value 0 of range 0 to 4";
+        string actualName = AutomationProperties.GetName(zSlider);
+        Assert.AreEqual(expectedName, actualName);
+
+        zSlider.Value = 3;
+        canvasPage.UpdateLayout();
+
+        expectedName = "Canvas.ZIndex value 3 of range 0 to 4";
+        actualName = AutomationProperties.GetName(zSlider);
+        Assert.AreEqual(expectedName, actualName);
     }
 
     // This test demonstrates executing test code both on and off the UI thread.

--- a/tests/WinUIGallery.UnitTests/UnitTests.cs
+++ b/tests/WinUIGallery.UnitTests/UnitTests.cs
@@ -111,16 +111,12 @@ public class UnitTests
         Slider zSlider = canvasPage.FindName("ZSlider") as Slider;
         Assert.IsNotNull(zSlider);
 
-        string expectedName = "Canvas.ZIndex value 0 of range 0 to 4";
-        string actualName = AutomationProperties.GetName(zSlider);
-        Assert.AreEqual(expectedName, actualName);
+        Assert.AreEqual("Canvas.ZIndex value 0 of range 0 to 4", AutomationProperties.GetName(zSlider));
 
         zSlider.Value = 3;
         canvasPage.UpdateLayout();
 
-        expectedName = "Canvas.ZIndex value 3 of range 0 to 4";
-        actualName = AutomationProperties.GetName(zSlider);
-        Assert.AreEqual(expectedName, actualName);
+        Assert.AreEqual("Canvas.ZIndex value 3 of range 0 to 4", AutomationProperties.GetName(zSlider));
     }
 
     // This test demonstrates executing test code both on and off the UI thread.


### PR DESCRIPTION
This PR fixes the screen reader announcemnet when we click on Canvas.ZIndex on Canvas in WInUI3 Gallery app.
Fixes : https://dev.azure.com/microsoft/OS/_workitems/edit/61665131

## Description
When performed below 
Repro-Steps:

Launch the WinUI 3 Gallery app.
Navigate to search box using tab key.
Type Canvas and hit enter.
Navigate to 'Canvas' button and invoke it.
Navigate to 'Canvas.ZIndex' slider.
Now adjust the slider values using arrow keys and listen to screen reader announcement.


##Actual Result:

The narrator is announcing slider size as percentage instead of announcing the actual size as visible.

##Expected Result:
Screen reader should announce the actual size along with minimum and maximum sizes.

## Motivation and Context
Users who rely on screen readers will find it a bit odd as the screen reader is announcing as percentage instead of actual size

## How Has This Been Tested?
Ran the command to make sure build is passing
dotnet build WinUIGallery/WinUIGallery.csproj -p:Platform=x64

Built and launched the WinUI-Gallery/WInUIGallery.slnx

## Screenshots (if appropriate):
Before:

https://github.com/user-attachments/assets/e0101e60-3584-4a15-8e0c-602fa8723b75



Ater


https://github.com/user-attachments/assets/60528b99-62ab-44de-a99d-450eb2f5d534





## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
