### PR TITLE
Fix keyboard navigation for ConnectedAnimation ItemsRepeater sample

### DIFF
--- a/WinUIGallery/SampleSupport/SamplePages/ItemsRepeaterCollectionPage.xaml
+++ b/WinUIGallery/SampleSupport/SamplePages/ItemsRepeaterCollectionPage.xaml
@@ -28,43 +28,31 @@
             <ItemsRepeater.ItemTemplate>
                 <DataTemplate>
                     <!--
-                        ItemsRepeater has no built-in focus or selection, so each item is hosted in a Button.
-                        This makes the items keyboard-focusable, invokable with Enter/Space, and exposes an
-                        Invoke automation pattern for Narrator. The Button chrome is made transparent so the
-                        visuals stay identical to the previous Grid-based template.
+                        ItemsRepeater has no built-in focus or selection, but IsTabStop and the
+                        keyboard events live on UIElement, so the item's own Grid can be made
+                        keyboard-focusable directly - no Button wrapper needed. Arrow keys move
+                        between items (XYFocusKeyboardNavigation above); Enter/Space and pointer
+                        activate the focused item (handled in code-behind).
                     -->
-                    <Button
+                    <Grid
                         AutomationProperties.Name="{Binding Title}"
-                        Background="Transparent"
-                        BorderThickness="0"
                         CornerRadius="4"
-                        HorizontalAlignment="Stretch"
-                        HorizontalContentAlignment="Stretch"
-                        Padding="0"
-                        VerticalAlignment="Stretch"
-                        VerticalContentAlignment="Stretch">
-                        <Button.Resources>
-                            <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="Transparent" />
-                            <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="Transparent" />
-                            <SolidColorBrush x:Key="ButtonBorderBrushPointerOver" Color="Transparent" />
-                            <SolidColorBrush x:Key="ButtonBorderBrushPressed" Color="Transparent" />
-                        </Button.Resources>
-                        <Grid CornerRadius="4">
-                            <Image
-                                x:Name="connectedElement"
-                                Source="{Binding ImageLocation}"
-                                Stretch="UniformToFill" />
-                            <Border
-                                VerticalAlignment="Bottom"
-                                Background="{ThemeResource AcrylicBackgroundFillColorBaseBrush}"
-                                Padding="8,4">
-                                <TextBlock
-                                    Style="{ThemeResource CaptionTextBlockStyle}"
-                                    Text="{Binding Title}"
-                                    Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
-                            </Border>
-                        </Grid>
-                    </Button>
+                        IsTabStop="True"
+                        UseSystemFocusVisuals="True">
+                        <Image
+                            x:Name="connectedElement"
+                            Source="{Binding ImageLocation}"
+                            Stretch="UniformToFill" />
+                        <Border
+                            VerticalAlignment="Bottom"
+                            Background="{ThemeResource AcrylicBackgroundFillColorBaseBrush}"
+                            Padding="8,4">
+                            <TextBlock
+                                Style="{ThemeResource CaptionTextBlockStyle}"
+                                Text="{Binding Title}"
+                                Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
+                        </Border>
+                    </Grid>
                 </DataTemplate>
             </ItemsRepeater.ItemTemplate>
         </ItemsRepeater>

--- a/WinUIGallery/SampleSupport/SamplePages/ItemsRepeaterCollectionPage.xaml
+++ b/WinUIGallery/SampleSupport/SamplePages/ItemsRepeaterCollectionPage.xaml
@@ -8,7 +8,8 @@
 
     <ScrollViewer x:Name="scrollViewer">
         <ItemsRepeater
-            x:Name="repeater">
+            x:Name="repeater"
+            XYFocusKeyboardNavigation="Enabled">
             <ItemsRepeater.Layout>
                 <UniformGridLayout
                     MinColumnSpacing="8"
@@ -18,23 +19,44 @@
             </ItemsRepeater.Layout>
             <ItemsRepeater.ItemTemplate>
                 <DataTemplate>
