### PR TITLE
Fix keyboard focus trap in StoragePickers sample after picker closes

### DIFF
--- a/WinUIGallery/Samples/StoragePickers/StoragePickersFileThumbnail.txt
+++ b/WinUIGallery/Samples/StoragePickers/StoragePickersFileThumbnail.txt
@@ -28,6 +28,9 @@ private async void PickFileForThumbnailButton_Click(object sender, RoutedEventAr
             ThumbnailDetailsTextBlock.Text = "No file selected.";
             ThumbnailImage.Source = null;
             button.IsEnabled = true;
+
+            // Return keyboard focus to the button, which lost focus when it was disabled, to avoid a keyboard trap.
+            button.Focus(FocusState.Programmatic);
             return;
         }
 
@@ -77,6 +80,10 @@ private async void PickFileForThumbnailButton_Click(object sender, RoutedEventAr
         }
 
         button.IsEnabled = true;
+
+        // Return keyboard focus to the button, which lost focus when it was disabled, to avoid a keyboard trap.
+        button.Focus(FocusState.Programmatic);
+
         UIHelper.AnnounceActionForAccessibility(button, ThumbnailDetailsTextBlock.Text, "ThumbnailPickedNotificationId");
     }
 }

--- a/WinUIGallery/Samples/StoragePickers/StoragePickersPage.xaml.cs
+++ b/WinUIGallery/Samples/StoragePickers/StoragePickersPage.xaml.cs
@@ -65,6 +65,10 @@ public sealed partial class StoragePickersPage : Page
 
             //re-enable the button
             button.IsEnabled = true;
+
+            // Return keyboard focus to the button, which lost focus when it was disabled, to avoid a keyboard trap.
+            button.Focus(FocusState.Programmatic);
+
             UIHelper.AnnounceActionForAccessibility(button, PickedSingleFileTextBlock.Text, "FilePickedNotificationId");
         }
     }
@@ -122,6 +126,9 @@ public sealed partial class StoragePickersPage : Page
             // Re-enable the button
             button.IsEnabled = true;
 
+            // Return keyboard focus to the button, which lost focus when it was disabled, to avoid a keyboard trap.
+            button.Focus(FocusState.Programmatic);
+
             // Announce result for accessibility
             UIHelper.AnnounceActionForAccessibility(button, PickedMultipleFilesTextBlock.Text, "FilesPickedNotificationId");
         }
@@ -178,6 +185,10 @@ public sealed partial class StoragePickersPage : Page
             }
 
             button.IsEnabled = true;
+
+            // Return keyboard focus to the button, which lost focus when it was disabled, to avoid a keyboard trap.
+            button.Focus(FocusState.Programmatic);
+
             UIHelper.AnnounceActionForAccessibility(button, SavedFileTextBlock.Text, "FileSavedNotificationId");
         }
     }
@@ -222,6 +233,9 @@ public sealed partial class StoragePickersPage : Page
             // re-enable the button
             button.IsEnabled = true;
 
+            // Return keyboard focus to the button, which lost focus when it was disabled, to avoid a keyboard trap.
+            button.Focus(FocusState.Programmatic);
+
             UIHelper.AnnounceActionForAccessibility(button, PickedFolderTextBlock.Text, "FolderPickedNotificationId");
         }
     }
@@ -241,6 +255,9 @@ public sealed partial class StoragePickersPage : Page
                 ThumbnailDetailsTextBlock.Text = "No file selected.";
                 ThumbnailImage.Source = null;
                 button.IsEnabled = true;
+
+                // Return keyboard focus to the button, which lost focus when it was disabled, to avoid a keyboard trap.
+                button.Focus(FocusState.Programmatic);
                 return;
             }
 
@@ -285,6 +302,10 @@ public sealed partial class StoragePickersPage : Page
             }
 
             button.IsEnabled = true;
+
+            // Return keyboard focus to the button, which lost focus when it was disabled, to avoid a keyboard trap.
+            button.Focus(FocusState.Programmatic);
+
             UIHelper.AnnounceActionForAccessibility(button, ThumbnailDetailsTextBlock.Text, "ThumbnailPickedNotificationId");
         }
     }
@@ -307,6 +328,10 @@ public sealed partial class StoragePickersPage : Page
             }
 
             button.IsEnabled = true;
