### PR TITLE
Bring keyboard-focused controls into view on Easing Functions page

### DIFF
--- a/WinUIGallery/Samples/EasingFunction/EasingFunctionPage.xaml.cs
+++ b/WinUIGallery/Samples/EasingFunction/EasingFunctionPage.xaml.cs
@@ -39,6 +39,19 @@ public sealed partial class EasingFunctionPage : Page
     public EasingFunctionPage()
     {
         this.InitializeComponent();
+
+        // Bring the keyboard-focused control into view so focus is never left obscured
+        // behind the hosting scroll viewer (MAS 2.4.11 - Focus Not Obscured).
+        GotFocus += OnControlGotFocus;
+    }
+
+    private void OnControlGotFocus(object sender, RoutedEventArgs e)
+    {
+        // Only react to keyboard/programmatic focus; pointer focus does not obscure the target.
+        if (e.OriginalSource is Control focusedControl && focusedControl.FocusState != FocusState.Pointer)
+        {
+            focusedControl.StartBringIntoView();
+        }
     }
 
     private void Button1_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Problem

On the **Easing Functions** sample page, keyboard focus can move to controls that are below the fold — most noticeably the `EaseOut` / `EaseIn` / `EaseInOut` radio buttons in the last example — without the page scrolling to reveal them. The focus indicator ends up obscured behind the hosting `ScrollViewer`, so keyboard and Narrator users can't see where focus is (fails "focus not obscured").

## Fix

Handle the page's bubbling `GotFocus` event and call `StartBringIntoView()` on the focused control so the host `ScrollViewer` scrolls it fully into view. Only keyboard/programmatic focus is handled — pointer focus is ignored, so mouse interaction is unchanged.

This mirrors the `StartBringIntoView()` approach already used for the ConnectedAnimation detail sample's back button.

## Testing

- Built `WinUIGallery` (x64, Debug) — succeeds with no errors.
- Ran the app, opened **Easing Functions**, resized the window short so it scrolls, and pressed **Tab** through the controls: the page now auto-scrolls to keep each focused control (including the radio buttons) fully visible.
- Verified with Narrator that focus stays on-screen as it moves.
- Confirmed mouse-clicking a partially visible control no longer triggers unexpected scrolling.


https://github.com/user-attachments/assets/bfa6654a-b7ab-42cf-ac37-9e2e1bfffa20