-                    <Grid
+                    <!--
+                        ItemsRepeater has no built-in focus or selection, so each item is hosted in a Button.
+                        This makes the items keyboard-focusable, invokable with Enter/Space, and exposes an
+                        Invoke automation pattern for Narrator. The Button chrome is made transparent so the
+                        visuals stay identical to the previous Grid-based template.
+                    -->
+                    <Button
+                        AutomationProperties.Name="{Binding Title}"
+                        Background="Transparent"
+                        BorderThickness="0"
                         CornerRadius="4"
-                        AutomationProperties.Name="{Binding Title}">
-                        <Image
-                            x:Name="connectedElement"
-                            Source="{Binding ImageLocation}"
-                            Stretch="UniformToFill" />
-                        <Border
-                            VerticalAlignment="Bottom"
-                            Background="{ThemeResource AcrylicBackgroundFillColorBaseBrush}"
-                            Padding="8,4">
-                            <TextBlock
-                                Style="{ThemeResource CaptionTextBlockStyle}"
-                                Text="{Binding Title}"
-                                Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
-                        </Border>
-                    </Grid>
+                        HorizontalAlignment="Stretch"
+                        HorizontalContentAlignment="Stretch"
+                        Padding="0"
+                        VerticalAlignment="Stretch"
+                        VerticalContentAlignment="Stretch">
+                        <Button.Resources>
+                            <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="Transparent" />
+                            <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="Transparent" />
+                            <SolidColorBrush x:Key="ButtonBorderBrushPointerOver" Color="Transparent" />
+                            <SolidColorBrush x:Key="ButtonBorderBrushPressed" Color="Transparent" />
+                        </Button.Resources>
+                        <Grid CornerRadius="4">
+                            <Image
+                                x:Name="connectedElement"
+                                Source="{Binding ImageLocation}"
+                                Stretch="UniformToFill" />
+                            <Border
+                                VerticalAlignment="Bottom"
+                                Background="{ThemeResource AcrylicBackgroundFillColorBaseBrush}"
+                                Padding="8,4">
+                                <TextBlock
+                                    Style="{ThemeResource CaptionTextBlockStyle}"
+                                    Text="{Binding Title}"
+                                    Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
+                            </Border>
+                        </Grid>
+                    </Button>
                 </DataTemplate>
             </ItemsRepeater.ItemTemplate>
         </ItemsRepeater>

--- a/WinUIGallery/SampleSupport/SamplePages/ItemsRepeaterCollectionPage.xaml
+++ b/WinUIGallery/SampleSupport/SamplePages/ItemsRepeaterCollectionPage.xaml
@@ -6,7 +6,15 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <ScrollViewer x:Name="scrollViewer">
+    <!--
+        TabFocusNavigation="Once" makes the whole repeater a single tab stop: Tab moves focus
+        into the group once (and the next Tab moves out), so Tab no longer steps through every
+        item. Navigation between items is done with the arrow keys via the ItemsRepeater's
+        XYFocusKeyboardNavigation="Enabled" below.
+    -->
+    <ScrollViewer
+        x:Name="scrollViewer"
+        TabFocusNavigation="Once">
         <ItemsRepeater
             x:Name="repeater"
             XYFocusKeyboardNavigation="Enabled">

