### PR TITLE
Add a DP for ColorSelector for enabling alpha channel

### DIFF
--- a/WinUIGallery/Controls/ColorSelector.xaml
+++ b/WinUIGallery/Controls/ColorSelector.xaml
@@ -1,33 +1,35 @@
-<?xml version="1.0" encoding="utf-8"?>
-<UserControl 
+<?xml version="1.0" encoding="utf-8" ?>
+<UserControl
     x:Class="WinUIGallery.Controls.ColorSelector"
-    x:Name="Root"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WinUIGallery.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:WinUIGallery.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    Margin="0,2,0,8">
+    x:Name="Root"
+    Margin="0,2,0,8"
+    mc:Ignorable="d">
 
     <SplitButton AutomationProperties.Name="{Binding Path=(AutomationProperties.Name), ElementName=Root, Mode=OneWay}">
-        <Border x:Name="CurrentColor"
-                Width="64"
-                Height="32"
-                CornerRadius="4,0,0,4"
-                Margin="-11,-6" />
+        <Border
+            x:Name="CurrentColor"
+            Width="64"
+            Height="32"
+            Margin="-11,-6"
+            CornerRadius="4,0,0,4" />
         <SplitButton.Flyout>
             <Flyout Placement="Bottom">
-                <ColorPicker x:Name="ColorPicker"
-                             ColorSpectrumShape="Ring"
-                             IsMoreButtonVisible="False"
-                             IsColorSliderVisible="True"
-                             IsColorChannelTextInputVisible="False"
-                             IsHexInputVisible="False"
-                             IsAlphaEnabled="True"
-                             IsAlphaSliderVisible="True"
-                             IsAlphaTextInputVisible="False"
-                             ColorChanged="ColorPicker_ColorChanged" />
+                <ColorPicker
+                    x:Name="ColorPicker"
+                    ColorChanged="ColorPicker_ColorChanged"
+                    ColorSpectrumShape="Ring"
+                    IsAlphaEnabled="{x:Bind IsAlphaEnabled, Mode=OneWay}"
+                    IsAlphaSliderVisible="True"
+                    IsAlphaTextInputVisible="False"
+                    IsColorChannelTextInputVisible="False"
+                    IsColorSliderVisible="True"
+                    IsHexInputVisible="False"
+                    IsMoreButtonVisible="False" />
             </Flyout>
         </SplitButton.Flyout>
     </SplitButton>

--- a/WinUIGallery/Controls/ColorSelector.xaml.cs
+++ b/WinUIGallery/Controls/ColorSelector.xaml.cs
@@ -31,6 +31,19 @@ public sealed partial class ColorSelector : UserControl
         set => SetValue(ColorProperty, value);
     }
 
+    public static readonly DependencyProperty IsAlphaEnabledProperty =
+        DependencyProperty.Register(
+            nameof(IsAlphaEnabled),
+            typeof(bool),
+            typeof(ColorSelector),
+            new PropertyMetadata(false));
+
+    public bool IsAlphaEnabled
+    {
+        get => (bool)GetValue(IsAlphaEnabledProperty);
+        set => SetValue(IsAlphaEnabledProperty, value);
+    }
+
     private static void OnColorPropertyChanged(
         DependencyObject d,
         DependencyPropertyChangedEventArgs e)


### PR DESCRIPTION
## Description
I see the `ColorSelector` controls is currently only used for demo `AppWindowTitleBar` customization. And the alpha channel is ignored, [see  this doc](https://learn.microsoft.com/en-us/windows/apps/develop/title-bar?tabs=wasdk#colors). So it's better to disable the alpha channel to avoid confusion. And it can be enabled using the DP if the control is used for other places in the future.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manual.

## Screenshots (if appropriate):

<img width="2860" height="1536" alt="image" src="https://github.com/user-attachments/assets/5638c8ad-ef88-4635-b1ac-84ac19fcd750" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
