### PR TITLE
Fix missing accessible name on AppWindow sample Close buttons

### DIFF
--- a/WinUIGallery/SampleSupport/SamplePages/SampleWindow1.xaml
+++ b/WinUIGallery/SampleSupport/SamplePages/SampleWindow1.xaml
@@ -32,6 +32,7 @@
             <TextBlock Text="Hide and show the window after 3 seconds" TextWrapping="WrapWholeWords" TextAlignment="Center"/>
         </Button>
         <Button x:Name="Close"
+                AutomationProperties.Name="Close"
                 Click="Close_Click"
                 Width="200"
                 Margin="0,16,0,0">

--- a/WinUIGallery/SampleSupport/SamplePages/SampleWindow3.xaml
+++ b/WinUIGallery/SampleSupport/SamplePages/SampleWindow3.xaml
@@ -29,6 +29,7 @@
             <TextBlock Text="Minimize and restore the window after 3 seconds" TextWrapping="WrapWholeWords" TextAlignment="Center"/>
         </Button>
         <Button x:Name="CloseBtn"
+                AutomationProperties.Name="Close"
                 Click="CloseBtn_Click"
                 Width="200"
                 Margin="0,16,0,0">

--- a/WinUIGallery/SampleSupport/SamplePages/SampleWindow4.xaml
+++ b/WinUIGallery/SampleSupport/SamplePages/SampleWindow4.xaml
@@ -30,6 +30,7 @@
 
         <Button
             x:Name="CloseBtn"
+            AutomationProperties.Name="Close"
             Width="200"
             Margin="0,16,0,0"
             Click="CloseBtn_Click">

--- a/WinUIGallery/SampleSupport/SamplePages/SampleWindow6.xaml
+++ b/WinUIGallery/SampleSupport/SamplePages/SampleWindow6.xaml
@@ -18,6 +18,7 @@
                        Style="{ThemeResource TitleTextBlockStyle}"
                        TextAlignment="Center" />
         <Button x:Name="Close"
+                AutomationProperties.Name="Close"
                 Click="Close_Click"
                 Width="200"
                 HorizontalAlignment="Center">

--- a/WinUIGallery/Samples/AppWindow/AppWindowSettingMinimumMaximumWidth.txt
+++ b/WinUIGallery/Samples/AppWindow/AppWindowSettingMinimumMaximumWidth.txt
@@ -23,6 +23,7 @@ Setting the minimum and maximum width / height on an AppWindow using OverlappedP
             <TextBlock Text="Minimize and restore the window after 3 seconds" TextWrapping="WrapWholeWords" TextAlignment="Center"/>
         </Button>
         <Button x:Name="CloseBtn"
+                AutomationProperties.Name="Close"
                 Click="CloseBtn_Click"
                 Width="200"
                 Margin="0,16,0,0">

--- a/WinUIGallery/Samples/AppWindow/AppwindowFullscreenpresenter.txt
+++ b/WinUIGallery/Samples/AppWindow/AppwindowFullscreenpresenter.txt
@@ -13,6 +13,7 @@ AppWindow with FullScreenPresenter
                        Style="{ThemeResource TitleTextBlockStyle}"
                        TextAlignment="Center" />
         <Button x:Name="Close"
+                AutomationProperties.Name="Close"
                 Click="Close_Click"
                 Width="200"
                 HorizontalAlignment="Center">

--- a/WinUIGallery/Samples/AppWindow/AppwindowOverlapedpresenter.txt
+++ b/WinUIGallery/Samples/AppWindow/AppwindowOverlapedpresenter.txt
@@ -23,6 +23,7 @@ AppWindow with OverlapedPresenter
             <TextBlock Text="Minimize and restore the window after 3 seconds" TextWrapping="WrapWholeWords" TextAlignment="Center"/>
         </Button>
         <Button x:Name="CloseBtn"
+                AutomationProperties.Name="Close"
                 Click="CloseBtn_Click"
                 Width="200"
                 Margin="0,16,0,0">

--- a/WinUIGallery/Samples/AppWindow/CreatingCustomizingAppwindowWindow.txt
+++ b/WinUIGallery/Samples/AppWindow/CreatingCustomizingAppwindowWindow.txt
@@ -28,6 +28,7 @@ Creating and customizing an AppWindow from a Window instance
             <TextBlock Text="Hide and show the window after 3 seconds" TextWrapping="WrapWholeWords" TextAlignment="Center"/>
         </Button>
         <Button x:Name="Close"
+                AutomationProperties.Name="Close"
                 Click="Close_Click"
                 Width="200"
                 Margin="0,16,0,0">


### PR DESCRIPTION
## Summary
The **Close** buttons in the AppWindow sample windows have no accessible name, so screen readers (Narrator) announce only *"button"* instead of *"Close, button"*.

**Root cause:** each Close button uses a `StackPanel` (SymbolIcon `Cancel` + TextBlock `Close`) as its `Content`. Because the content is a panel rather than a plain string, the framework derives no UI Automation **Name**.

**Fix:** add `AutomationProperties.Name="Close"` to each affected Close button. No visual or behavioral change.

## Repro (before fix)
1. Turn on Narrator (Win + Ctrl + Enter).
2. Open the app, search **AppWindow**, open the page.
3. Click **Show window** -> the *"This is a title"* window opens.
4. Tab to the **Close** button -> Narrator announces just *"button"*.

After the fix, Narrator announces *"Close, button"*.

## Files changed
Affected windows reachable from `AppWindowPage` (all use the icon+text Close pattern):
- `SampleWindow1.xaml` (the *"This is a title"* window)
- `SampleWindow3.xaml` (OverlappedPresenter window)
- `SampleWindow4.xaml` (min/max size window)
- `SampleWindow6.xaml` (fullscreen window)

`SampleWindow2`, `SampleWindow7` and `ModalWindow` were checked and already expose correct names (string content), so they are untouched.

## Testing
- Built `WinUIGallery` (Debug/x64) — succeeds with 0 errors; XAML compiles.
- Verified manually with Narrator: the Close button now announces *"Close, button"*.
- Aligns with the repo's `AutomationProperties.Name` accessibility convention (enforced by the Axe.Windows UI test scans).
[

https://github.com/user-attachments/assets/b4ad6046-b905-471a-908c-fe74a9a33350

](url)
