### PR TITLE
Update TimePicker regional clock guidance

### DIFF
--- a/WinUIGallery/SampleSupport/Data/ControlInfoData.json
+++ b/WinUIGallery/SampleSupport/Data/ControlInfoData.json
@@ -1322,7 +1322,7 @@
           "ApiNamespace": "Microsoft.UI.Xaml.Controls",
           "Subtitle": "A configurable control that lets a user pick a time value.",
           "ImagePath": "ms-appx:///Assets/ControlImages/TimePicker.png",
-          "Description": "Use a TimePicker to let users set a time in your app, for example to set a reminder. By default, the TimePicker uses the clock format for the user's region. Set ClockIdentifier to override the default with a 12-hour or 24-hour clock.",
+          "Description": "Use a TimePicker to let users set a time in your app, for example to set a reminder.",
           "SourcePath": "/CommonStyles/TimePicker_themeresources.xaml",
           "Docs": [
             {

--- a/WinUIGallery/SampleSupport/Data/ControlInfoData.json
+++ b/WinUIGallery/SampleSupport/Data/ControlInfoData.json
@@ -1322,7 +1322,7 @@
           "ApiNamespace": "Microsoft.UI.Xaml.Controls",
           "Subtitle": "A configurable control that lets a user pick a time value.",
           "ImagePath": "ms-appx:///Assets/ControlImages/TimePicker.png",
-          "Description": "Use a TimePicker to let users set a time in your app, for example to set a reminder.",
+          "Description": "Use a TimePicker to let users set a time in your app, for example to set a reminder. The TimePicker displays three controls for hour, minute, and AM/PM. These controls are easy to use with touch or mouse, and they can be styled and configured in several different ways.",
           "SourcePath": "/CommonStyles/TimePicker_themeresources.xaml",
           "Docs": [
             {

--- a/WinUIGallery/SampleSupport/Data/ControlInfoData.json
+++ b/WinUIGallery/SampleSupport/Data/ControlInfoData.json
@@ -1322,7 +1322,7 @@
           "ApiNamespace": "Microsoft.UI.Xaml.Controls",
           "Subtitle": "A configurable control that lets a user pick a time value.",
           "ImagePath": "ms-appx:///Assets/ControlImages/TimePicker.png",
-          "Description": "Use a TimePicker to let users set a time in your app, for example to set a reminder. The TimePicker displays three controls for hour, minute, and AM/PM. These controls are easy to use with touch or mouse, and they can be styled and configured in several different ways.",
+          "Description": "Use a TimePicker to let users set a time in your app, for example to set a reminder. By default, the TimePicker uses the clock format for the user's region. Set ClockIdentifier to override the default with a 12-hour or 24-hour clock.",
           "SourcePath": "/CommonStyles/TimePicker_themeresources.xaml",
           "Docs": [
             {

--- a/WinUIGallery/Samples/TimePicker/SimpleTimepicker.txt
+++ b/WinUIGallery/Samples/TimePicker/SimpleTimepicker.txt
@@ -1,4 +1,4 @@
 --- header
-A simple TimePicker.
+A simple TimePicker that uses the clock format for the user's region.
 --- xaml
 <TimePicker/>

--- a/WinUIGallery/Samples/TimePicker/TimePickerPage.xaml
+++ b/WinUIGallery/Samples/TimePicker/TimePickerPage.xaml
@@ -14,7 +14,6 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:WinUIGallery.Controls"
-    xmlns:sys="using:System"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
@@ -29,7 +28,7 @@
             <TimePicker Header="Arrival time" MinuteIncrement="15"/>
         </controls:ControlExample>
         <controls:ControlExample x:Name="Example3" SampleDefinition="TimePicker\TimepickerClockIdentifiers.txt">
-            <StackPanel Spacing="8">
+            <StackPanel xmlns:sys="using:System" Spacing="8">
                 <TimePicker ClockIdentifier="12HourClock" Header="12-hour clock" SelectedTime="{x:Bind sys:DateTime.Now.TimeOfDay}"/>
                 <TimePicker ClockIdentifier="24HourClock" Header="24-hour clock" SelectedTime="{x:Bind sys:DateTime.Now.TimeOfDay}"/>
             </StackPanel>

--- a/WinUIGallery/Samples/TimePicker/TimePickerPage.xaml
+++ b/WinUIGallery/Samples/TimePicker/TimePickerPage.xaml
@@ -28,8 +28,11 @@
             RelativePanel.Below="Example1">
             <TimePicker Header="Arrival time" MinuteIncrement="15"/>
         </controls:ControlExample>
-        <controls:ControlExample x:Name="Example3" SampleDefinition="TimePicker\Timepicker24HourClock.txt">
-            <TimePicker ClockIdentifier="24HourClock" Header="24 hour clock" SelectedTime="{x:Bind sys:DateTime.Now.TimeOfDay}"/>
+        <controls:ControlExample x:Name="Example3" SampleDefinition="TimePicker\TimepickerClockIdentifiers.txt">
+            <StackPanel Spacing="8">
+                <TimePicker ClockIdentifier="12HourClock" Header="12-hour clock" SelectedTime="{x:Bind sys:DateTime.Now.TimeOfDay}"/>
+                <TimePicker ClockIdentifier="24HourClock" Header="24-hour clock" SelectedTime="{x:Bind sys:DateTime.Now.TimeOfDay}"/>
+            </StackPanel>
         </controls:ControlExample>
     </StackPanel>
 </Page>

--- a/WinUIGallery/Samples/TimePicker/Timepicker24HourClock.txt
+++ b/WinUIGallery/Samples/TimePicker/Timepicker24HourClock.txt
@@ -1,5 +1,5 @@
 --- header
-A TimePicker using a 24-hour clock, initialized to current time.
+A TimePicker that overrides the regional format with a 24-hour clock and is initialized to the current time.
 --- xaml
 <xmlns:sys="using:System">
                     

--- a/WinUIGallery/Samples/TimePicker/Timepicker24HourClock.txt
+++ b/WinUIGallery/Samples/TimePicker/Timepicker24HourClock.txt
@@ -1,6 +1,0 @@
---- header
-A TimePicker that overrides the regional format with a 24-hour clock and is initialized to the current time.
---- xaml
-<xmlns:sys="using:System">
-                    
-                    <TimePicker ClockIdentifier="24HourClock" Header="24 hour clock" SelectedTime="{x:Bind sys:DateTime.Now.TimeOfDay}" />

--- a/WinUIGallery/Samples/TimePicker/TimepickerClockIdentifiers.txt
+++ b/WinUIGallery/Samples/TimePicker/TimepickerClockIdentifiers.txt
@@ -1,0 +1,9 @@
+--- header
+Use ClockIdentifier to override the regional clock format.
+--- xaml
+<xmlns:sys="using:System">
+
+                    <StackPanel Spacing="8">
+                        <TimePicker ClockIdentifier="12HourClock" Header="12-hour clock" SelectedTime="{x:Bind sys:DateTime.Now.TimeOfDay}" />
+                        <TimePicker ClockIdentifier="24HourClock" Header="24-hour clock" SelectedTime="{x:Bind sys:DateTime.Now.TimeOfDay}" />
+                    </StackPanel>

--- a/WinUIGallery/Samples/TimePicker/TimepickerClockIdentifiers.txt
+++ b/WinUIGallery/Samples/TimePicker/TimepickerClockIdentifiers.txt
@@ -1,9 +1,7 @@
 --- header
 Use ClockIdentifier to override the regional clock format.
 --- xaml
-<xmlns:sys="using:System">
-
-                    <StackPanel Spacing="8">
-                        <TimePicker ClockIdentifier="12HourClock" Header="12-hour clock" SelectedTime="{x:Bind sys:DateTime.Now.TimeOfDay}" />
-                        <TimePicker ClockIdentifier="24HourClock" Header="24-hour clock" SelectedTime="{x:Bind sys:DateTime.Now.TimeOfDay}" />
-                    </StackPanel>
+<StackPanel xmlns:sys="using:System" Spacing="8">
+    <TimePicker ClockIdentifier="12HourClock" Header="12-hour clock" SelectedTime="{x:Bind sys:DateTime.Now.TimeOfDay}" />
+    <TimePicker ClockIdentifier="24HourClock" Header="24-hour clock" SelectedTime="{x:Bind sys:DateTime.Now.TimeOfDay}" />
+</StackPanel>


### PR DESCRIPTION
## Description
Updates the TimePicker samples to explain that the default example follows the user's regional settings and to demonstrate both `ClockIdentifier="12HourClock"` and `ClockIdentifier="24HourClock"` overrides.

## Motivation and Context
The existing sample only showed the 24-hour override and did not explain the default regional behavior.

Fixes #2219

## How Has This Been Tested?
- Built `WinUIGallery.csproj` for Release/x64.
- Confirmed the renamed sample definition is referenced and the old filename is unused.

## Screenshots (if appropriate):
N/A - the sample uses existing TimePicker controls.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
