### PR TITLE
Fix Go Back button focus obscured in ConnectedAnimation detail sample

### DIFF
--- a/WinUIGallery/SampleSupport/SamplePages/DetailedInfoPage.xaml.cs
+++ b/WinUIGallery/SampleSupport/SamplePages/DetailedInfoPage.xaml.cs
@@ -23,6 +23,10 @@ public sealed partial class DetailedInfoPage : Page
     {
         // When we land in page, put focus on the back button
         GoBackButton.Focus(FocusState.Programmatic);
+
+        // Scroll the back button into view so keyboard focus is not left off-screen behind
+        // the surrounding scroll viewer (MAS 2.4.11 - Focus Not Obscured).
+        GoBackButton.StartBringIntoView();
     }
 
     protected override void OnNavigatedTo(NavigationEventArgs e)

--- a/WinUIGallery/Samples/ConnectedAnimation/ConnectedAnimationListPage.txt
+++ b/WinUIGallery/Samples/ConnectedAnimation/ConnectedAnimationListPage.txt
@@ -159,6 +159,10 @@ public sealed partial class DetailedInfoPage : Page
     {
         // When we land in page, put focus on the back button
         GoBackButton.Focus(FocusState.Programmatic);
+
+        // Scroll the back button into view so keyboard focus is not left off-screen behind
+        // the surrounding scroll viewer (MAS 2.4.11 - Focus Not Obscured).
+        GoBackButton.StartBringIntoView();
     }
 
     protected override void OnNavigatedTo(NavigationEventArgs e)


### PR DESCRIPTION
## Summary
On the **ConnectedAnimation** page, keyboard focus can be **obscured** in the *"connected animation between a list page and a detail page"* sample. The sample is hosted in a fixed-height `Frame` inside the gallery page's `ScrollViewer`.

After navigating in from a lower list item, the detail page's **Go Back** button receives focus but lands **outside the page's viewport**, so keyboard focus is on a control the user cannot see (**MAS 2.4.11 - Focus Not Obscured**).

## Fix
Call `GoBackButton.StartBringIntoView()` right after focusing it, so the page-level `ScrollViewer` scrolls the focused button into view. The displayed sample code snippet is updated to match.

## Repro (before fix)
1. Open **ConnectedAnimation** (most obvious when the window is not full-height).
2. In the list under *"A connected animation between a list page and a detail page"*, focus a lower item with the keyboard and press Enter.
3. On the detail page the **Go Back** button is focused but scrolled off-screen / not visible.

After the fix, the page scrolls so the focused **Go Back** button is visible.

## Testing
- Built `WinUIGallery` (Debug/x64) -> 0 errors.
- Verified via UI Automation that, before the fix, the focused `Go Back` button reports `IsOffscreen = True` after navigation.


https://github.com/user-attachments/assets/a4423198-d474-4115-ae7d-4449ee66c9c7


