### PR TITLE
Fix the AppWindow example where PreferredHeightOption was misspelled as HeightOption

### DIFF
--- a/WinUIGallery/Samples/AppWindowTitleBar/ExtendingContentAppwindowtitlebarArea.txt
+++ b/WinUIGallery/Samples/AppWindowTitleBar/ExtendingContentAppwindowtitlebarArea.txt
@@ -12,7 +12,7 @@ public sealed partial class AppWindowTitleBarExtendWindow : Window
         AppWindow.TitleBar.ExtendsContentIntoTitleBar = $(ExtendsContentIntoTitleBar);
         if (AppWindow.TitleBar.ExtendsContentIntoTitleBar)
         {
-            AppWindow.TitleBar.HeightOption = TitleBarHeightOption.$(TitleBarHeightOption);
+            AppWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.$(TitleBarHeightOption);
         }
     }
 }


### PR DESCRIPTION
The property was misspelled when this example was added in #2105; it should be [PreferredHeightOption](https://learn.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.windowing.appwindowtitlebar?view=windows-app-sdk-2.0), not HeightOption.

This issue was originally reported at https://github.com/microsoft/microsoft-ui-xaml/issues/11779.
