### PR TITLE
Fix low color contrast of spatial audio caption in dark mode

### DIFF
--- a/WinUIGallery/Samples/Sound/SoundPage.xaml
+++ b/WinUIGallery/Samples/Sound/SoundPage.xaml
@@ -37,7 +37,7 @@
                 <TextBlock
                     Margin="0,5,0,0"
                     FontStyle="Italic"
-                    Foreground="{ThemeResource SystemColorHotlightColor}"
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                     Style="{ThemeResource CaptionTextBlockStyle}"
                     Text="Can only enable spatial audio when sound is on!" />
             </StackPanel>


### PR DESCRIPTION
## Summary
On the **Sound** sample page, the caption *"Can only enable spatial audio when sound is on!"* under the **Enable Spatial Audio** checkbox has insufficient color contrast in **dark mode**.

It used:
```xml
<TextBlock
    FontStyle="Italic"
    Foreground="{ThemeResource SystemColorHotlightColor}"
    Style="{ThemeResource CaptionTextBlockStyle}"
    Text="Can only enable spatial audio when sound is on!" />
```

`SystemColorHotlightColor` is the **hyperlink text color** (it is even described that way in the gallery's own `Samples/Color/brushes.json`). It is not part of the theme's text-color ramp, so in dark mode the caption renders at roughly **2.78:1** against the page background - below the **4.5:1** minimum (**MAS 1.4.3 - Contrast (Minimum)**).

## Fix
Use the theme-aware `TextFillColorSecondaryBrush`, which adapts to light and dark themes and meets the contrast requirement, for this secondary caption text:

```xml
Foreground="{ThemeResource TextFillColorSecondaryBrush}"
```

One-line change in `SoundPage.xaml`. No behavioral change.

## Repro (before fix)
1. Set **Settings -> App theme -> Dark**.
2. Open the **Sound** page.
3. Observe the italic caption under the **Enable Spatial Audio** checkbox - it is a faint hyperlink-blue that fails 4.5:1 contrast.

After the fix, the caption uses a theme-aware secondary text color that passes the contrast requirement in both themes.

## Testing
- Built `WinUIGallery` (Debug/x64) -> 0 errors.
- Verified the caption uses a contrast-compliant, theme-aware brush.
- Aligns with the gallery's accessibility conventions (enforced by the Axe.Windows UI test scans).


<img width="948" height="714" alt="image" src="https://github.com/user-attachments/assets/96de3525-9745-463c-a4af-44f67606976c" />



