### PR TITLE
Fix and document Store release packaging

### DIFF
--- a/.pipelines/WinUI-Gallery-Store-Release.yml
+++ b/.pipelines/WinUI-Gallery-Store-Release.yml
@@ -11,8 +11,12 @@ resources:
     ref: refs/tags/release
 
 parameters:
+- name: releaseVersion
+  displayName: Release version (X.Y.Z)
+  type: string
+  default: '2.10.0'
 - name: publishToStore
-  displayName: Create a private Store submission
+  displayName: Submit package for Store certification
   type: boolean
   default: false
 - name: storeServiceEndpoint
@@ -26,10 +30,7 @@ parameters:
   - ARM64
 
 variables:
-  # Keep the counter prefix aligned with the app's major/minor version when
-  # starting a new release line.
-  StoreVersionBuild: $[counter('WinUIGalleryStore-2.10', 0)]
-  StorePackageVersion: 2.10.$(StoreVersionBuild).0
+  StorePackageVersion: ${{ parameters.releaseVersion }}.0
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
@@ -67,6 +68,25 @@ extends:
             inputs:
               targetType: inline
               script: |
+                $packageVersion = "$(StorePackageVersion)"
+                if ($packageVersion -notmatch '^\d{1,5}\.\d{1,5}\.\d{1,5}\.0$') {
+                  Write-Error "Release version '${{ parameters.releaseVersion }}' must use X.Y.Z format, with each component between 0 and 65535."
+                  exit 1
+                }
+
+                $versionParts = $packageVersion.Split('.') | ForEach-Object { [int]$_ }
+                if ($versionParts | Where-Object { $_ -gt 65535 }) {
+                  Write-Error "Package version '$packageVersion' contains a component greater than 65535."
+                  exit 1
+                }
+
+                [xml]$project = Get-Content "WinUIGallery\WinUIGallery.csproj"
+                $projectVersion = $project.SelectSingleNode("//Version").InnerText
+                if ($projectVersion -ne $packageVersion) {
+                  Write-Error "Release version '$packageVersion' does not match WinUIGallery.csproj version '$projectVersion'. Merge the version bump before running this pipeline."
+                  exit 1
+                }
+
                 dotnet publish WinUIGallery\WinUIGallery.csproj `
                   --runtime win-${{ lower(platform) }} `
                   --configuration Release `
@@ -166,7 +186,7 @@ extends:
                   exit 1
                 }
 
-                & $makeAppx.FullName bundle /d $bundleInputDirectory /p $bundlePath /o
+                & $makeAppx.FullName bundle /d $bundleInputDirectory /p $bundlePath /bv "$(StorePackageVersion)" /o
                 if ($LASTEXITCODE -ne 0) {
                   exit $LASTEXITCODE
                 }

--- a/.pipelines/WinUI-Gallery-Store-Release.yml
+++ b/.pipelines/WinUI-Gallery-Store-Release.yml
@@ -124,7 +124,7 @@ extends:
             os: windows
           steps:
           - task: PowerShell@2
-            displayName: Validate Store submission packages
+            displayName: Create and validate Store submission bundle
             inputs:
               targetType: inline
               script: |
@@ -144,14 +144,53 @@ extends:
                   $packages | ForEach-Object { Write-Host $_.FullName }
                   exit 1
                 }
+
+                $bundleInputDirectory = "$(Pipeline.Workspace)\StoreBundleInput"
+                $bundleOutputDirectory = "$(Pipeline.Workspace)\StoreBundle"
+                $bundleValidationDirectory = "$(Pipeline.Workspace)\StoreBundleValidation"
+                $bundlePath = Join-Path $bundleOutputDirectory "WinUIGallery_$(StorePackageVersion).msixbundle"
+
+                New-Item -ItemType Directory -Path $bundleInputDirectory -Force | Out-Null
+                New-Item -ItemType Directory -Path $bundleOutputDirectory -Force | Out-Null
+                $packages | Copy-Item -Destination $bundleInputDirectory -Force
+
+                $makeAppx = Get-ChildItem -Path "${env:ProgramFiles(x86)}\Windows Kits\10\bin" `
+                  -Recurse `
+                  -Filter makeappx.exe |
+                    Where-Object { $_.DirectoryName -like "*\x64" } |
+                    Sort-Object @{ Expression = { [version]$_.Directory.Parent.Name }; Descending = $true } |
+                    Select-Object -First 1
+
+                if (-not $makeAppx) {
+                  Write-Error "Could not find the Windows SDK makeappx.exe tool."
+                  exit 1
+                }
+
+                & $makeAppx.FullName bundle /d $bundleInputDirectory /p $bundlePath /o
+                if ($LASTEXITCODE -ne 0) {
+                  exit $LASTEXITCODE
+                }
+
+                & $makeAppx.FullName unbundle /p $bundlePath /d $bundleValidationDirectory /o
+                if ($LASTEXITCODE -ne 0) {
+                  exit $LASTEXITCODE
+                }
+
+                $bundledPackages = @(Get-ChildItem -Path $bundleValidationDirectory -Filter "WinUIGallery_*.msix")
+                if ($bundledPackages.Count -ne $requiredPlatforms.Count) {
+                  Write-Error "Expected the bundle to contain $($requiredPlatforms.Count) packages, found $($bundledPackages.Count)."
+                  exit 1
+                }
+
+                Write-Host "Created Store bundle: $bundlePath"
           - task: MS-RDX-MRO.windows-store-publish.publish-task.store-publish@3
             displayName: Publish WinUI Gallery StoreBroker package
             inputs:
               serviceEndpoint: ${{ parameters.storeServiceEndpoint }}
               appId: 9P3JFPWWDZRC
               inputMethod: Packages
-              sourceFolder: $(Pipeline.Workspace)
-              contents: '**/WinUIGallery_*.msix'
+              sourceFolder: '$(Pipeline.Workspace)\StoreBundle'
+              contents: 'WinUIGallery_*.msixbundle'
               force: true
               skipPolling: true
               deletePackages: true

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ Ensure that the `WinUIGallery` project is set as the startup project in Visual S
 
 To learn more about Windows app development, go to the [Windows Dev Center](https://developer.microsoft.com/windows).
 
+Maintainers can follow the [release runbook](docs/PublishingNewVersion.md) to
+coordinate Microsoft Store publishing with a GitHub release.
+
 
 ### Related topics
 

--- a/docs/PublishingNewVersion.md
+++ b/docs/PublishingNewVersion.md
@@ -17,7 +17,7 @@ The releaser needs:
 
 - Write access to this GitHub repository.
 - Permission to run the Azure DevOps pipeline named
-  `WinUI-Gallery-Store-Release` (pipeline ID `200728`).
+  `WinUI-Gallery-Store-Release`.
 - Access to the WinUI 3 Gallery product in Partner Center.
 
 The StoreBroker service connection and Store permissions are already configured.

--- a/docs/PublishingNewVersion.md
+++ b/docs/PublishingNewVersion.md
@@ -1,0 +1,122 @@
+# Publishing a new WinUI Gallery version
+
+This runbook coordinates the Microsoft Store package with the GitHub release so
+both represent the same source commit and version.
+
+The public release uses two forms of the same version:
+
+- GitHub release and tag: `vX.Y.Z` (for example, `v2.10.0`)
+- MSIX packages and bundle: `X.Y.Z.0` (for example, `2.10.0.0`)
+
+The Store package version must always be greater than the version that is
+currently published. Do not use a pipeline run number for the package version.
+
+## Prerequisites
+
+The releaser needs:
+
+- Write access to this GitHub repository.
+- Permission to run the Azure DevOps pipeline named
+  `WinUI-Gallery-Store-Release` (pipeline ID `200728`).
+- Access to the WinUI 3 Gallery product in Partner Center.
+
+The StoreBroker service connection and Store permissions are already configured.
+The pipeline uses workload identity federation; no client secret or signing
+certificate is needed by the releaser. Microsoft Store signs the package after
+ingestion.
+
+## 1. Prepare the release commit
+
+Choose the release version `X.Y.Z`. Update all three checked-in version values to
+`X.Y.Z.0`:
+
+- `WinUIGallery/WinUIGallery.csproj`
+- `WinUIGallery/Package.appxmanifest`
+- `WinUIGallery/Package.Dev.appxmanifest`
+
+Open and merge a version-bump pull request into `main`. Include any final
+dependency updates or release-only changes in that pull request so the merged
+commit is the exact source to release.
+
+Wait for the required GitHub checks on `main` to pass. Record the merged commit
+SHA; the Store build and GitHub release must both use that commit.
+
+## 2. Run a build-only rehearsal
+
+Manually run `WinUI-Gallery-Store-Release` in Azure DevOps with:
+
+- Branch: `main`
+- `releaseVersion`: `X.Y.Z`
+- `publishToStore`: `false`
+
+The pipeline verifies that `releaseVersion` matches the version in
+`WinUIGallery.csproj`, then builds x64 and ARM64 MSIX artifacts. Download and
+smoke-test the packages if the release warrants additional validation.
+
+A build-only run does not contact Partner Center and can be repeated safely
+without consuming a package version.
+
+## 3. Submit the Store package for certification
+
+Run the same pipeline again from the same `main` commit with:
+
+- `releaseVersion`: `X.Y.Z`
+- `publishToStore`: `true`
+
+This setting is not a dry run. It:
+
+1. Builds x64 and ARM64 packages as `X.Y.Z.0`.
+2. Combines them into one `X.Y.Z.0` MSIX bundle.
+3. Uploads the bundle to the private WinUI 3 Gallery Store product.
+4. Submits the update for Store certification.
+
+The pipeline uses manual Store publishing, so passing certification does not
+make the update public. Someone must still select **Publish now** in Partner
+Center.
+
+In Partner Center, confirm:
+
+- The submission version is `X.Y.Z.0`.
+- The bundle contains both x64 and ARM64 packages.
+- Publishing is held for manual release.
+- Certification starts without package validation errors.
+
+If the submission is wrong, select **Cancel certification**. Wait until the
+product returns to **Update in draft** before replacing or deleting it. Never
+select **Publish now** for a test submission.
+
+## 4. Prepare the GitHub release
+
+While Store certification is running, create a draft GitHub release:
+
+- Tag: `vX.Y.Z`
+- Target: the exact commit SHA used by the Store pipeline
+- Title: `WinUI 3 Gallery vX.Y.Z`
+- Release notes: summarize the release and include the generated comparison
+  from the previous release tag
+
+Leave the GitHub release as a draft. Publishing it creates the tag and announces
+the release before the Store package is necessarily available.
+
+WinUI Gallery releases historically do not attach MSIX files to GitHub; the
+Microsoft Store is the package distribution channel.
+
+## 5. Publish
+
+After Store certification passes:
+
+1. Review the certified package and release notes one final time.
+2. Select **Publish now** in Partner Center.
+3. Wait until the Microsoft Store listing offers version `X.Y.Z.0`.
+4. Publish the draft GitHub release.
+5. Verify the GitHub tag targets the recorded release commit.
+
+This order avoids announcing a GitHub release while Store users can still only
+install the previous version.
+
+## Hotfixes
+
+For a hotfix, increment the patch component (for example, `2.10.0` to
+`2.10.1`) and repeat the complete process. Microsoft Store does not support
+downgrading to an older package version; a corrective release must use a higher
+version.

--- a/docs/PublishingNewVersion.md
+++ b/docs/PublishingNewVersion.md
@@ -20,10 +20,6 @@ The releaser needs:
   `WinUI-Gallery-Store-Release`.
 - Access to the WinUI 3 Gallery product in Partner Center.
 
-The release infrastructure and Store permissions are already configured. No
-client secret or signing certificate is needed by the releaser. Microsoft Store
-signs the package after ingestion.
-
 ## 1. Prepare the release commit
 
 Choose the release version `X.Y.Z`. Update all three checked-in version values to
@@ -40,7 +36,7 @@ commit is the exact source to release.
 Wait for the required GitHub checks on `main` to pass. Record the merged commit
 SHA; the Store build and GitHub release must both use that commit.
 
-## 2. Run a build-only rehearsal
+## 2. Validate the packages
 
 Manually run `WinUI-Gallery-Store-Release` in Azure DevOps with:
 
@@ -48,12 +44,11 @@ Manually run `WinUI-Gallery-Store-Release` in Azure DevOps with:
 - `releaseVersion`: `X.Y.Z`
 - `publishToStore`: `false`
 
-The pipeline verifies that `releaseVersion` matches the version in
-`WinUIGallery.csproj`, then builds x64 and ARM64 MSIX artifacts. Download and
-smoke-test the packages if the release warrants additional validation.
+This verifies that `releaseVersion` matches the version in
+`WinUIGallery.csproj` and produces x64 and ARM64 packages without creating a
+Store submission. Download and smoke-test the packages before continuing.
 
-A build-only run does not contact Partner Center and can be repeated safely
-without consuming a package version.
+This step can be repeated without consuming a Store package version.
 
 ## 3. Submit the Store package for certification
 
@@ -62,12 +57,8 @@ Run the same pipeline again from the same `main` commit with:
 - `releaseVersion`: `X.Y.Z`
 - `publishToStore`: `true`
 
-This setting is not a dry run. It:
-
-1. Builds x64 and ARM64 packages as `X.Y.Z.0`.
-2. Combines them into one `X.Y.Z.0` MSIX bundle.
-3. Uploads the bundle to the private WinUI 3 Gallery Store product.
-4. Submits the update for Store certification.
+This setting is not a dry run. It builds the `X.Y.Z.0` Store package and submits
+the update for certification.
 
 The pipeline uses manual Store publishing, so passing certification does not
 make the update public. Someone must still select **Publish now** in Partner
@@ -89,7 +80,7 @@ select **Publish now** for a test submission.
 While Store certification is running, create a draft GitHub release:
 
 - Tag: `vX.Y.Z`
-- Target: the exact commit SHA used by the Store pipeline
+- Target: the exact commit SHA used for the Store update
 - Title: `WinUI 3 Gallery vX.Y.Z`
 - Release notes: summarize the release and include the generated comparison
   from the previous release tag

--- a/docs/PublishingNewVersion.md
+++ b/docs/PublishingNewVersion.md
@@ -20,10 +20,9 @@ The releaser needs:
   `WinUI-Gallery-Store-Release`.
 - Access to the WinUI 3 Gallery product in Partner Center.
 
-The StoreBroker service connection and Store permissions are already configured.
-The pipeline uses workload identity federation; no client secret or signing
-certificate is needed by the releaser. Microsoft Store signs the package after
-ingestion.
+The release infrastructure and Store permissions are already configured. No
+client secret or signing certificate is needed by the releaser. Microsoft Store
+signs the package after ingestion.
 
 ## 1. Prepare the release commit
 


### PR DESCRIPTION
## Description
- Create a single Store `.msixbundle` from the x64 and ARM64 packages before submitting them to the Store.
- Stamp the inner packages and bundle with the release version instead of an ADO counter or MakeAppx timestamp.
- Add a maintainer runbook for coordinating Store certification, manual Store publishing, and the GitHub release.

## Motivation and Context
The first automated Store submission reached Partner Center successfully, but validation failed because this product has historically shipped a Windows 10/11 bundle. Partner Center requires subsequent submissions to continue using `.msixbundle` rather than separate architecture-specific `.msix` files.

The successful bundle test then exposed a second issue: MakeAppx assigns a date/time bundle identity when `/bv` is omitted. The release version is now explicit and must match `WinUIGallery.csproj`, keeping `vX.Y.Z` on GitHub aligned with `X.Y.Z.0` in the Store.

## How Has This Been Tested?
- Reproduced the Partner Center validation failure with separate architecture-specific packages.
- Successfully submitted an x64 + ARM64 bundle, then canceled certification before publication.
- Created and unpacked a local bundle with `/bv 2.10.0.0`; its bundle manifest reports version `2.10.0.0`.
- Previewed the pipeline with publishing both disabled and enabled; the expanded YAML resolves the intended version, omits the Publish stage for build-only runs, and retains manual/private Store publishing safeguards.

## Screenshots (if appropriate)
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
