### PR TITLE
Fix keyboard focus indicator overlapping radio buttons in Border sample

### DIFF
--- a/WinUIGallery/Samples/Border/BorderPage.xaml
+++ b/WinUIGallery/Samples/Border/BorderPage.xaml
@@ -44,7 +44,7 @@
                         ValueChanged="ThicknessSlider_ValueChanged"
                         Value="2" />
 
-                    <Grid>
+                    <Grid ColumnSpacing="8">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition />
                             <ColumnDefinition />


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
The Layout - Border page renders its two option groups RadioButtons Header="Background" and RadioButtons Header="BorderBrush" in a two-column Grid with no spacing between the columns, so the two groups sit flush against each other.

RadioButton's default style sets FocusVisualMargin="-7,-3,-7,-3", i.e. the keyboard focus rectangle is deliberately drawn 7px outside the control's bounds on the left and right. With the columns touching, that 7px overhang has nowhere to go: focusing an item in the Background column paints its focus rectangle on top of the BorderBrush radio buttons next to it (and vice versa), so the indicator appears overlapped/obscured.

## Description
added ColumnSpacing="8" to that Grid in WinUIGallery/Samples/Border/BorderPage.xaml .
8px gives the 7px focus visual room to draw fully with a pixel to spare, and matches the compact spacing already used elsewhere in gallery option panes.

## Motivation and Context
The focus indicator should be fully visible around the focused radio button under Background and not be overlapped or obscured by any UI element. Today this is the case

## How Has This Been Tested?
Built WinUIGallery Debug / x64 - succeeds, no new warnings.
Manual keyboard repro against the bug's steps:
Launch WinUI 3 Gallery and search for Border and then open the sample.
Tab into the Background group and arrow through the radio buttons.
Before: the focus rectangle bleeds over the adjacent BorderBrush radio buttons. After: the focus rectangle draws completely within the gap; no overlap in either direction (also verified arrowing through the BorderBrush column).

## Screenshots (if appropriate):
<img width="926" height="572" alt="image" src="https://github.com/user-attachments/assets/10bd74fc-92ac-403e-9ceb-4076f38a96fb" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