+
+            // Return keyboard focus to the button, which lost focus when it was disabled, to avoid a keyboard trap.
+            button.Focus(FocusState.Programmatic);
+
             UIHelper.AnnounceActionForAccessibility(
                 button,
                 folder != null && !string.IsNullOrEmpty(folder.Path)

--- a/WinUIGallery/Samples/StoragePickers/StoragePickersPickFolder.txt
+++ b/WinUIGallery/Samples/StoragePickers/StoragePickersPickFolder.txt
@@ -30,5 +30,8 @@ private async void PickFolderButton_Click(object sender, RoutedEventArgs e)
 
         // re-enable the button
         button.IsEnabled = true;
+
+        // Return keyboard focus to the button, which lost focus when it was disabled, to avoid a keyboard trap.
+        button.Focus(FocusState.Programmatic);
     }
 }

--- a/WinUIGallery/Samples/StoragePickers/StoragePickersPickMultipleFiles.txt
+++ b/WinUIGallery/Samples/StoragePickers/StoragePickersPickMultipleFiles.txt
@@ -39,5 +39,8 @@ private async void PickMultipleFilesButton_Click(object sender, RoutedEventArgs 
 
         //re-enable the button
         button.IsEnabled = true;
+
+        // Return keyboard focus to the button, which lost focus when it was disabled, to avoid a keyboard trap.
+        button.Focus(FocusState.Programmatic);
     }
 }

--- a/WinUIGallery/Samples/StoragePickers/StoragePickersPickSingleFile.txt
+++ b/WinUIGallery/Samples/StoragePickers/StoragePickersPickSingleFile.txt
@@ -29,5 +29,8 @@ private async void PickSingleFileButton_Click(object sender, RoutedEventArgs e)
 
         //re-enable the button
         button.IsEnabled = true;
+
+        // Return keyboard focus to the button, which lost focus when it was disabled, to avoid a keyboard trap.
+        button.Focus(FocusState.Programmatic);
     }
 }

--- a/WinUIGallery/Samples/StoragePickers/StoragePickersSaveFile.txt
+++ b/WinUIGallery/Samples/StoragePickers/StoragePickersSaveFile.txt
@@ -41,5 +41,8 @@ $(TxtFileType)$(JsonFileType)$(XmlFileType)
         }
 
         button.IsEnabled = true;
+
+        // Return keyboard focus to the button, which lost focus when it was disabled, to avoid a keyboard trap.
+        button.Focus(FocusState.Programmatic);
     }
 }


### PR DESCRIPTION
## Summary
On the **Storage pickers** sample page, keyboard focus becomes trapped after a picker dialog closes. Each picker button handler disables the button while the picker is shown and re-enables it afterward:

```csharp
button.IsEnabled = false;      // focused button is disabled -> keyboard focus is dropped
var result = await picker...;  // show the Open/Save/Folder dialog
button.IsEnabled = true;       // re-enabled, but focus is NOT restored
```

Disabling the focused button drops keyboard focus, and re-enabling it does not bring focus back, so a keyboard-only user is left with no focused element and cannot Tab away (**MAS 2.1.2 - No Keyboard Trap**).

## Fix
Restore focus to the button with `Focus(FocusState.Programmatic)` immediately after re-enabling it. This matches the focus-restoration pattern already used elsewhere in the repo (e.g. `ThemeTransitionPage`, `DetailedInfoPage`). No visual or behavioral change other than focus correctly returning to the button.

Applied to all six handlers in `StoragePickersPage.xaml.cs` (Pick single file, Pick multiple files, Save a file, Pick folder, Pick file for thumbnail, Select suggested folder). The five displayed sample code snippets (`.txt`) are updated to match.

## Repro (before fix)
1. Open **Storage pickers**, scroll to the **Save a file** section.
2. Using the keyboard, Tab to **Save a file** and press Enter.
3. In the Save dialog, type a name, Tab to **Save**, press Enter.
4. Press Tab / Shift+Tab -> focus is lost / trapped.

After the fix, focus returns to the **Save a file** button and Tab navigation works normally.

## Testing
- Built `WinUIGallery` (Debug/x64) -> 0 errors.
- Verified manually: after saving, keyboard focus returns to the invoking button.
- Aligns with the repo's accessibility conventions (enforced by the Axe.Windows UI test scans).

[

https://github.com/user-attachments/assets/b054c543-1226-445a-bcc8-cfffb5309d5c

](url)