--- a/WinUIGallery/SampleSupport/SamplePages/ItemsRepeaterCollectionPage.xaml.cs
+++ b/WinUIGallery/SampleSupport/SamplePages/ItemsRepeaterCollectionPage.xaml.cs
@@ -28,8 +28,6 @@ public sealed partial class ItemsRepeaterCollectionPage : Page
 
     private void Repeater_ElementPrepared(ItemsRepeater sender, ItemsRepeaterElementPreparedEventArgs args)
     {
-        // The item's Grid is itself the focusable element (IsTabStop is set in the template), so no
-        // Button wrapper is needed. Wire pointer (Tapped) and keyboard (Enter/Space) activation on it.
         args.Element.Tapped -= Item_Tapped;
         args.Element.Tapped += Item_Tapped;
         args.Element.KeyDown -= Item_KeyDown;

--- a/WinUIGallery/SampleSupport/SamplePages/ItemsRepeaterCollectionPage.xaml.cs
+++ b/WinUIGallery/SampleSupport/SamplePages/ItemsRepeaterCollectionPage.xaml.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Animation;
 using Microsoft.UI.Xaml.Navigation;
@@ -27,12 +26,16 @@ public sealed partial class ItemsRepeaterCollectionPage : Page
 
     private void Repeater_ElementPrepared(ItemsRepeater sender, ItemsRepeaterElementPreparedEventArgs args)
     {
-        // Attach a Tapped handler to each item container so we can navigate on click.
-        args.Element.Tapped -= Item_Tapped;
-        args.Element.Tapped += Item_Tapped;
+        // Each item is hosted in a Button (see the DataTemplate) so it is keyboard-focusable and can be
+        // invoked with Enter/Space as well as the pointer. Wire the Click handler on the realized container.
+        if (args.Element is Button button)
+        {
+            button.Click -= Item_Click;
+            button.Click += Item_Click;
+        }
     }
 
-    private void Item_Tapped(object sender, TappedRoutedEventArgs e)
+    private void Item_Click(object sender, RoutedEventArgs e)
     {
         if (sender is not FrameworkElement element)
         {
@@ -68,21 +71,33 @@ public sealed partial class ItemsRepeaterCollectionPage : Page
         scrollViewer.ChangeView(null, _persistedScrollPosition, null, disableAnimation: true);
         UpdateLayout();
 
+        // Find the element for the stored item so we can run the back animation and restore focus to it.
+        int index = repeater.ItemsSourceView.IndexOf(_storedItem);
+        var container = repeater.TryGetElement(index) as FrameworkElement;
+
         ConnectedAnimation animation = ConnectedAnimationService.GetForCurrentView().GetAnimation("BackConnectedAnimation");
         if (animation != null)
         {
             animation.Configuration = new DirectConnectedAnimationConfiguration();
 
-            // Find the element for the stored item and start the back animation.
-            int index = repeater.ItemsSourceView.IndexOf(_storedItem);
-            if (repeater.TryGetElement(index) is FrameworkElement container
+            // Start the back animation from the target element inside the item's template.
+            if (container != null
                 && FindChildByName(container, "connectedElement") is UIElement animationTarget)
             {
                 animation.TryStart(animationTarget);
             }
         }
 
-        repeater.Focus(FocusState.Programmatic);
+        // Return keyboard focus to the item the user activated so keyboard and Narrator users
+        // resume from where they left off instead of losing their place.
+        if (container is Control itemContainer)
+        {
+            itemContainer.Focus(FocusState.Programmatic);
+        }
+        else
+        {
+            repeater.Focus(FocusState.Programmatic);
+        }
     }
 
     /// <summary>

--- a/WinUIGallery/SampleSupport/SamplePages/ItemsRepeaterCollectionPage.xaml.cs
+++ b/WinUIGallery/SampleSupport/SamplePages/ItemsRepeaterCollectionPage.xaml.cs
@@ -3,9 +3,11 @@
 
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Animation;
 using Microsoft.UI.Xaml.Navigation;
+using Windows.System;
 using WinUIGallery.ControlPages;
 
 namespace WinUIGallery.SamplePages;
@@ -26,18 +28,32 @@ public sealed partial class ItemsRepeaterCollectionPage : Page
 
     private void Repeater_ElementPrepared(ItemsRepeater sender, ItemsRepeaterElementPreparedEventArgs args)
     {
-        // Each item is hosted in a Button (see the DataTemplate) so it is keyboard-focusable and can be
-        // invoked with Enter/Space as well as the pointer. Wire the Click handler on the realized container.
-        if (args.Element is Button button)
+        // The item's Grid is itself the focusable element (IsTabStop is set in the template), so no
+        // Button wrapper is needed. Wire pointer (Tapped) and keyboard (Enter/Space) activation on it.
+        args.Element.Tapped -= Item_Tapped;
+        args.Element.Tapped += Item_Tapped;
+        args.Element.KeyDown -= Item_KeyDown;
+        args.Element.KeyDown += Item_KeyDown;
+    }
+
+    private void Item_Tapped(object sender, TappedRoutedEventArgs e)
+    {
+        NavigateToItem(sender as FrameworkElement);
+    }
+
+    private void Item_KeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        // Activate the focused item with Enter or Space, matching list-style keyboard behavior.
+        if (e.Key == VirtualKey.Enter || e.Key == VirtualKey.Space)
         {
-            button.Click -= Item_Click;
-            button.Click += Item_Click;
+            NavigateToItem(sender as FrameworkElement);
+            e.Handled = true;
         }
     }
 
-    private void Item_Click(object sender, RoutedEventArgs e)
+    private void NavigateToItem(FrameworkElement element)
     {
-        if (sender is not FrameworkElement element)
+        if (element == null)
         {
             return;
         }
@@ -89,10 +105,11 @@ public sealed partial class ItemsRepeaterCollectionPage : Page
         }
 
         // Return keyboard focus to the item the user activated so keyboard and Narrator users
-        // resume from where they left off instead of losing their place.
-        if (container is Control itemContainer)
+        // resume from where they left off instead of losing their place. Focus() is available on
+        // the Grid because it is a UIElement with IsTabStop set in the template.
+        if (container != null)
         {
-            itemContainer.Focus(FocusState.Programmatic);
+            container.Focus(FocusState.Programmatic);
         }
         else
         {

--- a/WinUIGallery/Samples/ConnectedAnimation/ConnectedAnimationItemsrepeater.txt
+++ b/WinUIGallery/Samples/ConnectedAnimation/ConnectedAnimationItemsrepeater.txt
@@ -7,7 +7,8 @@ Connected animation with ItemsRepeater
 <ScrollViewer x:Name="scrollViewer">
     <ItemsRepeater
         x:Name="repeater"
-        ItemsSource="{x:Bind Items}">
+        ItemsSource="{x:Bind Items}"
+        XYFocusKeyboardNavigation="Enabled">
         <ItemsRepeater.Layout>
             <UniformGridLayout
                 MinColumnSpacing="8"
@@ -17,18 +18,37 @@ Connected animation with ItemsRepeater
         </ItemsRepeater.Layout>
         <ItemsRepeater.ItemTemplate>
             <DataTemplate x:DataType="local:CustomDataObject">
-                <Grid CornerRadius="4">
-                    <!-- The element named "connectedElement" will be animated -->
-                    <Image x:Name="connectedElement"
-                           Source="{x:Bind ImageLocation}"
-                           Stretch="UniformToFill" />
-                    <Border VerticalAlignment="Bottom"
-                            Background="{ThemeResource AcrylicBackgroundFillColorBaseBrush}"
-                            Padding="8,4">
-                        <TextBlock Text="{x:Bind Title}"
-                                   Style="{ThemeResource CaptionTextBlockStyle}" />
-                    </Border>
-                </Grid>
+                <!-- ItemsRepeater has no built-in focus/selection, so host each item in a
+                     Button to make it keyboard-focusable and invokable with Enter/Space.
+                     The Button chrome is transparent so the visuals are unchanged. -->
+                <Button AutomationProperties.Name="{x:Bind Title}"
+                        Background="Transparent"
+                        BorderThickness="0"
+                        CornerRadius="4"
+                        Padding="0"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Stretch"
+                        HorizontalContentAlignment="Stretch"
+                        VerticalContentAlignment="Stretch">
+                    <Button.Resources>
+                        <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="Transparent" />
+                        <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="Transparent" />
+                        <SolidColorBrush x:Key="ButtonBorderBrushPointerOver" Color="Transparent" />
+                        <SolidColorBrush x:Key="ButtonBorderBrushPressed" Color="Transparent" />
+                    </Button.Resources>
+                    <Grid CornerRadius="4">
+                        <!-- The element named "connectedElement" will be animated -->
+                        <Image x:Name="connectedElement"
+                               Source="{x:Bind ImageLocation}"
+                               Stretch="UniformToFill" />
+                        <Border VerticalAlignment="Bottom"
+                                Background="{ThemeResource AcrylicBackgroundFillColorBaseBrush}"
+                                Padding="8,4">
+                            <TextBlock Text="{x:Bind Title}"
+                                       Style="{ThemeResource CaptionTextBlockStyle}" />
+                        </Border>
+                    </Grid>
+                </Button>
             </DataTemplate>
         </ItemsRepeater.ItemTemplate>
     </ItemsRepeater>
@@ -43,12 +63,15 @@ private double _persistedScrollPosition;
 
 private void Repeater_ElementPrepared(ItemsRepeater sender, ItemsRepeaterElementPreparedEventArgs args)
 {
-    // Attach a Tapped handler to each item container.
-    args.Element.Tapped -= Item_Tapped;
-    args.Element.Tapped += Item_Tapped;
+    // Each item is a Button, so it is keyboard-focusable and invokable with Enter/Space.
+    if (args.Element is Button button)
+    {
+        button.Click -= Item_Click;
+        button.Click += Item_Click;
+    }
 }
 
-private void Item_Tapped(object sender, TappedRoutedEventArgs e)
+private void Item_Click(object sender, RoutedEventArgs e)
 {
     var element = sender as FrameworkElement;
     _storedItem = repeater.ItemsSourceView.GetAt(
@@ -77,19 +100,27 @@ protected override void OnNavigatedTo(NavigationEventArgs e)
     scrollViewer.ChangeView(null, _persistedScrollPosition, null, true);
     UpdateLayout();
 
+    int index = repeater.ItemsSourceView.IndexOf(_storedItem);
+    var container = repeater.TryGetElement(index) as FrameworkElement;
+
     var animation = ConnectedAnimationService.GetForCurrentView()
         .GetAnimation("BackConnectedAnimation");
     if (animation != null)
     {
         animation.Configuration = new DirectConnectedAnimationConfiguration();
 
-        int index = repeater.ItemsSourceView.IndexOf(_storedItem);
-        if (repeater.TryGetElement(index) is FrameworkElement container
+        if (container != null
             && FindChildByName(container, "connectedElement") is UIElement target)
         {
             animation.TryStart(target);
         }
     }
+
+    // Return keyboard focus to the activated item for keyboard/Narrator users.
+    if (container is Control itemContainer)
+        itemContainer.Focus(FocusState.Programmatic);
+    else
+        repeater.Focus(FocusState.Programmatic);
 }
 
 // Helper to find a named element within a DataTemplate.

--- a/WinUIGallery/Samples/ConnectedAnimation/ConnectedAnimationItemsrepeater.txt
+++ b/WinUIGallery/Samples/ConnectedAnimation/ConnectedAnimationItemsrepeater.txt
@@ -4,7 +4,12 @@ Connected animation with ItemsRepeater
 <!-- Unlike ListView/GridView, ItemsRepeater does not have built-in
      ConnectedAnimation methods. Use ConnectedAnimationService directly. -->
 
-<ScrollViewer x:Name="scrollViewer">
+<!-- TabFocusNavigation="Once" makes the repeater a single tab stop, so Tab enters the group
+     once instead of stepping through every item. Arrow keys move between items via the
+     ItemsRepeater's XYFocusKeyboardNavigation="Enabled". -->
+<ScrollViewer
+    x:Name="scrollViewer"
+    TabFocusNavigation="Once">
     <ItemsRepeater
         x:Name="repeater"
         ItemsSource="{x:Bind Items}"

--- a/WinUIGallery/Samples/ConnectedAnimation/ConnectedAnimationItemsrepeater.txt
+++ b/WinUIGallery/Samples/ConnectedAnimation/ConnectedAnimationItemsrepeater.txt
@@ -23,37 +23,25 @@ Connected animation with ItemsRepeater
         </ItemsRepeater.Layout>
         <ItemsRepeater.ItemTemplate>
             <DataTemplate x:DataType="local:CustomDataObject">
-                <!-- ItemsRepeater has no built-in focus/selection, so host each item in a
-                     Button to make it keyboard-focusable and invokable with Enter/Space.
-                     The Button chrome is transparent so the visuals are unchanged. -->
-                <Button AutomationProperties.Name="{x:Bind Title}"
-                        Background="Transparent"
-                        BorderThickness="0"
-                        CornerRadius="4"
-                        Padding="0"
-                        HorizontalAlignment="Stretch"
-                        VerticalAlignment="Stretch"
-                        HorizontalContentAlignment="Stretch"
-                        VerticalContentAlignment="Stretch">
-                    <Button.Resources>
-                        <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="Transparent" />
-                        <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="Transparent" />
-                        <SolidColorBrush x:Key="ButtonBorderBrushPointerOver" Color="Transparent" />
-                        <SolidColorBrush x:Key="ButtonBorderBrushPressed" Color="Transparent" />
-                    </Button.Resources>
-                    <Grid CornerRadius="4">
-                        <!-- The element named "connectedElement" will be animated -->
-                        <Image x:Name="connectedElement"
-                               Source="{x:Bind ImageLocation}"
-                               Stretch="UniformToFill" />
-                        <Border VerticalAlignment="Bottom"
-                                Background="{ThemeResource AcrylicBackgroundFillColorBaseBrush}"
-                                Padding="8,4">
-                            <TextBlock Text="{x:Bind Title}"
-                                       Style="{ThemeResource CaptionTextBlockStyle}" />
-                        </Border>
-                    </Grid>
-                </Button>
+                <!-- ItemsRepeater has no built-in focus/selection, but IsTabStop and the keyboard
+                     events live on UIElement, so the item's Grid can be made keyboard-focusable
+                     directly - no Button needed. Arrow keys move between items; Enter/Space and
+                     pointer activate the focused item (see code-behind). -->
+                <Grid AutomationProperties.Name="{x:Bind Title}"
+                      CornerRadius="4"
+                      IsTabStop="True"
+                      UseSystemFocusVisuals="True">
+                    <!-- The element named "connectedElement" will be animated -->
+                    <Image x:Name="connectedElement"
+                           Source="{x:Bind ImageLocation}"
+                           Stretch="UniformToFill" />
+                    <Border VerticalAlignment="Bottom"
+                            Background="{ThemeResource AcrylicBackgroundFillColorBaseBrush}"
+                            Padding="8,4">
+                        <TextBlock Text="{x:Bind Title}"
+                                   Style="{ThemeResource CaptionTextBlockStyle}" />
+                    </Border>
+                </Grid>
             </DataTemplate>
         </ItemsRepeater.ItemTemplate>
     </ItemsRepeater>
@@ -68,17 +56,33 @@ private double _persistedScrollPosition;
 
 private void Repeater_ElementPrepared(ItemsRepeater sender, ItemsRepeaterElementPreparedEventArgs args)
 {
-    // Each item is a Button, so it is keyboard-focusable and invokable with Enter/Space.
-    if (args.Element is Button button)
+    // The item's Grid is itself focusable (IsTabStop in the template), so no Button is needed.
+    // Wire pointer (Tapped) and keyboard (Enter/Space) activation on it.
+    args.Element.Tapped -= Item_Tapped;
+    args.Element.Tapped += Item_Tapped;
+    args.Element.KeyDown -= Item_KeyDown;
+    args.Element.KeyDown += Item_KeyDown;
+}
+
+private void Item_Tapped(object sender, TappedRoutedEventArgs e)
+{
+    NavigateToItem(sender as FrameworkElement);
+}
+
+private void Item_KeyDown(object sender, KeyRoutedEventArgs e)
+{
+    // Activate the focused item with Enter or Space, matching list-style keyboard behavior.
+    if (e.Key == VirtualKey.Enter || e.Key == VirtualKey.Space)
     {
-        button.Click -= Item_Click;
-        button.Click += Item_Click;
+        NavigateToItem(sender as FrameworkElement);
+        e.Handled = true;
     }
 }
 
-private void Item_Click(object sender, RoutedEventArgs e)
+private void NavigateToItem(FrameworkElement element)
 {
-    var element = sender as FrameworkElement;
+    if (element == null) return;
+
     _storedItem = repeater.ItemsSourceView.GetAt(
         repeater.GetElementIndex(element)) as CustomDataObject;
 
@@ -122,8 +126,9 @@ protected override void OnNavigatedTo(NavigationEventArgs e)
     }
 
     // Return keyboard focus to the activated item for keyboard/Narrator users.
-    if (container is Control itemContainer)
-        itemContainer.Focus(FocusState.Programmatic);
+    // Focus() is available because the Grid is a UIElement with IsTabStop set.
+    if (container != null)
+        container.Focus(FocusState.Programmatic);
     else
         repeater.Focus(FocusState.Programmatic);
 }

--- a/WinUIGallery/Samples/ConnectedAnimation/ConnectedAnimationItemsrepeater.txt
+++ b/WinUIGallery/Samples/ConnectedAnimation/ConnectedAnimationItemsrepeater.txt
@@ -23,10 +23,6 @@ Connected animation with ItemsRepeater
         </ItemsRepeater.Layout>
         <ItemsRepeater.ItemTemplate>
             <DataTemplate x:DataType="local:CustomDataObject">
-                <!-- ItemsRepeater has no built-in focus/selection, but IsTabStop and the keyboard
-                     events live on UIElement, so the item's Grid can be made keyboard-focusable
-                     directly - no Button needed. Arrow keys move between items; Enter/Space and
-                     pointer activate the focused item (see code-behind). -->
                 <Grid AutomationProperties.Name="{x:Bind Title}"
                       CornerRadius="4"
                       IsTabStop="True"
@@ -56,8 +52,6 @@ private double _persistedScrollPosition;
 
 private void Repeater_ElementPrepared(ItemsRepeater sender, ItemsRepeaterElementPreparedEventArgs args)
 {
-    // The item's Grid is itself focusable (IsTabStop in the template), so no Button is needed.
-    // Wire pointer (Tapped) and keyboard (Enter/Space) activation on it.
     args.Element.Tapped -= Item_Tapped;
     args.Element.Tapped += Item_Tapped;
     args.Element.KeyDown -= Item_KeyDown;


### PR DESCRIPTION
The 'Connected animation with ItemsRepeater' sample rendered each item as a non-focusable Grid that only handled Tapped, so keyboard users could not focus, navigate between, or invoke the list items (accessibility issue, MAS 2.1.1).

Host each item in a chrome-less Button so items are keyboard-focusable and can be invoked with Enter/Space (and expose an Invoke automation pattern for Narrator), enable XYFocusKeyboardNavigation on the ItemsRepeater for arrow-key navigation, and return focus to the activated item on back-navigation. The displayed sample source (ConnectedAnimationItemsrepeater.txt) is updated to match.

Work item: https://dev.azure.com/microsoft/OS/_workitems/edit/62821652

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Build and Launched the solution file

## Screenshots (if appropriate):
Before

https://github.com/user-attachments/assets/39a85bef-d476-4962-b580-a88d421668d8

After

https://github.com/user-attachments/assets/e5ef1b40-ac7d-4a02-a26f-78d2c290f058



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
