### PR TITLE
Remove Storage Picker focus workaround

### DIFF
--- a/WinUIGallery/Samples/StoragePickers/StoragePickersFileThumbnail.txt
+++ b/WinUIGallery/Samples/StoragePickers/StoragePickersFileThumbnail.txt
@@ -29,8 +29,6 @@ private async void PickFileForThumbnailButton_Click(object sender, RoutedEventAr
             ThumbnailImage.Source = null;
             button.IsEnabled = true;
 
-            // Return keyboard focus to the button, which lost focus when it was disabled, to avoid a keyboard trap.
-            button.Focus(FocusState.Programmatic);
             return;
         }
 
@@ -80,9 +78,6 @@ private async void PickFileForThumbnailButton_Click(object sender, RoutedEventAr
         }
 
         button.IsEnabled = true;
-
-        // Return keyboard focus to the button, which lost focus when it was disabled, to avoid a keyboard trap.
-        button.Focus(FocusState.Programmatic);
 
         UIHelper.AnnounceActionForAccessibility(button, ThumbnailDetailsTextBlock.Text, "ThumbnailPickedNotificationId");
     }

--- a/WinUIGallery/Samples/StoragePickers/StoragePickersPage.xaml.cs
+++ b/WinUIGallery/Samples/StoragePickers/StoragePickersPage.xaml.cs
@@ -66,9 +66,6 @@ public sealed partial class StoragePickersPage : Page
             //re-enable the button
             button.IsEnabled = true;
 
-            // Return keyboard focus to the button, which lost focus when it was disabled, to avoid a keyboard trap.
-            button.Focus(FocusState.Programmatic);
-
             UIHelper.AnnounceActionForAccessibility(button, PickedSingleFileTextBlock.Text, "FilePickedNotificationId");
         }
     }
@@ -125,9 +122,6 @@ public sealed partial class StoragePickersPage : Page
 
             // Re-enable the button
             button.IsEnabled = true;
-
-            // Return keyboard focus to the button, which lost focus when it was disabled, to avoid a keyboard trap.
-            button.Focus(FocusState.Programmatic);
 
             // Announce result for accessibility
             UIHelper.AnnounceActionForAccessibility(button, PickedMultipleFilesTextBlock.Text, "FilesPickedNotificationId");
@@ -186,9 +180,6 @@ public sealed partial class StoragePickersPage : Page
 
             button.IsEnabled = true;
 
-            // Return keyboard focus to the button, which lost focus when it was disabled, to avoid a keyboard trap.
-            button.Focus(FocusState.Programmatic);
-
             UIHelper.AnnounceActionForAccessibility(button, SavedFileTextBlock.Text, "FileSavedNotificationId");
         }
     }
@@ -233,9 +224,6 @@ public sealed partial class StoragePickersPage : Page
             // re-enable the button
             button.IsEnabled = true;
 
-            // Return keyboard focus to the button, which lost focus when it was disabled, to avoid a keyboard trap.
-            button.Focus(FocusState.Programmatic);
-
             UIHelper.AnnounceActionForAccessibility(button, PickedFolderTextBlock.Text, "FolderPickedNotificationId");
         }
     }
@@ -256,8 +244,6 @@ public sealed partial class StoragePickersPage : Page
                 ThumbnailImage.Source = null;
                 button.IsEnabled = true;
 
-                // Return keyboard focus to the button, which lost focus when it was disabled, to avoid a keyboard trap.
-                button.Focus(FocusState.Programmatic);
                 return;
             }
 
@@ -303,9 +289,6 @@ public sealed partial class StoragePickersPage : Page
 
             button.IsEnabled = true;
 
-            // Return keyboard focus to the button, which lost focus when it was disabled, to avoid a keyboard trap.
-            button.Focus(FocusState.Programmatic);
-
             UIHelper.AnnounceActionForAccessibility(button, ThumbnailDetailsTextBlock.Text, "ThumbnailPickedNotificationId");
         }
     }
@@ -328,9 +311,6 @@ public sealed partial class StoragePickersPage : Page
             }
 
             button.IsEnabled = true;
-
-            // Return keyboard focus to the button, which lost focus when it was disabled, to avoid a keyboard trap.
-            button.Focus(FocusState.Programmatic);
 
             UIHelper.AnnounceActionForAccessibility(
                 button,

--- a/WinUIGallery/Samples/StoragePickers/StoragePickersPickFolder.txt
+++ b/WinUIGallery/Samples/StoragePickers/StoragePickersPickFolder.txt
@@ -30,8 +30,5 @@ private async void PickFolderButton_Click(object sender, RoutedEventArgs e)
 
         // re-enable the button
         button.IsEnabled = true;
-
-        // Return keyboard focus to the button, which lost focus when it was disabled, to avoid a keyboard trap.
-        button.Focus(FocusState.Programmatic);
     }
 }

--- a/WinUIGallery/Samples/StoragePickers/StoragePickersPickMultipleFiles.txt
+++ b/WinUIGallery/Samples/StoragePickers/StoragePickersPickMultipleFiles.txt
@@ -39,8 +39,5 @@ private async void PickMultipleFilesButton_Click(object sender, RoutedEventArgs 
 
         //re-enable the button
         button.IsEnabled = true;
-
-        // Return keyboard focus to the button, which lost focus when it was disabled, to avoid a keyboard trap.
-        button.Focus(FocusState.Programmatic);
     }
 }

--- a/WinUIGallery/Samples/StoragePickers/StoragePickersPickSingleFile.txt
+++ b/WinUIGallery/Samples/StoragePickers/StoragePickersPickSingleFile.txt
@@ -29,8 +29,5 @@ private async void PickSingleFileButton_Click(object sender, RoutedEventArgs e)
 
         //re-enable the button
         button.IsEnabled = true;
-
-        // Return keyboard focus to the button, which lost focus when it was disabled, to avoid a keyboard trap.
-        button.Focus(FocusState.Programmatic);
     }
 }

--- a/WinUIGallery/Samples/StoragePickers/StoragePickersSaveFile.txt
+++ b/WinUIGallery/Samples/StoragePickers/StoragePickersSaveFile.txt
@@ -41,8 +41,5 @@ $(TxtFileType)$(JsonFileType)$(XmlFileType)
         }
 
         button.IsEnabled = true;
-
-        // Return keyboard focus to the button, which lost focus when it was disabled, to avoid a keyboard trap.
-        button.Focus(FocusState.Programmatic);
     }
 }


### PR DESCRIPTION
## Description
- Removes explicit Focus(FocusState.Programmatic) calls after Storage Picker dialogs close.
- Updates the displayed C# snippets to match the live samples.

## Motivation and Context
Windows App SDK 2.4 restores keyboard focus to the calling WinUI app after FileOpenPicker, FileSavePicker, and FolderPicker dialogs close, making the previous workaround redundant.

## How Has This Been Tested?
- Built WinUIGallery.csproj for Release/x64.
- Confirmed no Storage Picker sample still contains the manual focus workaround.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)